### PR TITLE
Revert "chore(deps): update helm release openldap-stack-ha to v4"

### DIFF
--- a/cluster/apps/auth/openldap/helm-release.yaml
+++ b/cluster/apps/auth/openldap/helm-release.yaml
@@ -12,7 +12,7 @@ spec:
   chart:
     spec:
       chart: openldap-stack-ha
-      version: 4.0.0
+      version: 3.0.2
       sourceRef:
         kind: HelmRepository
         name: helm-openldap-charts


### PR DESCRIPTION
Reverts lucidph3nx/home-ops#458

threw error that LDAP_CONFIG_ADMIN_ENABLED had already been defined...