### PR TITLE
Revert "chore(deps): update helm release cilium to v1.16.0"

### DIFF
--- a/kubernetes/cluster0/apps/kube-system/cilium/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/kube-system/cilium/app/helm-release.yaml
@@ -10,7 +10,7 @@ spec:
   chart:
     spec:
       chart: cilium
-      version: 1.16.0
+      version: 1.15.7
       sourceRef:
         kind: HelmRepository
         name: cilium


### PR DESCRIPTION
Reverts lucidph3nx/home-ops#1532

not sure why but it now wants to install envoy... which breaks a bunch of things