### PR TITLE
fix(ci): unblock flux-local on reloader OCIRepository

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -52,6 +52,22 @@
       ],
       allowedVersions: '!/-(armhf|arm64|armv7|amd64|linux)$/',
     },
+    {
+      // Flux manager + OCIRepository hybrid digest shape is broken:
+      // Renovate writes `tag: <semver>@sha256:<digest>` instead of populating
+      // the separate `ref.digest` field (renovatebot/renovate#42082). flux-local
+      // then passes the hybrid string (or the bare digest, when split) to
+      // `helm template --version`, which Helm rejects as a non-semver
+      // constraint, breaking CI.
+      //
+      // Disable digest pinning on the reloader OCIRepository specifically.
+      // The flux-manifests OCIRepository keeps digest pinning because it is
+      // consumed by a Kustomization (not templated by helm) and is unaffected.
+      // See #2831 for full context.
+      matchManagers: ['flux'],
+      matchFileNames: ['kubernetes/cluster0/apps/kube-system/reloader/app/helm-release.yaml'],
+      pinDigests: false,
+    },
   ],
   customManagers: [
     {

--- a/kubernetes/cluster0/apps/kube-system/reloader/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/kube-system/reloader/app/helm-release.yaml
@@ -11,7 +11,7 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 2.2.11@sha256:05c912e1ed0703618454bf75a61e5ee19789f1108dd8ccf1e9fd246e4d127469
+    tag: "2.2.11"
   url: oci://ghcr.io/stakater/charts/reloader
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json

--- a/kubernetes/cluster0/flux/config/flux.yaml
+++ b/kubernetes/cluster0/flux/config/flux.yaml
@@ -8,7 +8,8 @@ spec:
   interval: 10m
   url: oci://ghcr.io/fluxcd/flux-manifests
   ref:
-    tag: v2.8.6@sha256:45ed09e8241e4b0ee38d0fc8d8e42b6002d55c880b0859c9c484bf22340116d5
+    tag: "v2.8.6"
+    digest: sha256:45ed09e8241e4b0ee38d0fc8d8e42b6002d55c880b0859c9c484bf22340116d5
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization


### PR DESCRIPTION
> [!IMPORTANT]
> **Known unsatisfiable check: `Flux Local - Diff (helmrelease)`**
>
> This check templates both branches and diffs them. The PR-side templates
> cleanly. The `main`-side still contains the broken `tag: 2.2.11@sha256:...`
> shape and fails Helm's improper-constraint error — that is the bug this PR
> exists to fix. The Diff check will go green automatically once this PR
> merges. AC5 is structurally unverifiable pre-merge.
>
> `Flux Local - Test` passes 100/100 on the PR branch — that is the meaningful
> pre-merge signal that the fix works.

## Summary

`flux-local` was failing the `Flux Local - Test` check on every PR opened against `main`. Two `OCIRepository` manifests had a hybrid `ref.tag: <semver>@sha256:<digest>` shape, which `helm template --version` rejected as a non-semver constraint:

```
Error: improper constraint: 2.2.11@sha256:05c912e1ed...
```

The hybrid shape was introduced after #2813 enabled `pinDigests: true` on the `docker` datasource. Renovate's Flux manager has an open bug ([renovatebot/renovate#42082](https://github.com/renovatebot/renovate/issues/42082)) where it packs the digest into the tag string instead of populating the separate `ref.digest` field.

## What initially looked like the fix didn't work

Issue #2831 proposed splitting the hybrid into separate `tag:` and `digest:` fields under `ref:` — the shape documented by [Renovate's Flux manager docs](https://docs.renovatebot.com/modules/manager/flux/#ocirepository-support) and supported by Flux source-controller. I implemented that and CI still failed on the reloader resource:

```
Error: improper constraint: sha256:05c912e1ed0703618454bf75a61e5ee19789f1108dd8ccf1e9fd246e4d127469
```

`flux-local` v8.2.0 prefers `ref.digest` over `ref.tag` when constructing `helm template --version`, mirroring source-controller's "digest takes precedence" rule. With both fields present, it passed the bare digest — also non-semver, also rejected. So the literal AC1 spec didn't work for the reloader resource. After escalating, the coordinator directed the approach below.

## Changes (what actually shipped)

The two `OCIRepository` resources need different shapes because `flux-local` treats them differently:

* **`kubernetes/cluster0/apps/kube-system/reloader/app/helm-release.yaml`** — consumed by a `HelmRelease` and templated by `flux-local`. Collapsed to a clean semver tag with no digest:
  ```yaml
  ref:
    tag: "2.2.11"
  ```
  Trade-off: source-controller no longer SHA-verifies this one chart pull. Renovate still pins via tag bumps.

* **`kubernetes/cluster0/flux/config/flux.yaml`** — consumed by a `Kustomization` (flux-manifests bootstrap), not templated by helm, so `flux-local` doesn't run `helm template` against it. Split into separate fields, preserving digest verification on the highest-trust component in the cluster:
  ```yaml
  ref:
    tag: "v2.8.6"
    digest: sha256:45ed09e8241e4b0ee38d0fc8d8e42b6002d55c880b0859c9c484bf22340116d5
  ```
  (Rebased onto current main, which had been bumped to v2.8.6 by #2841 after this branch was created.)

* **`.github/renovate.json5`** — narrowly-scoped `packageRules` entry to prevent regression. Disables `pinDigests` only for the reloader file under the flux manager. Without it, the next reloader chart bump would re-introduce the hybrid `tag@sha256:` shape and break CI again. flux-manifests is intentionally not in scope of the rule because its split shape works.

## CI status

* ✅ **`Flux Local - Test` passes** (100/100) on the PR branch — the original CI blocker is resolved (AC4).
* ✅ `Flux Local - Diff (kustomization)` passes.
* ❌ **`Flux Local - Diff (helmrelease)` fails on the `main` side**, not the PR side — see callout at top. Will resolve automatically on merge.

## AC8 deviation justification

Per AC8, Renovate config changes should only happen with a justified reason. Adding the `packageRules` entry is justified: without it, the upstream Renovate bug ([renovatebot/renovate#42082](https://github.com/renovatebot/renovate/issues/42082)) will regress this fix on the next reloader chart bump. The rule is scoped as narrowly as possible — single file, single manager — and includes an inline comment referencing the upstream bug and #2831 for future context.

## References

- Renovate Flux manager docs (OCIRepository support): https://docs.renovatebot.com/modules/manager/flux/#ocirepository-support
- Upstream Renovate bug: https://github.com/renovatebot/renovate/issues/42082
- Origin of the regression: #2813 (enabled `pinDigests: true`)

Closes #2831