### PR TITLE
revert(traefik): roll back chart v40 bump and fix-forward — restore v39.0.9

### DIFF
--- a/kubernetes/cluster0/apps/networking/traefik/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/networking/traefik/app/helm-release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: traefik
-      version: 40.0.0
+      version: 39.0.9
       sourceRef:
         kind: HelmRepository
         name: traefik-charts
@@ -27,10 +27,9 @@ spec:
       replicas: 3
     service:
       enabled: true
+      type: LoadBalancer
       annotations:
         io.cilium/lb-ipam-ips: ${TRAEFIK_IP}
-      spec:
-        type: LoadBalancer
     tlsStore:
       default:
         defaultCertificate:
@@ -98,6 +97,10 @@ spec:
       websecure:
         port: 443
         exposedPort: 443
+        http:
+          tls:
+            enabled: true
+            options: "default"
     logs:
       general:
         level: "INFO"


### PR DESCRIPTION
## Live Outage

All public services behind Traefik are currently returning **Cloudflare 525 (SSL handshake failed)** — Home Assistant, Authelia, Longhorn, Jellyfin, and others. This is a fleet-wide outage affecting every HTTPS endpoint.

## PRs Being Reverted

- **#2899** `feat(traefik): bump chart to v40.0.0 and migrate service block` — bumped chart `39.0.9` → `40.0.0` and migrated `service.type` into a `service.spec.type` sub-block.
- **#2900** `fix(traefik): remove legacy entrypoint TLS config that breaks websecure under v40` — removed the `ports.websecure.http.tls` sub-block in an attempt to fix-forward; made things worse: TLS handshakes fail with `tlsv1 unrecognized name` because the Gateway API listener's `certificateRefs` are not being installed onto the entrypoint.

## Why Revert vs Continue Iterating

Chart v40 changed how the Gateway API listener's `certificateRefs` are wired to Traefik entrypoints. Under v39, the `ports.websecure.http.tls` block (`enabled: true`, `options: default`) caused the TLS certificate to be installed directly on the entrypoint. Under v40 this mechanism changed, and two fix-forward attempts have failed to restore TLS handshake. With every public service returning 525, the right call is to restore the known-good v39.0.9 state and investigate v40's cert-wiring in a non-production-breaking context.

## Changes

Restores `kubernetes/cluster0/apps/networking/traefik/app/helm-release.yaml` to its state at commit `f86f49bb8` (the merge commit of v39.0.9). Net diff:

- `chart.spec.version`: `40.0.0` → `39.0.9`
- `service.spec.type: LoadBalancer` → `service.type: LoadBalancer` (flat, back to v39 format)
- `ports.websecure.http.tls.{enabled,options}` block re-added

No other files are modified.

## Verification

_To be filled in after Flux reconciles:_

```bash
flux reconcile source git home-ops-cluster0
flux reconcile helmrelease traefik -n networking
kubectl -n networking rollout status deploy/traefik --timeout=180s
```

```
# curl checks (expected: non-525)
curl -sS -o /dev/null -w "%{http_code}\n" https://home-assistant.tinfoilforest.nz/
curl -sS -o /dev/null -w "%{http_code}\n" https://auth.tinfoilforest.nz/

# TLS cert check (expected: Let's Encrypt issuer, not self-signed)
echo | openssl s_client -connect 10.87.42.10:443 -servername home-assistant.tinfoilforest.nz 2>&1 | grep -E 'subject=|issuer='
```

## Future Work

A future PR will re-attempt the v40 bump with proper investigation of how `certificateRefs` should be configured under the new chart architecture. Renovate will eventually re-propose the v40 bump; that is the appropriate time to investigate. No Renovate config has been modified here.

Closes #2899
Closes #2900