### PR TITLE
fix(system-upgrade): revert to single-version-marker plans and bump to v1.36.0

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -60,6 +60,19 @@
       // `helm template --version`, which Helm rejects as a non-semver
       // constraint, breaking CI.
       //
+      // Disable digest pinning for rancher/k3s-upgrade: system-upgrade-controller
+      // substitutes spec.version into the image tag automatically (translating
+      // + -> - for Docker compat), so the image line must stay bare. Pinning a
+      // digest or tag here creates a second Renovate-tracked version marker that
+      // can desync from spec.version and cause upgrade jobs to spin forever.
+      // See #2819, #2876, #2895, #2898 for the full history.
+    },
+    {
+      matchDatasources: ['docker'],
+      matchPackageNames: ['rancher/k3s-upgrade'],
+      pinDigests: false,
+    },
+    {
       // Disable digest pinning on the reloader OCIRepository specifically.
       // The flux-manifests OCIRepository keeps digest pinning because it is
       // consumed by a Kustomization (not templated by helm) and is unaffected.

--- a/kubernetes/cluster0/apps/system-upgrade/system-upgrade-controller/plans/agent-plan.yaml
+++ b/kubernetes/cluster0/apps/system-upgrade/system-upgrade-controller/plans/agent-plan.yaml
@@ -13,11 +13,9 @@ spec:
     args:
     - prepare
     - server-plan
-    # renovate: datasource=docker depName=rancher/k3s-upgrade
-    image: rancher/k3s-upgrade:v1.36.0-k3s1@sha256:86bd241a0ad0960fcc95190f8edf0de5e8e346d8c2e2df4c268cc7681ab9a22a
+    image: rancher/k3s-upgrade
   serviceAccountName: system-upgrade
   upgrade:
-    # renovate: datasource=docker depName=rancher/k3s-upgrade
-    image: rancher/k3s-upgrade:v1.36.0-k3s1@sha256:86bd241a0ad0960fcc95190f8edf0de5e8e346d8c2e2df4c268cc7681ab9a22a
+    image: rancher/k3s-upgrade
   # renovate: datasource=github-releases depName=k3s-io/k3s
-  version: "v1.35.4+k3s1"
+  version: "v1.36.0+k3s1"

--- a/kubernetes/cluster0/apps/system-upgrade/system-upgrade-controller/plans/server-plan.yaml
+++ b/kubernetes/cluster0/apps/system-upgrade/system-upgrade-controller/plans/server-plan.yaml
@@ -12,7 +12,6 @@ spec:
       - {key: node-role.kubernetes.io/control-plane, operator: Exists}
   serviceAccountName: system-upgrade
   upgrade:
-    # renovate: datasource=docker depName=rancher/k3s-upgrade
-    image: rancher/k3s-upgrade:v1.36.0-k3s1@sha256:86bd241a0ad0960fcc95190f8edf0de5e8e346d8c2e2df4c268cc7681ab9a22a
+    image: rancher/k3s-upgrade
   # renovate: datasource=github-releases depName=k3s-io/k3s
-  version: "v1.35.4+k3s1"
+  version: "v1.36.0+k3s1"


### PR DESCRIPTION
## Problem

PR #2895 bumped the `rancher/k3s-upgrade` image tag to `v1.36.0-k3s1` (via the `datasource=docker` Renovate marker) but left `spec.version` at `v1.35.4+k3s1` (the `datasource=github-releases` marker hadn't picked up GA yet). This created a two-markers-in-two-datasources desync between the image tag and the version string.

The agent-plan prepare script string-compares the control-plane kubelet version against `spec.version`, so it entered an infinite wait loop:

```
[INFO] Waiting for all control-plane nodes to be upgraded to version v1.35.4-k3s1
```

Masters are on `v1.36.0-rc3+k3s1`; they will never report `v1.35.4`. The worker (node3) is blocked.

## Root cause history

- **PR #2819** – blanket "pin all image digests" sweep that didn't account for system-upgrade-controller's tag-substitution behaviour (it automatically substitutes `spec.version` into the image tag, translating `+` → `-` for Docker compat)
- **PR #2876** – added a versioned tag back to the image to stop Renovate tracking `latest`, but introduced the second Renovate datasource (`datasource=docker`) alongside the existing `datasource=github-releases`
- **PR #2895** – the two datasources updated independently, leaving the cluster half-upgraded

## Fix

Revert both plan files to the pre-#2819 single-version-marker pattern (matching the shape at commit `1ef66ef46`, the v1.35.3 update):

1. Replace `image: rancher/k3s-upgrade:<tag>@sha256:<digest>` with bare `image: rancher/k3s-upgrade` in both files (both `spec.prepare.image` and `spec.upgrade.image` in agent-plan)
2. Remove the `# renovate: datasource=docker depName=rancher/k3s-upgrade` comments — only one Renovate marker needed
3. Bump `spec.version` from `v1.35.4+k3s1` to `v1.36.0+k3s1`
4. Retain the `# renovate: datasource=github-releases depName=k3s-io/k3s` comment above `spec.version` — this is the single source of truth going forward

## Validation

```
kubectl kustomize kubernetes/cluster0/apps/system-upgrade/system-upgrade-controller/plans
```

Shows `image: rancher/k3s-upgrade` (no tag/digest) and `version: v1.36.0+k3s1` in both plans.