### PR TITLE
fix: pin k3s-upgrade image to versioned tag with digest

### DIFF
--- a/kubernetes/cluster0/apps/system-upgrade/system-upgrade-controller/plans/agent-plan.yaml
+++ b/kubernetes/cluster0/apps/system-upgrade/system-upgrade-controller/plans/agent-plan.yaml
@@ -13,9 +13,11 @@ spec:
     args:
     - prepare
     - server-plan
-    image: rancher/k3s-upgrade@sha256:8448c66782e42c7dd562408f5494f2a83ba4086d261dfba2555317d087ce994b
+    # renovate: datasource=docker depName=rancher/k3s-upgrade
+    image: rancher/k3s-upgrade:v1.35.4-k3s1@sha256:8448c66782e42c7dd562408f5494f2a83ba4086d261dfba2555317d087ce994b
   serviceAccountName: system-upgrade
   upgrade:
-    image: rancher/k3s-upgrade@sha256:8448c66782e42c7dd562408f5494f2a83ba4086d261dfba2555317d087ce994b
+    # renovate: datasource=docker depName=rancher/k3s-upgrade
+    image: rancher/k3s-upgrade:v1.35.4-k3s1@sha256:8448c66782e42c7dd562408f5494f2a83ba4086d261dfba2555317d087ce994b
   # renovate: datasource=github-releases depName=k3s-io/k3s
   version: "v1.35.4+k3s1"

--- a/kubernetes/cluster0/apps/system-upgrade/system-upgrade-controller/plans/server-plan.yaml
+++ b/kubernetes/cluster0/apps/system-upgrade/system-upgrade-controller/plans/server-plan.yaml
@@ -12,6 +12,7 @@ spec:
       - {key: node-role.kubernetes.io/control-plane, operator: Exists}
   serviceAccountName: system-upgrade
   upgrade:
-    image: rancher/k3s-upgrade@sha256:8448c66782e42c7dd562408f5494f2a83ba4086d261dfba2555317d087ce994b
+    # renovate: datasource=docker depName=rancher/k3s-upgrade
+    image: rancher/k3s-upgrade:v1.35.4-k3s1@sha256:8448c66782e42c7dd562408f5494f2a83ba4086d261dfba2555317d087ce994b
   # renovate: datasource=github-releases depName=k3s-io/k3s
   version: "v1.35.4+k3s1"


### PR DESCRIPTION
## Summary

- Change bare digest image references to \`rancher/k3s-upgrade:v1.35.4-k3s1@sha256:<digest>\` format in both plan files
- Add \`# renovate: datasource=docker depName=rancher/k3s-upgrade\` comments above each image field
- Update version from \`v1.35.3+k3s1\` to \`v1.35.4+k3s1\`

Bare digests caused Renovate to track the \`latest\` tag, which led to accidental upgrade to a release candidate (\`v1.36.0-rc3-k3s1\`).

Closes #2875