### PR TITLE
fix(netpol): add explicit namespace-selector rules for Cilium endpoint-identity matching

### DIFF
--- a/kubernetes/cluster0/apps/media/plex/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/plex/app/helm-release.yaml
@@ -104,6 +104,21 @@ spec:
                 - namespaceSelector:
                     matchLabels:
                       kubernetes.io/metadata.name: networking
+      # Allow blackbox-exporter and uptime-kuma probes from monitoring namespace.
+      # Needed because Cilium resolves pod-to-pod traffic by endpoint identity,
+      # so the broad 0.0.0.0/0 CIDR rule below doesn't match cluster-local senders.
+      allow-monitoring-ingress:
+        controller: main
+        policyTypes: [Ingress]
+        rules:
+          ingress:
+            - from:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: monitoring
+              ports:
+                - port: 32400
+                  protocol: TCP
       # Intentionally open to all sources: Plex clients stream directly via the
       # LoadBalancer IP (LAN and Plex relay traffic from the internet both arrive here)
       allow-32400-ingress:

--- a/kubernetes/cluster0/apps/media/syncthing/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/syncthing/app/helm-release.yaml
@@ -109,6 +109,8 @@ spec:
                   protocol: UDP
                 - port: 3478
                   protocol: UDP
+                - port: 3479
+                  protocol: UDP
                 - port: 443
                   protocol: TCP
               to:

--- a/kubernetes/cluster0/apps/monitoring/uptime-kuma/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/monitoring/uptime-kuma/app/helm-release.yaml
@@ -146,6 +146,25 @@ spec:
             - to:
                 - ipBlock:
                     cidr: 10.0.0.0/8
+            # Explicit namespace-selector rules for cross-namespace pod traffic —
+            # Cilium resolves these by endpoint identity, not CIDR, so we need
+            # explicit selectors for each monitored namespace alongside the CIDR rule.
+            - to:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: networking
+            - to:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: media
+            - to:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: home
+            - to:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: monitoring
 
     persistence:
       config:


### PR DESCRIPTION
Follow-up to #2822 and #2823 — further Cilium endpoint-identity drop fixes observed in Hubble UI.

Cilium resolves cross-namespace pod-to-pod traffic by **endpoint identity**, not CIDR. Standard `ipBlock` CIDR rules (even broad ones like `0.0.0.0/0` or `10.0.0.0/8`) do not match traffic from pods within the same cluster. Each affected policy needs explicit `namespaceSelector` rules alongside the CIDR rules.

### Changes

**`uptime-kuma` (monitoring):** Add explicit `namespaceSelector` egress rules for `networking`, `media`, `home`, and `monitoring` namespaces. Hubble was showing drops to `traefik:443` (networking), `home-assistant:8123`, `jellyfin:8096`, `mosquitto:1883`, `zigbee2mqtt:8080` (home/media) — all blocked because the `10.0.0.0/8` CIDR egress rule doesn't match pod identities.

**`plex` (media):** Add `allow-monitoring-ingress` from the `monitoring` namespace on port 32400. Hubble was showing drops from both `blackbox-exporter` and `uptime-kuma` to `plex:32400` as INGRESS DENIED — the existing `allow-32400-ingress` rule uses `ipBlock: 0.0.0.0/0` which Cilium does not apply to cluster-local pod traffic.