### PR TITLE
fix(netpol): add CiliumNetworkPolicy to allow external-dns kube-apiserver egress

### DIFF
--- a/kubernetes/cluster0/apps/networking/external-dns/app/cilium-network-policy.yaml
+++ b/kubernetes/cluster0/apps/networking/external-dns/app/cilium-network-policy.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: external-dns-allow-kube-apiserver
+  namespace: networking
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: external-dns
+  egress:
+    - toEntities:
+        - kube-apiserver

--- a/kubernetes/cluster0/apps/networking/external-dns/app/kustomization.yaml
+++ b/kubernetes/cluster0/apps/networking/external-dns/app/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ./secret.sops.yaml
   - ./crd.yaml
   - ./network-policy.yaml
+  - ./cilium-network-policy.yaml
 labels:
   - pairs:
       app.kubernetes.io/name: external-dns


### PR DESCRIPTION
## Problem

`external-dns` is in a persistent `CrashLoopBackOff` because it cannot reach the Kubernetes API server at `10.43.0.1:443` (connection timeout).

A standard Kubernetes `NetworkPolicy` (`external-dns-allow-k8s-api`) with `ipBlock` egress rules for both the service CIDR and the control plane node IP is already in place, but it has no effect. This is because Cilium is running with `kubeProxyReplacement: true` — the k3s API server runs in the **host network namespace** and Cilium assigns it the `kube-apiserver` entity identity. Standard `ipBlock` rules do not match against Cilium entity identities, so both rules are silently bypassed.

## Fix

Add a `CiliumNetworkPolicy` resource that uses `toEntities: kube-apiserver` — the correct Cilium-native mechanism for allowing egress to a host-networked kube-apiserver.

The existing standard `NetworkPolicy` rules are kept intact as defensive depth.

## Changes

- **New**: `kubernetes/cluster0/apps/networking/external-dns/app/cilium-network-policy.yaml` — `CiliumNetworkPolicy` allowing external-dns → kube-apiserver egress
- **Updated**: `kubernetes/cluster0/apps/networking/external-dns/app/kustomization.yaml` — added the new file to `resources`

No other files changed.

Closes #2829