### PR TITLE
feat: deploy SeaweedFS as S3-compatible object store

### DIFF
--- a/kubernetes/cluster0/apps/auth/authelia/app/middleware.yaml
+++ b/kubernetes/cluster0/apps/auth/authelia/app/middleware.yaml
@@ -120,3 +120,18 @@ spec:
       - Remote-Name
       - Remote-Email
       - Remote-Groups
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: forwardauth-authelia
+  namespace: seaweedfs
+spec:
+  forwardAuth:
+    address: http://authelia.auth.svc.cluster.local/api/verify?rd=https://auth.${SECRET_PUBLIC_DOMAIN}/
+    trustForwardHeader: true
+    authResponseHeaders:
+      - Remote-User
+      - Remote-Name
+      - Remote-Email
+      - Remote-Groups

--- a/kubernetes/cluster0/apps/seaweedfs/helm-repository.yaml
+++ b/kubernetes/cluster0/apps/seaweedfs/helm-repository.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/helmrepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: seaweedfs
+  namespace: seaweedfs
+spec:
+  interval: 1h
+  url: https://seaweedfs.github.io/seaweedfs/helm

--- a/kubernetes/cluster0/apps/seaweedfs/kustomization.yaml
+++ b/kubernetes/cluster0/apps/seaweedfs/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  # Pre Flux-Kustomizations
+  - ./namespace.yaml
+  - ./helm-repository.yaml
+  # Flux-Kustomizations
+  - ./seaweedfs/ks.yaml

--- a/kubernetes/cluster0/apps/seaweedfs/namespace.yaml
+++ b/kubernetes/cluster0/apps/seaweedfs/namespace.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: seaweedfs
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    trust.cert-manager.io/enabled: "true"

--- a/kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/certificate.yaml
+++ b/kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/certificate.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/certificate.yaml
+++ b/kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/certificate.yaml
@@ -1,0 +1,13 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: seaweedfs-s3-tls
+  namespace: seaweedfs
+spec:
+  secretName: seaweedfs-s3-tls
+  issuerRef:
+    name: internal-services-clusterissuer
+    kind: ClusterIssuer
+  dnsNames:
+    - seaweedfs-s3.seaweedfs.svc
+    - seaweedfs-s3.seaweedfs.svc.cluster.local

--- a/kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/helm-release.yaml
@@ -68,9 +68,6 @@ spec:
       s3:
         enabled: true
         enableAuth: true
-        createBuckets:
-          - name: postgresql
-            anonymousRead: false
 
     s3:
       enabled: true
@@ -80,3 +77,6 @@ spec:
       replicas: 1
       logs:
         type: emptyDir
+      createBuckets:
+        - name: postgresql
+          anonymousRead: false

--- a/kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/helm-release.yaml
@@ -1,0 +1,82 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: seaweedfs
+  namespace: seaweedfs
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: seaweedfs
+      version: 4.21.0
+      sourceRef:
+        kind: HelmRepository
+        name: seaweedfs
+        namespace: seaweedfs
+      interval: 5m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  valuesFrom:
+    - kind: Secret
+      name: seaweedfs-s3-credentials
+      valuesKey: admin_access_key_id
+      targetPath: s3.credentials.admin.accessKey
+    - kind: Secret
+      name: seaweedfs-s3-credentials
+      valuesKey: admin_secret_access_key
+      targetPath: s3.credentials.admin.secretKey
+  values:
+    global:
+      seaweedfs:
+        enableSecurity: true
+
+    master:
+      replicas: 1
+      data:
+        type: persistentVolumeClaim
+        size: 1Gi
+        storageClass: longhorn
+      logs:
+        type: emptyDir
+
+    volume:
+      replicas: 2
+      dataDirs:
+        - name: data
+          type: persistentVolumeClaim
+          size: 50Gi
+          storageClass: longhorn
+          maxVolumes: 0
+      logs:
+        type: emptyDir
+
+    filer:
+      replicas: 1
+      data:
+        type: persistentVolumeClaim
+        size: 1Gi
+        storageClass: longhorn
+      logs:
+        type: emptyDir
+      s3:
+        enabled: true
+        enableAuth: true
+        createBuckets:
+          - name: postgresql
+            anonymousRead: false
+
+    s3:
+      enabled: true
+      httpsPort: 8443
+      tlsSecret: seaweedfs-s3-tls
+      enableAuth: true
+      replicas: 1
+      logs:
+        type: emptyDir

--- a/kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/httproute.yaml
+++ b/kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/httproute.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: seaweedfs-console
+  namespace: seaweedfs
+spec:
+  hostnames:
+    - seaweedfs.${SECRET_PUBLIC_DOMAIN}
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: traefik-gateway
+      namespace: networking
+      sectionName: websecure
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: seaweedfs-filer
+          namespace: seaweedfs
+          port: 8888
+      filters:
+        - extensionRef:
+            group: traefik.io
+            kind: Middleware
+            name: forwardauth-authelia
+          type: ExtensionRef
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/kustomization.yaml
+++ b/kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - certificate.yaml
+  - helm-release.yaml
+  - httproute.yaml
+  - secret.sops.yaml

--- a/kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/secret.sops.yaml
+++ b/kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/secret.sops.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: seaweedfs-s3-credentials
+    namespace: seaweedfs
+stringData:
+    admin_access_key_id: ENC[AES256_GCM,data:M3uY4H0kobtbkNa4kmtBPJXKYvZYqMSbzlJCVBQDGdw=,iv:Sr5WYM7eAhVugU9y5IxOkK5UZgl1CFyesi5TKmKV3Cg=,tag:e1D82F1zrNzjeMinY7xwPQ==,type:str]
+    admin_secret_access_key: ENC[AES256_GCM,data:Ok9r2VJSN4amY/GPj/LgP5ErW48bf3Ky6g5IaARWARu5P6x2XI/BWOevkLwngSUj/T2RTP+MjEDmytf1848m0g==,iv:CCedPbj/LflJpORC0WPaHWW/Rip2pdl6QZC3pLsunQE=,tag:gm3346bKapTClzdfxVczIw==,type:str]
+sops:
+    age:
+        - recipient: age1582vh25trj6w7klwt38d44n5nr8njr8rrxxx5kcfu3y2ezx9ss3s6j24ex
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB5b3FKdVZzTHdHa3YzOUlH
+            S0dVaXgwby9SMm8rRURaam5hWTlCQktYN1hBCjNWYnJYZEp5S0Jtbkk0YnhzSlE1
+            ZTh5WCtWTFlub1VPcktFc2JNN1VsZTgKLS0tIEtMeGMybjhjYzRMQWJmOW9MK3k0
+            SzJQSHJxVnZWKzFhcThocEdKai8rRWsKu7D64HsHF58M25145CmEKOSZP4bfzxZ7
+            2ufH029QrhGeN7nrQAeTP0zrd7zDSWXUs25Z5VgjZrIy+0jnFMiDeQ==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age185kanaq3uw2gjx5enu2v69nk9ner3lamdevrfgx3wqucsl9ewa2qlt2gf7
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBpQ0dVV3hCcHZYNngwRnZE
+            UE83eGxiWTN1UkE3NTUvTTBTN3hKWEZPNGg4CnB6V0o3dHZTRWhBTnJLdnBjR21R
+            SEJSbHh6TGowekl3RGI1dHRJYXQ4Y1EKLS0tIDhxM0UxZFNBVEJBOTk3Vlk2c0tX
+            WEQ5TU1VdFhCYWEvUFV2a3dUUUlKM28KG/9y47SYkTXK9GGuNMfKb15ZyMgUX9rZ
+            hKKAPAnfO54zlkN1A7uis/UN6NeTFJ66As4FhxHA4ZlApxqIGNr6uA==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-04-26T22:55:44Z"
+    mac: ENC[AES256_GCM,data:LSoqK4ci0J2889YkJJI2F4j9GxSSVXX0NK+eYKy2eWlTX8sXD825PkgOXYL0A1MnFdepOfJeHgWhjjOUR5XPNFtpVSs3T7Yf2AFZHWeAJc9CVWHOcVnsyQh9S3zbVwX4S8t353kuoz4axo6DsPF7QRlEPUrDD/XWatMpWsnTdQ0=,iv:AAAyCz/di6eflGDFGu5LX+suFkpLjSUcyXL5jkpG8Ys=,tag:6CpFlBPLmGwMXux3Ei7tbg==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.12.2

--- a/kubernetes/cluster0/apps/seaweedfs/seaweedfs/ks.yaml
+++ b/kubernetes/cluster0/apps/seaweedfs/seaweedfs/ks.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-apps-seaweedfs
+  namespace: flux-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: seaweedfs
+  interval: 1h
+  path: ./kubernetes/cluster0/apps/seaweedfs/seaweedfs/app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-cluster0
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: seaweedfs
+      namespace: seaweedfs
+  timeout: 5m
+  wait: false


### PR DESCRIPTION
## Summary

- Deploys SeaweedFS via Flux HelmRelease in a new `seaweedfs` namespace
- Internal HTTPS S3 endpoint at `https://seaweedfs-s3.seaweedfs.svc:8443` with cert-manager TLS from `internal-services-clusterissuer`
- SOPS-encrypted credentials secret; credentials injected via Flux `valuesFrom`
- `postgresql` bucket pre-created via `filer.s3.createBuckets`
- Console UI (SeaweedFS filer) exposed at `seaweedfs.<domain>` behind Authelia forwardauth HTTPRoute

## Architecture

- **master**: 1 replica, 1Gi PVC on longhorn
- **volume**: 2 replicas, 50Gi PVC each on longhorn
- **filer**: 1 replica, 1Gi PVC on longhorn
- **s3 gateway**: 1 replica, HTTPS on port 8443 with cert from `internal-services-clusterissuer`

## CA trust chain

The `seaweedfs` namespace has `trust.cert-manager.io/enabled: "true"` so it receives the `internal-ca-bundle` Secret via trust-manager. The `databases` namespace also already has this label, so CNPG clusters can validate the SeaweedFS S3 TLS certificate without any additional configuration.

Closes #2855