### PR TITLE
fix(netpol): allow ICMP egress from uptime-kuma via CiliumNetworkPolicy

### DIFF
--- a/kubernetes/cluster0/apps/monitoring/uptime-kuma/app/cilium-network-policy.yaml
+++ b/kubernetes/cluster0/apps/monitoring/uptime-kuma/app/cilium-network-policy.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: uptime-kuma-allow-icmp
+  namespace: monitoring
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: uptime-kuma
+  egress:
+    - icmps:
+        - fields:
+            - family: IPv4
+              type: "8"
+      toEntities:
+        - world
+        - cluster

--- a/kubernetes/cluster0/apps/monitoring/uptime-kuma/app/kustomization.yaml
+++ b/kubernetes/cluster0/apps/monitoring/uptime-kuma/app/kustomization.yaml
@@ -2,6 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./cilium-network-policy.yaml
   - ./helm-release.yaml
   - ./secret.sops.yaml
 labels:


### PR DESCRIPTION
## Summary

- Adds a `CiliumNetworkPolicy` (`uptime-kuma-allow-icmp`) that permits ICMPv4 Echo Request (type 8) egress from uptime-kuma pods to `world` and `cluster` entities.
- This is **additive** to the chart-managed NetworkPolicies (`uptime-kuma-default-deny`, `uptime-kuma-allow-dns`, `uptime-kuma-allow-monitored-egress`, `uptime-kuma-allow-traefik-ingress`) — none of those are modified.

## Why a CNP, not a NetworkPolicy?

Standard Kubernetes `NetworkPolicy` cannot permit ICMP. Cilium's dataplane only honours TCP/UDP in `ports` stanzas, so even a port-free egress rule won't allow pings. After the phase 1 netpol rollout in #2821 the chart-managed NetworkPolicies caused uptime-kuma's ping checks (`1.1.1.1`, control-plane nodes, etc.) to be silently denied.

## Spec correction vs the issue example

The issue body's example listed two separate `egress:` items — one for `icmps` and one for `toEntities`. In Cilium, each top-level `egress:` list item is an independent allow rule, so that shape would have allowed *all* traffic to `world` + `cluster` in addition to ICMP. That's far broader than intended.

The fix uses a **single** egress rule item that combines `icmps` + `toEntities`, which the [Cilium policy docs](https://docs.cilium.io/en/v1.18/security/policy/language/#limit-icmp-icmpv6-types) confirm is the correct shape: ICMP fields and L3 selectors in the same rule item AND together to mean "ICMPv4 type 8 to world or cluster only".

## Selector choice

Used `app.kubernetes.io/name: uptime-kuma` for the `endpointSelector` (rather than `app.kubernetes.io/instance` shown in the issue) to mirror the existing `external-dns-allow-kube-apiserver` CNP. Both labels are present on uptime-kuma pods, so either works functionally — consistency wins.

## Files changed

- **NEW** `kubernetes/cluster0/apps/monitoring/uptime-kuma/app/cilium-network-policy.yaml`
- **MODIFY** `kubernetes/cluster0/apps/monitoring/uptime-kuma/app/kustomization.yaml` (added the new file to `resources:`)

Closes #2826