### PR TITLE
feat(traefik): bump chart to v40.0.0 and migrate service block

### DIFF
--- a/kubernetes/cluster0/apps/networking/traefik/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/networking/traefik/app/helm-release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: traefik
-      version: 39.0.9
+      version: 40.0.0
       sourceRef:
         kind: HelmRepository
         name: traefik-charts
@@ -27,9 +27,10 @@ spec:
       replicas: 3
     service:
       enabled: true
-      type: LoadBalancer
       annotations:
         io.cilium/lb-ipam-ips: ${TRAEFIK_IP}
+      spec:
+        type: LoadBalancer
     tlsStore:
       default:
         defaultCertificate:


### PR DESCRIPTION
## Summary

Bumps the Traefik Helm chart from v39.0.8 to v40.0.0 and applies the required breaking-change config migration.

## Changes

### 1. Chart version bump
`spec.chart.spec.version`: `39.0.8` → `40.0.0`

### 2. `service:` block migration

In v40, the following fields moved from the top level of `service:` into a new `service.spec:` sub-block: `type`, `externalTrafficPolicy`, `ipFamilyPolicy`, `loadBalancerSourceRanges`, and related fields. Fields `enabled`, `annotations`, `annotationsTCP`, `annotationsUDP`, `labels`, and `single` stay at the top level.

**Before:**
```yaml
service:
  enabled: true
  type: LoadBalancer
  annotations:
    io.cilium/lb-ipam-ips: ${TRAEFIK_IP}
```

**After:**
```yaml
service:
  enabled: true
  annotations:
    io.cilium/lb-ipam-ips: ${TRAEFIK_IP}
  spec:
    type: LoadBalancer
```

All other value blocks (`deployment`, `tlsStore`, `tlsOptions`, `rbac`, `ingressClass`, `ingressRoute`, `providers`, `gateway`, `ports`, `additionalArguments`, `logs`) are unchanged.

## Validation

- `kustomize build kubernetes/cluster0/apps/networking/traefik/app` — renders cleanly, version shows as `40.0.0`
- `helm template traefik traefik-charts/traefik --version 40.0.0 -f values.yaml` — renders without errors; Service object has correct `spec.type: LoadBalancer` and annotation `io.cilium/lb-ipam-ips` preserved

## Notes

- Supersedes #2892 (Renovate PR) — that PR only bumped the chart version without the required `service:` schema migration.
- Other v40 breaking changes (`kubernetesIngressNginx` rename, drop of K8s <1.25 / proxy <3.6 support) do not affect this deployment.