### PR TITLE
fix: disable seaweedfs internal mTLS to unblock bucket hook job

### DIFF
--- a/kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/helm-release.yaml
@@ -35,7 +35,7 @@ spec:
   values:
     global:
       seaweedfs:
-        enableSecurity: true
+        enableSecurity: false
 
     master:
       replicas: 1


### PR DESCRIPTION
## Summary

- Changes `global.seaweedfs.enableSecurity` from `true` to `false` in the SeaweedFS HelmRelease
- The `seaweedfs-bucket-hook` Job was hanging because internal mTLS (enabled by `enableSecurity: true`) requires client certificates that the bucket hook pod doesn't have mounted
- S3 endpoint TLS is handled separately by the cert-manager Certificate resource (`seaweedfs-s3-tls`), so this change does not affect the security of the S3 API surface used by CNPG

Closes #(see issue if applicable)