### PR TITLE
fix(netpol): patch 5 NetworkPolicy gaps from phase 1 rollout

### DIFF
--- a/kubernetes/cluster0/apps/media/syncthing/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/syncthing/app/helm-release.yaml
@@ -107,6 +107,8 @@ spec:
                   protocol: UDP
                 - port: 21027
                   protocol: UDP
+                - port: 3478
+                  protocol: UDP
                 - port: 443
                   protocol: TCP
               to:

--- a/kubernetes/cluster0/apps/monitoring/blackbox-exporter/app/network-policy.yaml
+++ b/kubernetes/cluster0/apps/monitoring/blackbox-exporter/app/network-policy.yaml
@@ -203,3 +203,13 @@ spec:
           podSelector:
             matchLabels:
               app.kubernetes.io/name: mosquitto
+    - ports:
+        - port: 8080
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: home
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: zigbee2mqtt

--- a/kubernetes/cluster0/apps/monitoring/blackbox-exporter/app/network-policy.yaml
+++ b/kubernetes/cluster0/apps/monitoring/blackbox-exporter/app/network-policy.yaml
@@ -75,28 +75,131 @@ spec:
               - 192.168.0.0/16
     # Cluster-internal probes — allow all TCP/UDP to cluster CIDR.
     # Note: Cilium resolves cross-namespace pod traffic via endpoint identity,
-    # so we also enumerate known service ports explicitly to ensure matching.
+    # so we also add scoped namespace+pod selector rules for each probe target
+    # to ensure matching regardless of how Cilium evaluates the traffic.
     - to:
         - ipBlock:
             cidr: 10.0.0.0/8
-    # Explicit port allowances for cluster-internal service probes
-    # (covers cases where Cilium matches by endpoint identity rather than CIDR)
+    # media namespace probe targets
     - ports:
-        - port: 3000   # grafana
-          protocol: TCP
-        - port: 5055   # overseerr
-          protocol: TCP
-        - port: 7878   # radarr
-          protocol: TCP
-        - port: 8080   # sabnzbd, qbittorrent
-          protocol: TCP
-        - port: 8096   # jellyfin
-          protocol: TCP
-        - port: 8686   # lidarr
-          protocol: TCP
-        - port: 8989   # sonarr
-          protocol: TCP
-        - port: 32400  # plex
+        - port: 8096
           protocol: TCP
       to:
-        - namespaceSelector: {}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: media
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: jellyfin
+    - ports:
+        - port: 32400
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: media
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: plex
+    - ports:
+        - port: 5055
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: media
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: overseerr
+    - ports:
+        - port: 7878
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: media
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: radarr
+    - ports:
+        - port: 8989
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: media
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: sonarr
+    - ports:
+        - port: 8686
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: media
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: lidarr
+    - ports:
+        - port: 8080
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: media
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: sabnzbd
+    - ports:
+        - port: 8080
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: media
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: qbittorrent
+    - ports:
+        - port: 9696
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: media
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prowlarr
+    # monitoring namespace probe targets
+    - ports:
+        - port: 3000
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: grafana
+    # home namespace probe targets
+    - ports:
+        - port: 8123
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: home
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: home-assistant
+    - ports:
+        - port: 1883
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: home
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: mosquitto

--- a/kubernetes/cluster0/apps/monitoring/blackbox-exporter/app/network-policy.yaml
+++ b/kubernetes/cluster0/apps/monitoring/blackbox-exporter/app/network-policy.yaml
@@ -73,8 +73,30 @@ spec:
               - 10.0.0.0/8
               - 172.16.0.0/12
               - 192.168.0.0/16
-    # Cluster-internal probes — allow all TCP to cluster CIDR so blackbox can
-    # reach arbitrary service ports without enumerating every target port
+    # Cluster-internal probes — allow all TCP/UDP to cluster CIDR.
+    # Note: Cilium resolves cross-namespace pod traffic via endpoint identity,
+    # so we also enumerate known service ports explicitly to ensure matching.
     - to:
         - ipBlock:
             cidr: 10.0.0.0/8
+    # Explicit port allowances for cluster-internal service probes
+    # (covers cases where Cilium matches by endpoint identity rather than CIDR)
+    - ports:
+        - port: 3000   # grafana
+          protocol: TCP
+        - port: 5055   # overseerr
+          protocol: TCP
+        - port: 7878   # radarr
+          protocol: TCP
+        - port: 8080   # sabnzbd, qbittorrent
+          protocol: TCP
+        - port: 8096   # jellyfin
+          protocol: TCP
+        - port: 8686   # lidarr
+          protocol: TCP
+        - port: 8989   # sonarr
+          protocol: TCP
+        - port: 32400  # plex
+          protocol: TCP
+      to:
+        - namespaceSelector: {}

--- a/kubernetes/cluster0/apps/monitoring/uptime-kuma/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/monitoring/uptime-kuma/app/helm-release.yaml
@@ -140,17 +140,10 @@ spec:
                       - 10.0.0.0/8
                       - 172.16.0.0/12
                       - 192.168.0.0/16
-            # Allow reaching cluster-internal monitored services
-            - ports:
-                - port: 80
-                  protocol: TCP
-                - port: 443
-                  protocol: TCP
-                - port: 8080
-                  protocol: TCP
-                - port: 8443
-                  protocol: TCP
-              to:
+            # Allow reaching cluster-internal monitored services — no port
+            # restriction since uptime-kuma monitors many non-standard ports
+            # (e.g. 3000 grafana, 8123 home-assistant, 1883 mosquitto, etc.)
+            - to:
                 - ipBlock:
                     cidr: 10.0.0.0/8
 

--- a/kubernetes/cluster0/apps/networking/cloudflared/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/networking/cloudflared/app/helm-release.yaml
@@ -143,6 +143,8 @@ spec:
             - ports:
                 - port: 443
                   protocol: TCP
+                - port: 7844
+                  protocol: UDP
               to:
                 - ipBlock:
                     cidr: 0.0.0.0/0

--- a/kubernetes/cluster0/apps/networking/external-dns/app/network-policy.yaml
+++ b/kubernetes/cluster0/apps/networking/external-dns/app/network-policy.yaml
@@ -75,4 +75,8 @@ spec:
           protocol: TCP
       to:
         - ipBlock:
-            cidr: 10.87.42.2/32  # Control plane node
+            cidr: 10.87.42.100/32  # control plane node0
+        - ipBlock:
+            cidr: 10.87.42.101/32  # control plane node1
+        - ipBlock:
+            cidr: 10.87.42.102/32  # control plane node2


### PR DESCRIPTION
## Summary

Follow-up fixes for NetworkPolicy gaps identified via Hubble flow analysis after the phase 1 rollout (PR #2821). Five policies were either missing protocols, had wrong IPs, or had overly restrictive port lists.

Closes #2809

## Fixes

### Fix 1 — CRITICAL: cloudflared UDP 7844 (QUIC/MASQUE) egress ⚡

Both cloudflared pods were **crash-looping** (18 restarts). The `allow-cloudflare-egress` policy only allowed TCP 443, but cloudflared uses **UDP 7844** for its QUIC/MASQUE tunnel protocol. Without it the tunnel couldn't establish, health probes returned 503, and the pods looped.

**File:** `kubernetes/cluster0/apps/networking/cloudflared/app/helm-release.yaml`

### Fix 2 — external-dns wrong control plane IPs

`external-dns-allow-k8s-api` had `10.87.42.2/32` as the control plane address, but the actual k3s nodes are at `.100`, `.101`, `.102`. external-dns was being load-balanced to real node IPs and all connections were dropped.

**File:** `kubernetes/cluster0/apps/networking/external-dns/app/network-policy.yaml`

### Fix 3 — uptime-kuma internal egress port restriction too narrow

`allow-monitored-egress` only allowed TCP ports 80/443/8080/8443 to `10.0.0.0/8`. Uptime Kuma monitors services on many non-standard ports (grafana :3000, home-assistant :8123, mosquitto :1883, arr stack, etc.) — all were being dropped. Replaced the port-restricted internal rule with a port-free rule scoped to `10.0.0.0/8`.

**File:** `kubernetes/cluster0/apps/monitoring/uptime-kuma/app/helm-release.yaml`

### Fix 4 — blackbox-exporter missing explicit port egress rules

Hubble showed `policy-verdict:none EGRESS DENIED` from blackbox to cluster-internal services. The existing catch-all `10.0.0.0/8` CIDR rule without ports wasn't matching because Cilium resolves cross-namespace pod traffic via endpoint identity rather than CIDR. Added explicit per-port egress rules for all probed service ports alongside the existing CIDR rule.

**File:** `kubernetes/cluster0/apps/monitoring/blackbox-exporter/app/network-policy.yaml`

### Fix 5 — Syncthing UDP 3478 (STUN) egress missing

Hubble showed Syncthing drops on UDP 3478 to external IPs. This is the STUN protocol for NAT traversal/hole-punching used to establish direct peer connections. Added to `allow-sync-egress-internet`.

**File:** `kubernetes/cluster0/apps/media/syncthing/app/helm-release.yaml`