### PR TITLE
Increase SeaweedFS Helm install timeout

### DIFF
--- a/kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/helm-release.yaml
@@ -17,6 +17,7 @@ spec:
         namespace: seaweedfs
       interval: 5m
   install:
+    timeout: 15m
     remediation:
       retries: 3
   upgrade:


### PR DESCRIPTION
Add a 15-minute timeout to the SeaweedFS Helm release installation. This prevents the Helm controller from failing prematurely during resource-heavy deployment processes.