### PR TITLE
Revert "chore(deps): update container image ghcr.io/onedr0p/qbittorrent to v5.0.3"

### DIFF
--- a/kubernetes/cluster0/apps/media/qbittorrent/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/qbittorrent/app/helm-release.yaml
@@ -32,7 +32,7 @@ spec:
             nameOverride: qbittorrent
             image:
               repository: ghcr.io/onedr0p/qbittorrent
-              tag: 5.0.3@sha256:025f32d260a3e924885405c0ca01ab8e396360330438ef8562ffd973d2dbb927
+              tag: 4.6.7@sha256:5391f94b321d563c3b44136a5e799b7e4e4888926c1c31d3081a1cf3e74a9aec
             env:
               TZ: "${TIMEZONE}"
               QBITTORRENT__PORT: &port 8080


### PR DESCRIPTION
Reverts lucidph3nx/home-ops#1890

Still affected by ui bug https://github.com/qbittorrent/qBittorrent/issues/21703