### PR TITLE
feat(renovate): enable digest pinning for all docker images

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -39,6 +39,10 @@
   },
   packageRules: [
     {
+      matchDatasources: ['docker'],
+      pinDigests: true,
+    },
+    {
       matchDatasources: [
         'docker',
       ],


### PR DESCRIPTION
## Summary

- Adds a new `packageRules` entry with `pinDigests: true` scoped to the `docker` datasource
- Leaves the existing plex-specific rule (`matchPackageNames: ['/plexinc/pms-docker/']`) intact and unmodified
- No helm datasource rules are affected

Once merged, Renovate will automatically open digest-pin PRs for the 23 container images listed in the issue. Those PRs will auto-merge via the existing `:automergeDigest` preset.

Closes #2813