### PR TITLE
feat(minio): add Authelia forward auth to MinIO console

### DIFF
--- a/kubernetes/cluster0/apps/auth/authelia/app/middleware.yaml
+++ b/kubernetes/cluster0/apps/auth/authelia/app/middleware.yaml
@@ -95,6 +95,21 @@ apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   name: forwardauth-authelia
+  namespace: minio
+spec:
+  forwardAuth:
+    address: http://authelia.auth.svc.cluster.local/api/verify?rd=https://auth.${SECRET_PUBLIC_DOMAIN}/
+    trustForwardHeader: true
+    authResponseHeaders:
+      - Remote-User
+      - Remote-Name
+      - Remote-Email
+      - Remote-Groups
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: forwardauth-authelia
   namespace: networking
 spec:
   forwardAuth:

--- a/kubernetes/cluster0/apps/minio/minio/tenant/httproute.yaml
+++ b/kubernetes/cluster0/apps/minio/minio/tenant/httproute.yaml
@@ -1,7 +1,8 @@
+---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: minio
+  name: minio-console
   namespace: minio
 spec:
   hostnames:
@@ -14,12 +15,44 @@ spec:
       sectionName: websecure
   rules:
     - backendRefs:
-      - group: ""
-        kind: Service
-        name: minio-tenant-console
-        namespace: minio
-        port: 9443
-      matches:                                                                                                                                                                                                                                                  
-      - path:                                                                                                                                                                                                                                                   
-          type: PathPrefix                                                                                                                                                                                                                                      
-          value: /
+        - group: ""
+          kind: Service
+          name: minio-tenant-console
+          namespace: minio
+          port: 9443
+      filters:
+        - extensionRef:
+            group: traefik.io
+            kind: Middleware
+            name: forwardauth-authelia
+          type: ExtensionRef
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: minio-api
+  namespace: minio
+spec:
+  hostnames:
+    - s3.${SECRET_PUBLIC_DOMAIN}
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: traefik-gateway
+      namespace: networking
+      sectionName: websecure
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: minio
+          namespace: minio
+          port: 443
+      matches:
+        - path:
+            type: PathPrefix
+            value: /


### PR DESCRIPTION
## Summary

- Split the single MinIO HTTPRoute into two separate resources:
  - **`minio-console`**: routes `minio.${SECRET_PUBLIC_DOMAIN}` → `minio-tenant-console:9443` with `forwardauth-authelia` middleware applied
  - **`minio-api`**: routes `s3.${SECRET_PUBLIC_DOMAIN}` → `minio:443` (S3 API) without any Authelia middleware, preserving S3 client access key/secret key authentication
- Added `forwardauth-authelia` Traefik Middleware resource for the `minio` namespace to `middleware.yaml` (required because Gateway API resolves `ExtensionRef` in the same namespace as the HTTPRoute)

## Why

The MinIO console was exposed without any SSO/2FA protection. Adding `forwardauth-authelia` ensures that access to the console requires an active Authelia session (subject to `default_policy: two_factor`). The S3 API endpoint is kept entirely separate and free of Authelia so S3 clients are unaffected.

## Service verification

`kubectl get services -n minio` confirms the `minio` service exists on port 443/TCP (ClusterIP) with selector `v1.min.io/tenant=minio-tenant`. The `minio-api` HTTPRoute targeting `minio:443` is correct.

```
NAME                   TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)    AGE
minio                  ClusterIP   10.43.41.176    <none>        443/TCP    157d
minio-tenant-console   ClusterIP   10.43.182.186   <none>        9443/TCP   157d
minio-tenant-hl        ClusterIP   None            <none>        9000/TCP   157d
```

## Changes

- `kubernetes/cluster0/apps/minio/minio/tenant/httproute.yaml`: replaced single `minio` HTTPRoute with two resources (`minio-console` and `minio-api`)
- `kubernetes/cluster0/apps/auth/authelia/app/middleware.yaml`: added `forwardauth-authelia` Middleware for the `minio` namespace

Closes #2808