### PR TITLE
fix(traefik): remove legacy entrypoint TLS config that breaks websecure under v40

### DIFF
--- a/kubernetes/cluster0/apps/networking/traefik/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/networking/traefik/app/helm-release.yaml
@@ -98,10 +98,6 @@ spec:
       websecure:
         port: 443
         exposedPort: 443
-        http:
-          tls:
-            enabled: true
-            options: "default"
     logs:
       general:
         level: "INFO"


### PR DESCRIPTION
## Problem

Since the Traefik chart bump from **39.0.9 → 40.0.0** (PR #2899, merged ~30 min ago), all public services behind Traefik are returning **Cloudflare 525 (SSL handshake failed)** — Home Assistant, Authelia, Longhorn, Jellyfin, etc. Cluster-internal HTTP is healthy (apps and Gateway API routes are fine); the break is at TLS termination on the `websecure` entrypoint.

## Root cause

`helm-release.yaml` carried a legacy IngressRoute-style TLS block under `ports.websecure`:

```yaml
ports:
  websecure:
    port: 443
    exposedPort: 443
    http:
      tls:
        enabled: true
        options: "default"
```

This caused Traefik to launch with:
```
--entryPoints.websecure.http.tls=true
--entryPoints.websecure.http.tls.options=default
```

In chart v40 the way these flags layer onto the entrypoint changed. Combined with `sniStrict: true` in `tlsOptions.default`, this causes Traefik to reject TLS handshakes on the `websecure` entrypoint.

All **26 routes** attached to `websecure` are **Gateway API HTTPRoutes** — not IngressRoute CRDs. The legacy IngressRoute-style TLS chart values have never been needed and are now harmful. The Gateway API listener already carries the correct `certificateRefs` pointing at the wildcard Let's Encrypt secret, and that is the sole TLS authority required.

## Change

Deleted the four-line `http.tls` sub-block from `ports.websecure`. No other changes.

`ports.websecure` now reads:
```yaml
      websecure:
        port: 443
        exposedPort: 443
```

## Verification

After Flux reconciles:

```bash
# Force reconcile
flux reconcile source git home-ops-cluster0
flux reconcile helmrelease traefik -n networking

# Wait for rollout
kubectl -n networking rollout status deploy/traefik

# Confirm offending args are gone
kubectl -n networking get pod -l app.kubernetes.io/name=traefik   -o jsonpath='{.items[0].spec.containers[0].args}'

# TLS handshake checks
curl -sS -o /dev/null -w "%{http_code}\n" https://home-assistant.tinfoilforest.nz/
curl -sS -o /dev/null -w "%{http_code}\n" https://auth.tinfoilforest.nz/

# Certificate issuer check
echo | openssl s_client -connect <traefik-lb-ip>:443   -servername home-assistant.tinfoilforest.nz 2>&1 | grep -E 'subject=|issuer='
```

*Verification outputs will be added once Flux reconciles the change in-cluster.*

## Follow-up (out of scope for this PR)

`tlsStore.default` and `tlsOptions.default` remain in the values. They are only consumed by the IngressRoute path (which is unused), so they are low-risk. A follow-up PR may clean them up once this fix-forward is confirmed stable.

Closes #2899