### PR TITLE
fix(netpol): allow TCP 443 to control plane nodes for external-dns

### DIFF
--- a/kubernetes/cluster0/apps/networking/external-dns/app/network-policy.yaml
+++ b/kubernetes/cluster0/apps/networking/external-dns/app/network-policy.yaml
@@ -71,6 +71,8 @@ spec:
         - ipBlock:
             cidr: 10.43.0.0/16  # Service CIDR (kubernetes.default.svc)
     - ports:
+        - port: 443
+          protocol: TCP
         - port: 6443
           protocol: TCP
       to:


### PR DESCRIPTION
external-dns was timing out on `10.43.0.1:443` — Cilium resolves the kubernetes ClusterIP to control plane node endpoint identity post-DNAT, so both port 443 and 6443 need to be allowed on the node IPs.

The existing `external-dns-allow-k8s-api` policy had:
- `10.43.0.0/16:443` — covers the ClusterIP VIP
- `10.87.42.100-102/32:6443` — covers direct node access

But Cilium was evaluating post-DNAT traffic against the node identity with only port 6443 permitted, causing `connection timed out` on every API call and putting external-dns into CrashLoopBackOff.

Adds port 443 alongside 6443 for all three control plane node CIDRs.