### PR TITLE
fix(netpol): correct control plane IP in external-dns k8s API egress rule

### DIFF
--- a/kubernetes/cluster0/apps/networking/external-dns/app/network-policy.yaml
+++ b/kubernetes/cluster0/apps/networking/external-dns/app/network-policy.yaml
@@ -77,8 +77,4 @@ spec:
           protocol: TCP
       to:
         - ipBlock:
-            cidr: 10.87.42.100/32  # control plane node0
-        - ipBlock:
-            cidr: 10.87.42.101/32  # control plane node1
-        - ipBlock:
-            cidr: 10.87.42.102/32  # control plane node2
+            cidr: 10.87.42.2/32  # control plane node


### PR DESCRIPTION
## Problem

`external-dns` was in CrashLoopBackOff, unable to reach the Kubernetes API server:

```
dial tcp 10.43.0.1:443: connect: connection timed out
```

## Root cause

The `external-dns-allow-k8s-api` NetworkPolicy listed three non-existent HA control plane IPs:
- `10.87.42.100/32`
- `10.87.42.101/32`
- `10.87.42.102/32`

With Cilium running in `kubeProxyReplacement: true` mode, traffic destined for the kubernetes ClusterIP (`10.43.0.1:443`) is DNAT'd by Cilium's eBPF dataplane to the **real** API server (`10.87.42.2:6443`) **before** NetworkPolicy is evaluated. The egress allow rule therefore needs to permit traffic to `10.87.42.2`, not the three phantom IPs.

The correct IP (`10.87.42.2`) is the single control plane node confirmed in `kubernetes/cluster0/flux/vars/cluster-settings.yaml`.

## Fix

Replace the three wrong `ipBlock` entries with the single correct control plane IP `10.87.42.2/32`. Both ports (443 for defensive depth, 6443 for post-DNAT k3s API server) are retained on that rule. The `10.43.0.0/16:443` rule is kept as-is.

## Changed files

- `kubernetes/cluster0/apps/networking/external-dns/app/network-policy.yaml`

Closes #<!-- issue number if applicable -->