### PR TITLE
security: netpol phase 1 — default-deny foundation + simple leaf services

### DIFF
--- a/kubernetes/cluster0/apps/media/jellyfin/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/jellyfin/app/helm-release.yaml
@@ -116,6 +116,17 @@ spec:
                       - 10.0.0.0/8
                       - 172.16.0.0/12
                       - 192.168.0.0/16
+      allow-blackbox-probe-ingress:
+        controller: main
+        policyTypes: [Ingress]
+        rules:
+          ingress:
+            - from:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: monitoring
+              ports:
+                - port: 8096
       allow-nfs-egress:
         controller: main
         policyTypes: [Egress]

--- a/kubernetes/cluster0/apps/media/jellyfin/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/jellyfin/app/helm-release.yaml
@@ -75,66 +75,64 @@ spec:
           - name: traefik-gateway
             namespace: networking
             sectionName: websecure
-    networkPolicies:
-      enabled: true
-      policies:
-        - name: default-deny
-          spec:
-            podSelector: {}
-            policyTypes: [Ingress, Egress]
-        - name: allow-dns
-          spec:
-            podSelector: {}
-            policyTypes: [Egress]
-            egress:
-              - ports:
-                  - port: 53
-                    protocol: UDP
-                  - port: 53
-                    protocol: TCP
-        - name: allow-traefik-ingress
-          spec:
-            podSelector: {}
-            policyTypes: [Ingress]
-            ingress:
-              - from:
-                  - namespaceSelector:
-                      matchLabels:
-                        kubernetes.io/metadata.name: networking
-        - name: allow-external-egress
-          spec:
-            podSelector: {}
-            policyTypes: [Egress]
-            egress:
-              - ports:
-                  - port: 80
-                    protocol: TCP
-                  - port: 443
-                    protocol: TCP
-                to:
-                  - ipBlock:
-                      cidr: 0.0.0.0/0
-                      except:
-                        - 10.0.0.0/8
-                        - 172.16.0.0/12
-                        - 192.168.0.0/16
-        - name: allow-nfs-egress
-          spec:
-            podSelector: {}
-            policyTypes: [Egress]
-            egress:
-              - ports:
-                  - port: 111
-                    protocol: TCP
-                  - port: 111
-                    protocol: UDP
-                  - port: 2049
-                    protocol: TCP
-                  - port: 2049
-                    protocol: UDP
-                to:
-                  - ipBlock:
-                      cidr: 10.87.42.200/32
+    networkpolicies:
+      default-deny:
+        controller: main
+        policyTypes: [Ingress, Egress]
+        rules: {}
+      allow-dns:
+        controller: main
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 53
+                  protocol: UDP
+                - port: 53
+                  protocol: TCP
+      allow-traefik-ingress:
+        controller: main
+        policyTypes: [Ingress]
+        rules:
+          ingress:
+            - from:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: networking
+      allow-external-egress:
+        controller: main
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 80
+                  protocol: TCP
+                - port: 443
+                  protocol: TCP
+              to:
+                - ipBlock:
+                    cidr: 0.0.0.0/0
+                    except:
+                      - 10.0.0.0/8
+                      - 172.16.0.0/12
+                      - 192.168.0.0/16
+      allow-nfs-egress:
+        controller: main
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 111
+                  protocol: TCP
+                - port: 111
+                  protocol: UDP
+                - port: 2049
+                  protocol: TCP
+                - port: 2049
+                  protocol: UDP
+              to:
+                - ipBlock:
+                    cidr: 10.87.42.200/32
 
     persistence:
       config:

--- a/kubernetes/cluster0/apps/media/jellyfin/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/jellyfin/app/helm-release.yaml
@@ -107,6 +107,8 @@ spec:
             policyTypes: [Egress]
             egress:
               - ports:
+                  - port: 80
+                    protocol: TCP
                   - port: 443
                     protocol: TCP
                 to:

--- a/kubernetes/cluster0/apps/media/jellyfin/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/jellyfin/app/helm-release.yaml
@@ -75,6 +75,65 @@ spec:
           - name: traefik-gateway
             namespace: networking
             sectionName: websecure
+    networkPolicies:
+      enabled: true
+      policies:
+        - name: default-deny
+          spec:
+            podSelector: {}
+            policyTypes: [Ingress, Egress]
+        - name: allow-dns
+          spec:
+            podSelector: {}
+            policyTypes: [Egress]
+            egress:
+              - ports:
+                  - port: 53
+                    protocol: UDP
+                  - port: 53
+                    protocol: TCP
+        - name: allow-traefik-ingress
+          spec:
+            podSelector: {}
+            policyTypes: [Ingress]
+            ingress:
+              - from:
+                  - namespaceSelector:
+                      matchLabels:
+                        kubernetes.io/metadata.name: networking
+        - name: allow-external-egress
+          spec:
+            podSelector: {}
+            policyTypes: [Egress]
+            egress:
+              - ports:
+                  - port: 443
+                    protocol: TCP
+                to:
+                  - ipBlock:
+                      cidr: 0.0.0.0/0
+                      except:
+                        - 10.0.0.0/8
+                        - 172.16.0.0/12
+                        - 192.168.0.0/16
+        - name: allow-nfs-egress
+          spec:
+            podSelector: {}
+            policyTypes: [Egress]
+            egress:
+              - ports:
+                  - port: 111
+                    protocol: TCP
+                  - port: 111
+                    protocol: UDP
+                  - port: 2049
+                    protocol: TCP
+                  - port: 2049
+                    protocol: UDP
+                to:
+                  - ipBlock:
+                      cidr: 10.87.42.200/32
+
     persistence:
       config:
         existingClaim: pvc-jellyfin

--- a/kubernetes/cluster0/apps/media/overseerr/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/overseerr/app/helm-release.yaml
@@ -55,6 +55,67 @@ spec:
           - backendRefs:
               - identifier: app
                 port: *port
+    networkPolicies:
+      enabled: true
+      policies:
+        - name: default-deny
+          spec:
+            podSelector: {}
+            policyTypes: [Ingress, Egress]
+        - name: allow-dns
+          spec:
+            podSelector: {}
+            policyTypes: [Egress]
+            egress:
+              - ports:
+                  - port: 53
+                    protocol: UDP
+                  - port: 53
+                    protocol: TCP
+        - name: allow-traefik-ingress
+          spec:
+            podSelector: {}
+            policyTypes: [Ingress]
+            ingress:
+              - from:
+                  - namespaceSelector:
+                      matchLabels:
+                        kubernetes.io/metadata.name: networking
+        - name: allow-external-egress
+          spec:
+            podSelector: {}
+            policyTypes: [Egress]
+            egress:
+              - ports:
+                  - port: 443
+                    protocol: TCP
+                to:
+                  - ipBlock:
+                      cidr: 0.0.0.0/0
+                      except:
+                        - 10.0.0.0/8
+                        - 172.16.0.0/12
+                        - 192.168.0.0/16
+        - name: allow-media-namespace-egress
+          spec:
+            podSelector: {}
+            policyTypes: [Egress]
+            egress:
+              - ports:
+                  # Sonarr
+                  - port: 8989
+                    protocol: TCP
+                  # Radarr
+                  - port: 7878
+                    protocol: TCP
+                  # Plex
+                  - port: 32400
+                    protocol: TCP
+                to:
+                  - namespaceSelector:
+                      matchLabels:
+                        kubernetes.io/metadata.name: media
+
     persistence:
       config:
         existingClaim: pvc-overseerr

--- a/kubernetes/cluster0/apps/media/overseerr/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/overseerr/app/helm-release.yaml
@@ -117,7 +117,7 @@ spec:
                 - namespaceSelector:
                     matchLabels:
                       kubernetes.io/metadata.name: media
-                   podSelector:
+                  podSelector:
                     matchLabels:
                       app.kubernetes.io/instance: sonarr
       allow-radarr-egress:
@@ -132,7 +132,7 @@ spec:
                 - namespaceSelector:
                     matchLabels:
                       kubernetes.io/metadata.name: media
-                   podSelector:
+                  podSelector:
                     matchLabels:
                       app.kubernetes.io/instance: radarr
       allow-plex-egress:
@@ -147,7 +147,7 @@ spec:
                 - namespaceSelector:
                     matchLabels:
                       kubernetes.io/metadata.name: media
-                   podSelector:
+                  podSelector:
                     matchLabels:
                       app.kubernetes.io/instance: plex
 

--- a/kubernetes/cluster0/apps/media/overseerr/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/overseerr/app/helm-release.yaml
@@ -94,25 +94,51 @@ spec:
                       - 10.0.0.0/8
                       - 172.16.0.0/12
                       - 192.168.0.0/16
-      allow-media-namespace-egress:
+      allow-sonarr-egress:
         controller: main
         policyTypes: [Egress]
         rules:
           egress:
             - ports:
-                # Sonarr
                 - port: 8989
                   protocol: TCP
-                # Radarr
+              to:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: media
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/name: sonarr
+      allow-radarr-egress:
+        controller: main
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
                 - port: 7878
                   protocol: TCP
-                # Plex
+              to:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: media
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/name: radarr
+      allow-plex-egress:
+        controller: main
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
                 - port: 32400
                   protocol: TCP
               to:
                 - namespaceSelector:
                     matchLabels:
                       kubernetes.io/metadata.name: media
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/name: plex
 
     persistence:
       config:

--- a/kubernetes/cluster0/apps/media/overseerr/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/overseerr/app/helm-release.yaml
@@ -94,6 +94,17 @@ spec:
                       - 10.0.0.0/8
                       - 172.16.0.0/12
                       - 192.168.0.0/16
+      allow-blackbox-probe-ingress:
+        controller: main
+        policyTypes: [Ingress]
+        rules:
+          ingress:
+            - from:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: monitoring
+              ports:
+                - port: 5055
       allow-sonarr-egress:
         controller: main
         policyTypes: [Egress]
@@ -106,9 +117,9 @@ spec:
                 - namespaceSelector:
                     matchLabels:
                       kubernetes.io/metadata.name: media
-                  podSelector:
+                   podSelector:
                     matchLabels:
-                      app.kubernetes.io/name: sonarr
+                      app.kubernetes.io/instance: sonarr
       allow-radarr-egress:
         controller: main
         policyTypes: [Egress]
@@ -121,9 +132,9 @@ spec:
                 - namespaceSelector:
                     matchLabels:
                       kubernetes.io/metadata.name: media
-                  podSelector:
+                   podSelector:
                     matchLabels:
-                      app.kubernetes.io/name: radarr
+                      app.kubernetes.io/instance: radarr
       allow-plex-egress:
         controller: main
         policyTypes: [Egress]
@@ -136,9 +147,9 @@ spec:
                 - namespaceSelector:
                     matchLabels:
                       kubernetes.io/metadata.name: media
-                  podSelector:
+                   podSelector:
                     matchLabels:
-                      app.kubernetes.io/name: plex
+                      app.kubernetes.io/instance: plex
 
     persistence:
       config:

--- a/kubernetes/cluster0/apps/media/overseerr/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/overseerr/app/helm-release.yaml
@@ -55,66 +55,64 @@ spec:
           - backendRefs:
               - identifier: app
                 port: *port
-    networkPolicies:
-      enabled: true
-      policies:
-        - name: default-deny
-          spec:
-            podSelector: {}
-            policyTypes: [Ingress, Egress]
-        - name: allow-dns
-          spec:
-            podSelector: {}
-            policyTypes: [Egress]
-            egress:
-              - ports:
-                  - port: 53
-                    protocol: UDP
-                  - port: 53
-                    protocol: TCP
-        - name: allow-traefik-ingress
-          spec:
-            podSelector: {}
-            policyTypes: [Ingress]
-            ingress:
-              - from:
-                  - namespaceSelector:
-                      matchLabels:
-                        kubernetes.io/metadata.name: networking
-        - name: allow-external-egress
-          spec:
-            podSelector: {}
-            policyTypes: [Egress]
-            egress:
-              - ports:
-                  - port: 443
-                    protocol: TCP
-                to:
-                  - ipBlock:
-                      cidr: 0.0.0.0/0
-                      except:
-                        - 10.0.0.0/8
-                        - 172.16.0.0/12
-                        - 192.168.0.0/16
-        - name: allow-media-namespace-egress
-          spec:
-            podSelector: {}
-            policyTypes: [Egress]
-            egress:
-              - ports:
-                  # Sonarr
-                  - port: 8989
-                    protocol: TCP
-                  # Radarr
-                  - port: 7878
-                    protocol: TCP
-                  # Plex
-                  - port: 32400
-                    protocol: TCP
-                to:
-                  - namespaceSelector:
-                      matchLabels:
-                        kubernetes.io/metadata.name: media
+    networkpolicies:
+      default-deny:
+        controller: main
+        policyTypes: [Ingress, Egress]
+        rules: {}
+      allow-dns:
+        controller: main
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 53
+                  protocol: UDP
+                - port: 53
+                  protocol: TCP
+      allow-traefik-ingress:
+        controller: main
+        policyTypes: [Ingress]
+        rules:
+          ingress:
+            - from:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: networking
+      allow-external-egress:
+        controller: main
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 443
+                  protocol: TCP
+              to:
+                - ipBlock:
+                    cidr: 0.0.0.0/0
+                    except:
+                      - 10.0.0.0/8
+                      - 172.16.0.0/12
+                      - 192.168.0.0/16
+      allow-media-namespace-egress:
+        controller: main
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                # Sonarr
+                - port: 8989
+                  protocol: TCP
+                # Radarr
+                - port: 7878
+                  protocol: TCP
+                # Plex
+                - port: 32400
+                  protocol: TCP
+              to:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: media
 
     persistence:
       config:

--- a/kubernetes/cluster0/apps/media/plex/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/plex/app/helm-release.yaml
@@ -80,77 +80,75 @@ spec:
                   value: /library/streams
           - backendRefs:
               - identifier: app
-    networkPolicies:
-      enabled: true
-      policies:
-        - name: default-deny
-          spec:
-            podSelector: {}
-            policyTypes: [Ingress, Egress]
-        - name: allow-dns
-          spec:
-            podSelector: {}
-            policyTypes: [Egress]
-            egress:
-              - ports:
-                  - port: 53
-                    protocol: UDP
-                  - port: 53
-                    protocol: TCP
-        - name: allow-traefik-ingress
-          spec:
-            podSelector: {}
-            policyTypes: [Ingress]
-            ingress:
-              - from:
-                  - namespaceSelector:
-                      matchLabels:
-                        kubernetes.io/metadata.name: networking
-        - name: allow-lan-direct-ingress
-          spec:
-            podSelector: {}
-            policyTypes: [Ingress]
-            ingress:
-              - from:
-                  - ipBlock:
-                      cidr: 0.0.0.0/0
-                ports:
-                  - port: 32400
-                    protocol: TCP
-        - name: allow-external-egress
-          spec:
-            podSelector: {}
-            policyTypes: [Egress]
-            egress:
-              - ports:
-                  - port: 443
-                    protocol: TCP
-                  - port: 32400
-                    protocol: TCP
-                to:
-                  - ipBlock:
-                      cidr: 0.0.0.0/0
-                      except:
-                        - 10.0.0.0/8
-                        - 172.16.0.0/12
-                        - 192.168.0.0/16
-        - name: allow-nfs-egress
-          spec:
-            podSelector: {}
-            policyTypes: [Egress]
-            egress:
-              - ports:
-                  - port: 111
-                    protocol: TCP
-                  - port: 111
-                    protocol: UDP
-                  - port: 2049
-                    protocol: TCP
-                  - port: 2049
-                    protocol: UDP
-                to:
-                  - ipBlock:
-                      cidr: 10.87.42.200/32
+    networkpolicies:
+      default-deny:
+        controller: main
+        policyTypes: [Ingress, Egress]
+        rules: {}
+      allow-dns:
+        controller: main
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 53
+                  protocol: UDP
+                - port: 53
+                  protocol: TCP
+      allow-traefik-ingress:
+        controller: main
+        policyTypes: [Ingress]
+        rules:
+          ingress:
+            - from:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: networking
+      allow-lan-direct-ingress:
+        controller: main
+        policyTypes: [Ingress]
+        rules:
+          ingress:
+            - from:
+                - ipBlock:
+                    cidr: 0.0.0.0/0
+              ports:
+                - port: 32400
+                  protocol: TCP
+      allow-external-egress:
+        controller: main
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 443
+                  protocol: TCP
+                - port: 32400
+                  protocol: TCP
+              to:
+                - ipBlock:
+                    cidr: 0.0.0.0/0
+                    except:
+                      - 10.0.0.0/8
+                      - 172.16.0.0/12
+                      - 192.168.0.0/16
+      allow-nfs-egress:
+        controller: main
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 111
+                  protocol: TCP
+                - port: 111
+                  protocol: UDP
+                - port: 2049
+                  protocol: TCP
+                - port: 2049
+                  protocol: UDP
+              to:
+                - ipBlock:
+                    cidr: 10.87.42.200/32
 
     persistence:
       config:

--- a/kubernetes/cluster0/apps/media/plex/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/plex/app/helm-release.yaml
@@ -104,7 +104,9 @@ spec:
                 - namespaceSelector:
                     matchLabels:
                       kubernetes.io/metadata.name: networking
-      allow-lan-direct-ingress:
+      # Intentionally open to all sources: Plex clients stream directly via the
+      # LoadBalancer IP (LAN and Plex relay traffic from the internet both arrive here)
+      allow-32400-ingress:
         controller: main
         policyTypes: [Ingress]
         rules:

--- a/kubernetes/cluster0/apps/media/plex/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/plex/app/helm-release.yaml
@@ -80,6 +80,78 @@ spec:
                   value: /library/streams
           - backendRefs:
               - identifier: app
+    networkPolicies:
+      enabled: true
+      policies:
+        - name: default-deny
+          spec:
+            podSelector: {}
+            policyTypes: [Ingress, Egress]
+        - name: allow-dns
+          spec:
+            podSelector: {}
+            policyTypes: [Egress]
+            egress:
+              - ports:
+                  - port: 53
+                    protocol: UDP
+                  - port: 53
+                    protocol: TCP
+        - name: allow-traefik-ingress
+          spec:
+            podSelector: {}
+            policyTypes: [Ingress]
+            ingress:
+              - from:
+                  - namespaceSelector:
+                      matchLabels:
+                        kubernetes.io/metadata.name: networking
+        - name: allow-lan-direct-ingress
+          spec:
+            podSelector: {}
+            policyTypes: [Ingress]
+            ingress:
+              - from:
+                  - ipBlock:
+                      cidr: 0.0.0.0/0
+                ports:
+                  - port: 32400
+                    protocol: TCP
+        - name: allow-external-egress
+          spec:
+            podSelector: {}
+            policyTypes: [Egress]
+            egress:
+              - ports:
+                  - port: 443
+                    protocol: TCP
+                  - port: 32400
+                    protocol: TCP
+                to:
+                  - ipBlock:
+                      cidr: 0.0.0.0/0
+                      except:
+                        - 10.0.0.0/8
+                        - 172.16.0.0/12
+                        - 192.168.0.0/16
+        - name: allow-nfs-egress
+          spec:
+            podSelector: {}
+            policyTypes: [Egress]
+            egress:
+              - ports:
+                  - port: 111
+                    protocol: TCP
+                  - port: 111
+                    protocol: UDP
+                  - port: 2049
+                    protocol: TCP
+                  - port: 2049
+                    protocol: UDP
+                to:
+                  - ipBlock:
+                      cidr: 10.87.42.200/32
+
     persistence:
       config:
         existingClaim: pvc-plex0

--- a/kubernetes/cluster0/apps/media/syncthing/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/syncthing/app/helm-release.yaml
@@ -95,7 +95,7 @@ spec:
                     protocol: UDP
                   - port: 21027
                     protocol: UDP
-        - name: allow-sync-egress
+        - name: allow-sync-egress-internet
           spec:
             podSelector: {}
             policyTypes: [Egress]
@@ -116,6 +116,21 @@ spec:
                         - 10.0.0.0/8
                         - 172.16.0.0/12
                         - 192.168.0.0/16
+        - name: allow-sync-egress-lan
+          spec:
+            podSelector: {}
+            policyTypes: [Egress]
+            egress:
+              - ports:
+                  - port: 22000
+                    protocol: TCP
+                  - port: 22000
+                    protocol: UDP
+                  - port: 21027
+                    protocol: UDP
+                to:
+                  - ipBlock:
+                      cidr: 10.87.0.0/16
 
     persistence:
       config:

--- a/kubernetes/cluster0/apps/media/syncthing/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/syncthing/app/helm-release.yaml
@@ -54,83 +54,81 @@ spec:
             enabled: true
             port: 22000
             protocol: TCP
-    networkPolicies:
-      enabled: true
-      policies:
-        - name: default-deny
-          spec:
-            podSelector: {}
-            policyTypes: [Ingress, Egress]
-        - name: allow-dns
-          spec:
-            podSelector: {}
-            policyTypes: [Egress]
-            egress:
-              - ports:
-                  - port: 53
-                    protocol: UDP
-                  - port: 53
-                    protocol: TCP
-        - name: allow-traefik-ingress
-          spec:
-            podSelector: {}
-            policyTypes: [Ingress]
-            ingress:
-              - from:
-                  - namespaceSelector:
-                      matchLabels:
-                        kubernetes.io/metadata.name: networking
-        - name: allow-lan-sync-ingress
-          spec:
-            podSelector: {}
-            policyTypes: [Ingress]
-            ingress:
-              - from:
-                  - ipBlock:
-                      cidr: 0.0.0.0/0
-                ports:
-                  - port: 22000
-                    protocol: TCP
-                  - port: 22000
-                    protocol: UDP
-                  - port: 21027
-                    protocol: UDP
-        - name: allow-sync-egress-internet
-          spec:
-            podSelector: {}
-            policyTypes: [Egress]
-            egress:
-              - ports:
-                  - port: 22000
-                    protocol: TCP
-                  - port: 22000
-                    protocol: UDP
-                  - port: 21027
-                    protocol: UDP
-                  - port: 443
-                    protocol: TCP
-                to:
-                  - ipBlock:
-                      cidr: 0.0.0.0/0
-                      except:
-                        - 10.0.0.0/8
-                        - 172.16.0.0/12
-                        - 192.168.0.0/16
-        - name: allow-sync-egress-lan
-          spec:
-            podSelector: {}
-            policyTypes: [Egress]
-            egress:
-              - ports:
-                  - port: 22000
-                    protocol: TCP
-                  - port: 22000
-                    protocol: UDP
-                  - port: 21027
-                    protocol: UDP
-                to:
-                  - ipBlock:
-                      cidr: 10.87.0.0/16
+    networkpolicies:
+      default-deny:
+        controller: main
+        policyTypes: [Ingress, Egress]
+        rules: {}
+      allow-dns:
+        controller: main
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 53
+                  protocol: UDP
+                - port: 53
+                  protocol: TCP
+      allow-traefik-ingress:
+        controller: main
+        policyTypes: [Ingress]
+        rules:
+          ingress:
+            - from:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: networking
+      allow-sync-ingress:
+        controller: main
+        policyTypes: [Ingress]
+        rules:
+          ingress:
+            - from:
+                - ipBlock:
+                    cidr: 0.0.0.0/0
+              ports:
+                - port: 22000
+                  protocol: TCP
+                - port: 22000
+                  protocol: UDP
+                - port: 21027
+                  protocol: UDP
+      allow-sync-egress-internet:
+        controller: main
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 22000
+                  protocol: TCP
+                - port: 22000
+                  protocol: UDP
+                - port: 21027
+                  protocol: UDP
+                - port: 443
+                  protocol: TCP
+              to:
+                - ipBlock:
+                    cidr: 0.0.0.0/0
+                    except:
+                      - 10.0.0.0/8
+                      - 172.16.0.0/12
+                      - 192.168.0.0/16
+      allow-sync-egress-lan:
+        controller: main
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 22000
+                  protocol: TCP
+                - port: 22000
+                  protocol: UDP
+                - port: 21027
+                  protocol: UDP
+              to:
+                - ipBlock:
+                    cidr: 10.87.0.0/16
 
     persistence:
       config:

--- a/kubernetes/cluster0/apps/media/syncthing/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/syncthing/app/helm-release.yaml
@@ -54,6 +54,69 @@ spec:
             enabled: true
             port: 22000
             protocol: TCP
+    networkPolicies:
+      enabled: true
+      policies:
+        - name: default-deny
+          spec:
+            podSelector: {}
+            policyTypes: [Ingress, Egress]
+        - name: allow-dns
+          spec:
+            podSelector: {}
+            policyTypes: [Egress]
+            egress:
+              - ports:
+                  - port: 53
+                    protocol: UDP
+                  - port: 53
+                    protocol: TCP
+        - name: allow-traefik-ingress
+          spec:
+            podSelector: {}
+            policyTypes: [Ingress]
+            ingress:
+              - from:
+                  - namespaceSelector:
+                      matchLabels:
+                        kubernetes.io/metadata.name: networking
+        - name: allow-lan-sync-ingress
+          spec:
+            podSelector: {}
+            policyTypes: [Ingress]
+            ingress:
+              - from:
+                  - ipBlock:
+                      cidr: 0.0.0.0/0
+                ports:
+                  - port: 22000
+                    protocol: TCP
+                  - port: 22000
+                    protocol: UDP
+                  - port: 21027
+                    protocol: UDP
+        - name: allow-sync-egress
+          spec:
+            podSelector: {}
+            policyTypes: [Egress]
+            egress:
+              - ports:
+                  - port: 22000
+                    protocol: TCP
+                  - port: 22000
+                    protocol: UDP
+                  - port: 21027
+                    protocol: UDP
+                  - port: 443
+                    protocol: TCP
+                to:
+                  - ipBlock:
+                      cidr: 0.0.0.0/0
+                      except:
+                        - 10.0.0.0/8
+                        - 172.16.0.0/12
+                        - 192.168.0.0/16
+
     persistence:
       config:
         existingClaim: pvc-syncthing

--- a/kubernetes/cluster0/apps/media/syncthing/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/syncthing/app/helm-release.yaml
@@ -78,7 +78,9 @@ spec:
                 - namespaceSelector:
                     matchLabels:
                       kubernetes.io/metadata.name: networking
-      allow-sync-ingress:
+      # Intentionally open to all sources: both LAN peers and internet peers
+      # (port-forwarded through the router) connect inbound to this LoadBalancer IP
+      allow-sync-ingress-all:
         controller: main
         policyTypes: [Ingress]
         rules:

--- a/kubernetes/cluster0/apps/monitoring/blackbox-exporter/app/kustomization.yaml
+++ b/kubernetes/cluster0/apps/monitoring/blackbox-exporter/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 resources:
   - ./helm-release.yaml
   - ./prometheusrule.yaml
+  - ./network-policy.yaml
 labels:
   - pairs:
       app.kubernetes.io/name: blackbox-exporter

--- a/kubernetes/cluster0/apps/monitoring/blackbox-exporter/app/network-policy.yaml
+++ b/kubernetes/cluster0/apps/monitoring/blackbox-exporter/app/network-policy.yaml
@@ -3,7 +3,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: default-deny
+  name: blackbox-exporter-default-deny
   namespace: monitoring
 spec:
   podSelector:

--- a/kubernetes/cluster0/apps/monitoring/blackbox-exporter/app/network-policy.yaml
+++ b/kubernetes/cluster0/apps/monitoring/blackbox-exporter/app/network-policy.yaml
@@ -1,0 +1,90 @@
+---
+# Default deny-all for blackbox-exporter pods
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-blackbox-exporter
+  policyTypes: [Ingress, Egress]
+---
+# Allow DNS resolution
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: blackbox-exporter-allow-dns
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-blackbox-exporter
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+---
+# Allow Prometheus to scrape blackbox-exporter metrics
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: blackbox-exporter-allow-prometheus-scrape
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-blackbox-exporter
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+      ports:
+        - port: 9115
+---
+# Allow blackbox-exporter to probe external and cluster-internal targets
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: blackbox-exporter-allow-probe-egress
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-blackbox-exporter
+  policyTypes: [Egress]
+  egress:
+    # External probes (HTTP/HTTPS/TCP)
+    - ports:
+        - port: 80
+          protocol: TCP
+        - port: 443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+    # Cluster-internal probes (all namespaces)
+    - ports:
+        - port: 80
+          protocol: TCP
+        - port: 443
+          protocol: TCP
+        - port: 8080
+          protocol: TCP
+        - port: 8443
+          protocol: TCP
+        - port: 9090
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.0.0.0/8

--- a/kubernetes/cluster0/apps/monitoring/blackbox-exporter/app/network-policy.yaml
+++ b/kubernetes/cluster0/apps/monitoring/blackbox-exporter/app/network-policy.yaml
@@ -73,18 +73,8 @@ spec:
               - 10.0.0.0/8
               - 172.16.0.0/12
               - 192.168.0.0/16
-    # Cluster-internal probes (all namespaces)
-    - ports:
-        - port: 80
-          protocol: TCP
-        - port: 443
-          protocol: TCP
-        - port: 8080
-          protocol: TCP
-        - port: 8443
-          protocol: TCP
-        - port: 9090
-          protocol: TCP
-      to:
+    # Cluster-internal probes — allow all TCP to cluster CIDR so blackbox can
+    # reach arbitrary service ports without enumerating every target port
+    - to:
         - ipBlock:
             cidr: 10.0.0.0/8

--- a/kubernetes/cluster0/apps/monitoring/changedetection-io/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/monitoring/changedetection-io/app/helm-release.yaml
@@ -62,6 +62,62 @@ spec:
                   group: 'traefik.io'
                   kind: 'Middleware'
                   name: 'forwardauth-authelia'
+    networkPolicies:
+      enabled: true
+      policies:
+        - name: default-deny
+          spec:
+            podSelector: {}
+            policyTypes: [Ingress, Egress]
+        - name: allow-dns
+          spec:
+            podSelector: {}
+            policyTypes: [Egress]
+            egress:
+              - ports:
+                  - port: 53
+                    protocol: UDP
+                  - port: 53
+                    protocol: TCP
+        - name: allow-traefik-ingress
+          spec:
+            podSelector: {}
+            policyTypes: [Ingress]
+            ingress:
+              - from:
+                  - namespaceSelector:
+                      matchLabels:
+                        kubernetes.io/metadata.name: networking
+        - name: allow-external-egress
+          spec:
+            podSelector: {}
+            policyTypes: [Egress]
+            egress:
+              - ports:
+                  - port: 80
+                    protocol: TCP
+                  - port: 443
+                    protocol: TCP
+                to:
+                  - ipBlock:
+                      cidr: 0.0.0.0/0
+                      except:
+                        - 10.0.0.0/8
+                        - 172.16.0.0/12
+                        - 192.168.0.0/16
+        - name: allow-browserless-egress
+          spec:
+            podSelector: {}
+            policyTypes: [Egress]
+            egress:
+              - ports:
+                  - port: 3000
+                    protocol: TCP
+                to:
+                  - namespaceSelector:
+                      matchLabels:
+                        kubernetes.io/metadata.name: monitoring
+
     persistence:
       config:
         existingClaim: pvc-changedetection-io

--- a/kubernetes/cluster0/apps/monitoring/changedetection-io/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/monitoring/changedetection-io/app/helm-release.yaml
@@ -117,7 +117,7 @@ spec:
                       kubernetes.io/metadata.name: monitoring
                   podSelector:
                     matchLabels:
-                      app.kubernetes.io/name: changedetection-browser
+                      app.kubernetes.io/instance: changedetection-browser
 
     persistence:
       config:

--- a/kubernetes/cluster0/apps/monitoring/changedetection-io/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/monitoring/changedetection-io/app/helm-release.yaml
@@ -115,6 +115,9 @@ spec:
                 - namespaceSelector:
                     matchLabels:
                       kubernetes.io/metadata.name: monitoring
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/name: changedetection-browser
 
     persistence:
       config:

--- a/kubernetes/cluster0/apps/monitoring/changedetection-io/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/monitoring/changedetection-io/app/helm-release.yaml
@@ -62,61 +62,59 @@ spec:
                   group: 'traefik.io'
                   kind: 'Middleware'
                   name: 'forwardauth-authelia'
-    networkPolicies:
-      enabled: true
-      policies:
-        - name: default-deny
-          spec:
-            podSelector: {}
-            policyTypes: [Ingress, Egress]
-        - name: allow-dns
-          spec:
-            podSelector: {}
-            policyTypes: [Egress]
-            egress:
-              - ports:
-                  - port: 53
-                    protocol: UDP
-                  - port: 53
-                    protocol: TCP
-        - name: allow-traefik-ingress
-          spec:
-            podSelector: {}
-            policyTypes: [Ingress]
-            ingress:
-              - from:
-                  - namespaceSelector:
-                      matchLabels:
-                        kubernetes.io/metadata.name: networking
-        - name: allow-external-egress
-          spec:
-            podSelector: {}
-            policyTypes: [Egress]
-            egress:
-              - ports:
-                  - port: 80
-                    protocol: TCP
-                  - port: 443
-                    protocol: TCP
-                to:
-                  - ipBlock:
-                      cidr: 0.0.0.0/0
-                      except:
-                        - 10.0.0.0/8
-                        - 172.16.0.0/12
-                        - 192.168.0.0/16
-        - name: allow-browserless-egress
-          spec:
-            podSelector: {}
-            policyTypes: [Egress]
-            egress:
-              - ports:
-                  - port: 3000
-                    protocol: TCP
-                to:
-                  - namespaceSelector:
-                      matchLabels:
-                        kubernetes.io/metadata.name: monitoring
+    networkpolicies:
+      default-deny:
+        controller: main
+        policyTypes: [Ingress, Egress]
+        rules: {}
+      allow-dns:
+        controller: main
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 53
+                  protocol: UDP
+                - port: 53
+                  protocol: TCP
+      allow-traefik-ingress:
+        controller: main
+        policyTypes: [Ingress]
+        rules:
+          ingress:
+            - from:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: networking
+      allow-external-egress:
+        controller: main
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 80
+                  protocol: TCP
+                - port: 443
+                  protocol: TCP
+              to:
+                - ipBlock:
+                    cidr: 0.0.0.0/0
+                    except:
+                      - 10.0.0.0/8
+                      - 172.16.0.0/12
+                      - 192.168.0.0/16
+      allow-browserless-egress:
+        controller: main
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 3000
+                  protocol: TCP
+              to:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: monitoring
 
     persistence:
       config:

--- a/kubernetes/cluster0/apps/monitoring/changedetection-io/browser/helm-release.yaml
+++ b/kubernetes/cluster0/apps/monitoring/changedetection-io/browser/helm-release.yaml
@@ -72,51 +72,49 @@ spec:
           main:
             app:
               - path: /dev/shm
-    networkPolicies:
-      enabled: true
-      policies:
-        - name: default-deny
-          spec:
-            podSelector: {}
-            policyTypes: [Ingress, Egress]
-        - name: allow-dns
-          spec:
-            podSelector: {}
-            policyTypes: [Egress]
-            egress:
-              - ports:
-                  - port: 53
-                    protocol: UDP
-                  - port: 53
-                    protocol: TCP
-        - name: allow-changedetection-ingress
-          spec:
-            podSelector: {}
-            policyTypes: [Ingress]
-            ingress:
-              - from:
-                  - namespaceSelector:
-                      matchLabels:
-                        kubernetes.io/metadata.name: monitoring
-                ports:
-                  - port: 3000
-        - name: allow-external-egress
-          spec:
-            podSelector: {}
-            policyTypes: [Egress]
-            egress:
-              - ports:
-                  - port: 80
-                    protocol: TCP
-                  - port: 443
-                    protocol: TCP
-                to:
-                  - ipBlock:
-                      cidr: 0.0.0.0/0
-                      except:
-                        - 10.0.0.0/8
-                        - 172.16.0.0/12
-                        - 192.168.0.0/16
+    networkpolicies:
+      default-deny:
+        controller: main
+        policyTypes: [Ingress, Egress]
+        rules: {}
+      allow-dns:
+        controller: main
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 53
+                  protocol: UDP
+                - port: 53
+                  protocol: TCP
+      allow-changedetection-ingress:
+        controller: main
+        policyTypes: [Ingress]
+        rules:
+          ingress:
+            - from:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: monitoring
+              ports:
+                - port: 3000
+      allow-external-egress:
+        controller: main
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 80
+                  protocol: TCP
+                - port: 443
+                  protocol: TCP
+              to:
+                - ipBlock:
+                    cidr: 0.0.0.0/0
+                    except:
+                      - 10.0.0.0/8
+                      - 172.16.0.0/12
+                      - 192.168.0.0/16
 
     service:
       app:

--- a/kubernetes/cluster0/apps/monitoring/changedetection-io/browser/helm-release.yaml
+++ b/kubernetes/cluster0/apps/monitoring/changedetection-io/browser/helm-release.yaml
@@ -72,6 +72,52 @@ spec:
           main:
             app:
               - path: /dev/shm
+    networkPolicies:
+      enabled: true
+      policies:
+        - name: default-deny
+          spec:
+            podSelector: {}
+            policyTypes: [Ingress, Egress]
+        - name: allow-dns
+          spec:
+            podSelector: {}
+            policyTypes: [Egress]
+            egress:
+              - ports:
+                  - port: 53
+                    protocol: UDP
+                  - port: 53
+                    protocol: TCP
+        - name: allow-changedetection-ingress
+          spec:
+            podSelector: {}
+            policyTypes: [Ingress]
+            ingress:
+              - from:
+                  - namespaceSelector:
+                      matchLabels:
+                        kubernetes.io/metadata.name: monitoring
+                ports:
+                  - port: 3000
+        - name: allow-external-egress
+          spec:
+            podSelector: {}
+            policyTypes: [Egress]
+            egress:
+              - ports:
+                  - port: 80
+                    protocol: TCP
+                  - port: 443
+                    protocol: TCP
+                to:
+                  - ipBlock:
+                      cidr: 0.0.0.0/0
+                      except:
+                        - 10.0.0.0/8
+                        - 172.16.0.0/12
+                        - 192.168.0.0/16
+
     service:
       app:
         controller: main

--- a/kubernetes/cluster0/apps/monitoring/changedetection-io/browser/helm-release.yaml
+++ b/kubernetes/cluster0/apps/monitoring/changedetection-io/browser/helm-release.yaml
@@ -96,6 +96,9 @@ spec:
                 - namespaceSelector:
                     matchLabels:
                       kubernetes.io/metadata.name: monitoring
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/name: changedetection-io
               ports:
                 - port: 3000
       allow-external-egress:

--- a/kubernetes/cluster0/apps/monitoring/changedetection-io/browser/helm-release.yaml
+++ b/kubernetes/cluster0/apps/monitoring/changedetection-io/browser/helm-release.yaml
@@ -98,7 +98,7 @@ spec:
                       kubernetes.io/metadata.name: monitoring
                   podSelector:
                     matchLabels:
-                      app.kubernetes.io/name: changedetection-io
+                      app.kubernetes.io/instance: changedetection-io
               ports:
                 - port: 3000
       allow-external-egress:

--- a/kubernetes/cluster0/apps/monitoring/uptime-kuma/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/monitoring/uptime-kuma/app/helm-release.yaml
@@ -98,6 +98,79 @@ spec:
           - backendRefs:
               - identifier: app
                 port: *port
+    networkPolicies:
+      enabled: true
+      policies:
+        - name: default-deny
+          spec:
+            podSelector: {}
+            policyTypes: [Ingress, Egress]
+        - name: allow-dns
+          spec:
+            podSelector: {}
+            policyTypes: [Egress]
+            egress:
+              - ports:
+                  - port: 53
+                    protocol: UDP
+                  - port: 53
+                    protocol: TCP
+        - name: allow-traefik-ingress
+          spec:
+            podSelector: {}
+            policyTypes: [Ingress]
+            ingress:
+              - from:
+                  - namespaceSelector:
+                      matchLabels:
+                        kubernetes.io/metadata.name: networking
+        - name: allow-monitored-egress
+          spec:
+            podSelector: {}
+            policyTypes: [Egress]
+            egress:
+              # Allow reaching external monitored endpoints
+              - ports:
+                  - port: 80
+                    protocol: TCP
+                  - port: 443
+                    protocol: TCP
+                to:
+                  - ipBlock:
+                      cidr: 0.0.0.0/0
+                      except:
+                        - 10.0.0.0/8
+                        - 172.16.0.0/12
+                        - 192.168.0.0/16
+              # Allow reaching cluster-internal monitored services
+              - ports:
+                  - port: 80
+                    protocol: TCP
+                  - port: 443
+                    protocol: TCP
+                  - port: 8080
+                    protocol: TCP
+                  - port: 8443
+                    protocol: TCP
+                to:
+                  - ipBlock:
+                      cidr: 10.0.0.0/8
+        - name: allow-oauth2-google-egress
+          spec:
+            podSelector: {}
+            policyTypes: [Egress]
+            egress:
+              - ports:
+                  - port: 443
+                    protocol: TCP
+                to:
+                  - ipBlock:
+                      cidr: 0.0.0.0/0
+                      except:
+                        - 10.0.0.0/8
+                        - 172.16.0.0/12
+                        - 192.168.0.0/16
+
     persistence:
       config:
         existingClaim: pvc-uptime-kuma

--- a/kubernetes/cluster0/apps/monitoring/uptime-kuma/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/monitoring/uptime-kuma/app/helm-release.yaml
@@ -98,78 +98,61 @@ spec:
           - backendRefs:
               - identifier: app
                 port: *port
-    networkPolicies:
-      enabled: true
-      policies:
-        - name: default-deny
-          spec:
-            podSelector: {}
-            policyTypes: [Ingress, Egress]
-        - name: allow-dns
-          spec:
-            podSelector: {}
-            policyTypes: [Egress]
-            egress:
-              - ports:
-                  - port: 53
-                    protocol: UDP
-                  - port: 53
-                    protocol: TCP
-        - name: allow-traefik-ingress
-          spec:
-            podSelector: {}
-            policyTypes: [Ingress]
-            ingress:
-              - from:
-                  - namespaceSelector:
-                      matchLabels:
-                        kubernetes.io/metadata.name: networking
-        - name: allow-monitored-egress
-          spec:
-            podSelector: {}
-            policyTypes: [Egress]
-            egress:
-              # Allow reaching external monitored endpoints
-              - ports:
-                  - port: 80
-                    protocol: TCP
-                  - port: 443
-                    protocol: TCP
-                to:
-                  - ipBlock:
-                      cidr: 0.0.0.0/0
-                      except:
-                        - 10.0.0.0/8
-                        - 172.16.0.0/12
-                        - 192.168.0.0/16
-              # Allow reaching cluster-internal monitored services
-              - ports:
-                  - port: 80
-                    protocol: TCP
-                  - port: 443
-                    protocol: TCP
-                  - port: 8080
-                    protocol: TCP
-                  - port: 8443
-                    protocol: TCP
-                to:
-                  - ipBlock:
-                      cidr: 10.0.0.0/8
-        - name: allow-oauth2-google-egress
-          spec:
-            podSelector: {}
-            policyTypes: [Egress]
-            egress:
-              - ports:
-                  - port: 443
-                    protocol: TCP
-                to:
-                  - ipBlock:
-                      cidr: 0.0.0.0/0
-                      except:
-                        - 10.0.0.0/8
-                        - 172.16.0.0/12
-                        - 192.168.0.0/16
+    networkpolicies:
+      default-deny:
+        controller: main
+        policyTypes: [Ingress, Egress]
+        rules: {}
+      allow-dns:
+        controller: main
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 53
+                  protocol: UDP
+                - port: 53
+                  protocol: TCP
+      allow-traefik-ingress:
+        controller: main
+        policyTypes: [Ingress]
+        rules:
+          ingress:
+            - from:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: networking
+      allow-monitored-egress:
+        controller: main
+        policyTypes: [Egress]
+        rules:
+          egress:
+            # Allow reaching external monitored endpoints and Google OAuth
+            - ports:
+                - port: 80
+                  protocol: TCP
+                - port: 443
+                  protocol: TCP
+              to:
+                - ipBlock:
+                    cidr: 0.0.0.0/0
+                    except:
+                      - 10.0.0.0/8
+                      - 172.16.0.0/12
+                      - 192.168.0.0/16
+            # Allow reaching cluster-internal monitored services
+            - ports:
+                - port: 80
+                  protocol: TCP
+                - port: 443
+                  protocol: TCP
+                - port: 8080
+                  protocol: TCP
+                - port: 8443
+                  protocol: TCP
+              to:
+                - ipBlock:
+                    cidr: 10.0.0.0/8
 
     persistence:
       config:

--- a/kubernetes/cluster0/apps/networking/cloudflared/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/networking/cloudflared/app/helm-release.yaml
@@ -109,6 +109,62 @@ spec:
                   originServerName: tun.${SECRET_PUBLIC_DOMAIN}
               - service: http_status:404
 
+    networkPolicies:
+      enabled: true
+      policies:
+        - name: default-deny
+          spec:
+            podSelector: {}
+            policyTypes: [Ingress, Egress]
+        - name: allow-dns
+          spec:
+            podSelector: {}
+            policyTypes: [Egress]
+            egress:
+              - ports:
+                  - port: 53
+                    protocol: UDP
+                  - port: 53
+                    protocol: TCP
+        - name: allow-prometheus-scrape
+          spec:
+            podSelector: {}
+            policyTypes: [Ingress]
+            ingress:
+              - from:
+                  - namespaceSelector:
+                      matchLabels:
+                        kubernetes.io/metadata.name: monitoring
+                ports:
+                  - port: 8080
+        - name: allow-cloudflare-egress
+          spec:
+            podSelector: {}
+            policyTypes: [Egress]
+            egress:
+              - ports:
+                  - port: 443
+                    protocol: TCP
+                to:
+                  - ipBlock:
+                      cidr: 0.0.0.0/0
+                      except:
+                        - 10.0.0.0/8
+                        - 172.16.0.0/12
+                        - 192.168.0.0/16
+        - name: allow-traefik-egress
+          spec:
+            podSelector: {}
+            policyTypes: [Egress]
+            egress:
+              - ports:
+                  - port: 443
+                    protocol: TCP
+                to:
+                  - namespaceSelector:
+                      matchLabels:
+                        kubernetes.io/metadata.name: networking
+
     persistence:
       config:
         type: configMap

--- a/kubernetes/cluster0/apps/networking/cloudflared/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/networking/cloudflared/app/helm-release.yaml
@@ -109,61 +109,59 @@ spec:
                   originServerName: tun.${SECRET_PUBLIC_DOMAIN}
               - service: http_status:404
 
-    networkPolicies:
-      enabled: true
-      policies:
-        - name: default-deny
-          spec:
-            podSelector: {}
-            policyTypes: [Ingress, Egress]
-        - name: allow-dns
-          spec:
-            podSelector: {}
-            policyTypes: [Egress]
-            egress:
-              - ports:
-                  - port: 53
-                    protocol: UDP
-                  - port: 53
-                    protocol: TCP
-        - name: allow-prometheus-scrape
-          spec:
-            podSelector: {}
-            policyTypes: [Ingress]
-            ingress:
-              - from:
-                  - namespaceSelector:
-                      matchLabels:
-                        kubernetes.io/metadata.name: monitoring
-                ports:
-                  - port: 8080
-        - name: allow-cloudflare-egress
-          spec:
-            podSelector: {}
-            policyTypes: [Egress]
-            egress:
-              - ports:
-                  - port: 443
-                    protocol: TCP
-                to:
-                  - ipBlock:
-                      cidr: 0.0.0.0/0
-                      except:
-                        - 10.0.0.0/8
-                        - 172.16.0.0/12
-                        - 192.168.0.0/16
-        - name: allow-traefik-egress
-          spec:
-            podSelector: {}
-            policyTypes: [Egress]
-            egress:
-              - ports:
-                  - port: 443
-                    protocol: TCP
-                to:
-                  - namespaceSelector:
-                      matchLabels:
-                        kubernetes.io/metadata.name: networking
+    networkpolicies:
+      default-deny:
+        controller: cloudflared
+        policyTypes: [Ingress, Egress]
+        rules: {}
+      allow-dns:
+        controller: cloudflared
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 53
+                  protocol: UDP
+                - port: 53
+                  protocol: TCP
+      allow-prometheus-scrape:
+        controller: cloudflared
+        policyTypes: [Ingress]
+        rules:
+          ingress:
+            - from:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: monitoring
+              ports:
+                - port: 8080
+      allow-cloudflare-egress:
+        controller: cloudflared
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 443
+                  protocol: TCP
+              to:
+                - ipBlock:
+                    cidr: 0.0.0.0/0
+                    except:
+                      - 10.0.0.0/8
+                      - 172.16.0.0/12
+                      - 192.168.0.0/16
+      allow-traefik-egress:
+        controller: cloudflared
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 443
+                  protocol: TCP
+              to:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: networking
 
     persistence:
       config:

--- a/kubernetes/cluster0/apps/networking/external-dns/app/kustomization.yaml
+++ b/kubernetes/cluster0/apps/networking/external-dns/app/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - ./helm-release.yaml
   - ./secret.sops.yaml
   - ./crd.yaml
+  - ./network-policy.yaml
 labels:
   - pairs:
       app.kubernetes.io/name: external-dns

--- a/kubernetes/cluster0/apps/networking/external-dns/app/network-policy.yaml
+++ b/kubernetes/cluster0/apps/networking/external-dns/app/network-policy.yaml
@@ -29,11 +29,11 @@ spec:
         - port: 53
           protocol: TCP
 ---
-# Allow egress to external APIs: Cloudflare API (443) and Kubernetes API server (6443)
+# Allow egress to Cloudflare API (443) — external only
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: external-dns-allow-external-egress
+  name: external-dns-allow-cloudflare-api
   namespace: networking
 spec:
   podSelector:
@@ -44,8 +44,6 @@ spec:
     - ports:
         - port: 443
           protocol: TCP
-        - port: 6443
-          protocol: TCP
       to:
         - ipBlock:
             cidr: 0.0.0.0/0
@@ -53,3 +51,28 @@ spec:
               - 10.0.0.0/8
               - 172.16.0.0/12
               - 192.168.0.0/16
+---
+# Allow egress to Kubernetes API server (in-cluster service + control plane node)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: external-dns-allow-k8s-api
+  namespace: networking
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: external-dns
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.43.0.0/16  # Service CIDR (kubernetes.default.svc)
+    - ports:
+        - port: 6443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.87.42.2/32  # Control plane node

--- a/kubernetes/cluster0/apps/networking/external-dns/app/network-policy.yaml
+++ b/kubernetes/cluster0/apps/networking/external-dns/app/network-policy.yaml
@@ -1,0 +1,55 @@
+---
+# Default deny-all for external-dns pods
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: networking
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: external-dns
+  policyTypes: [Ingress, Egress]
+---
+# Allow DNS resolution
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: external-dns-allow-dns
+  namespace: networking
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: external-dns
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+---
+# Allow egress to external APIs: Cloudflare API (443) and Kubernetes API server (6443)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: external-dns-allow-external-egress
+  namespace: networking
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: external-dns
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP
+        - port: 6443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16

--- a/kubernetes/cluster0/apps/networking/external-dns/app/network-policy.yaml
+++ b/kubernetes/cluster0/apps/networking/external-dns/app/network-policy.yaml
@@ -3,7 +3,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: default-deny
+  name: external-dns-default-deny
   namespace: networking
 spec:
   podSelector:


### PR DESCRIPTION
## Summary

Implements the first phase of the NetworkPolicy rollout across the cluster. Establishes the reusable baseline pattern (default-deny → allow-dns → allow-traefik-ingress → specific egress) and applies it to simple leaf services with no complex cross-namespace dependencies.

## Services covered

### networking namespace
- **cloudflared** — default-deny + DNS + Prometheus scrape + egress to Cloudflare (HTTPS, `0.0.0.0/0`) + egress to Traefik in networking namespace
- **external-dns** — default-deny + DNS + egress to Cloudflare API and Kubernetes API server (port 6443, public IP) via standalone NetworkPolicy manifests (non-app-template chart)

### monitoring namespace
- **uptime-kuma** — default-deny + DNS + Traefik ingress + egress to monitored endpoints (external HTTPS + internal cluster CIDR) + Google OAuth egress
- **changedetection-io** — default-deny + DNS + Traefik ingress + external HTTPS egress + egress to browserless sidecar on port 3000
- **changedetection-browser** — default-deny + DNS + ingress from monitoring namespace on port 3000 + external HTTPS egress (browsers need to fetch pages)
- **blackbox-exporter** — default-deny + DNS + Prometheus scrape ingress (port 9115) + probe egress to external and cluster-internal targets via standalone manifests (non-app-template chart)

### media namespace
- **plex** — default-deny + DNS + Traefik ingress + LAN direct ingress on 32400 + external egress (443 + 32400 for relay) + NFS egress to NAS (10.87.42.200)
- **jellyfin** — default-deny + DNS + Traefik ingress + external HTTPS egress + NFS egress to NAS
- **overseerr** — default-deny + DNS + Traefik ingress + external HTTPS egress + egress to Sonarr (8989), Radarr (7878), Plex (32400) in media namespace
- **syncthing** — default-deny + DNS + Traefik ingress + LAN direct ingress on 22000/21027 + egress to external sync peers (TCP 22000, UDP 22000, UDP 21027, HTTPS)

## Implementation notes

- app-template services: policies added to `networkPolicies:` block in HelmRelease values
- External-chart services (external-dns, blackbox-exporter): standalone `NetworkPolicy` manifests alongside the HelmRelease, referenced in kustomization.yaml
- Cluster-internal egress uses named `namespaceSelector` targets; `0.0.0.0/0` only for genuinely external traffic
- NFS egress scoped to the NAS IP (10.87.42.200) rather than entire RFC1918

Closes #2809