### PR TITLE
security: fix PUID/PGID=0 on arr services (Sonarr, Radarr, Lidarr, Prowlarr)

### DIFF
--- a/kubernetes/cluster0/apps/media/lidarr/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/lidarr/app/helm-release.yaml
@@ -33,8 +33,8 @@ spec:
               tag: 2.12.4.4658-ls49@sha256:286af1e270d2829efd0b6a33d26dbadc614d61d8e9bb1a07b8396ad6231921a2
             env:
               TZ: "${TIMEZONE}"
-              PUID: 0
-              PGID: 0
+              PUID: 1000
+              PGID: 1000
             # to avoid permissions issues on volume
             securityContext:
               runAsUser: 0

--- a/kubernetes/cluster0/apps/media/prowlarr/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/prowlarr/app/helm-release.yaml
@@ -33,8 +33,8 @@ spec:
               tag: "2.0.5.5160-ls125@sha256:4f2a6d597845b2f3e19284b1d982b3e0b4bd7c22472c2979c956aa198b83f472"
             env:
               TZ: "${TIMEZONE}"
-              PUID: 0
-              PGID: 0
+              PUID: 1000
+              PGID: 1000
             # to avoid permissions issues on volume
             securityContext:
               runAsUser: 0

--- a/kubernetes/cluster0/apps/media/radarr/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/radarr/app/helm-release.yaml
@@ -33,8 +33,8 @@ spec:
               tag: "6.1.1@sha256:15417a594ebda4c660a9fa9748e7199d33e2d17b31bbc5ad7ba2e86f0b414763"
             env:
               TZ: "${TIMEZONE}"
-              PUID: 0
-              PGID: 0
+              PUID: 1000
+              PGID: 1000
             # to avoid permissions issues on volume
             securityContext:
               runAsUser: 0

--- a/kubernetes/cluster0/apps/media/sonarr/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/sonarr/app/helm-release.yaml
@@ -33,8 +33,8 @@ spec:
               tag: "4.0.17@sha256:60f3b6b5c7647ba2bafd81163acfe34b11117b9b834ebd7fbcc3e5f1b309c7ef"
             env:
               TZ: "${TIMEZONE}"
-              PUID: 0
-              PGID: 0
+              PUID: 1000
+              PGID: 1000
             # to avoid permissions issues on volume
             securityContext:
               runAsUser: 0


### PR DESCRIPTION
## Summary

Fixes the security issue where four LinuxServer arr services had `PUID: 0` / `PGID: 0` set, which told s6-overlay to run the application process as root and never drop privileges — defeating LinuxServer's own privilege-dropping mechanism entirely.

### How LinuxServer.io images work

LinuxServer images use s6-overlay which **requires** the container to start as root (`runAsUser: 0` in securityContext — preserved unchanged here). After init, s6-overlay drops the app process to the uid/gid specified by `PUID`/`PGID`. With both set to `0`, no privilege drop occurred.

### Changes

Changed `PUID: 0` → `PUID: 1000` and `PGID: 0` → `PGID: 1000` in the env section of:

- `kubernetes/cluster0/apps/media/sonarr/app/helm-release.yaml`
- `kubernetes/cluster0/apps/media/radarr/app/helm-release.yaml`
- `kubernetes/cluster0/apps/media/lidarr/app/helm-release.yaml`
- `kubernetes/cluster0/apps/media/prowlarr/app/helm-release.yaml`

The `runAsUser: 0` securityContext block is **not changed** on any of the four — this is required by s6-overlay and correct.

No other fields were modified.

## ⚠️ PVC Permission Risk (post-merge action required)

Data on the persistent volumes (config PVCs and NFS mounts) was previously written as uid 0 (root). After this change, the app processes will run as uid/gid 1000 and may encounter **permission-denied errors** reading or writing their config directories.

**After Flux reconciles, check logs for all four services:**
```bash
kubectl logs -n media -l app.kubernetes.io/name=sonarr --tail=50
kubectl logs -n media -l app.kubernetes.io/name=radarr --tail=50
kubectl logs -n media -l app.kubernetes.io/name=lidarr --tail=50
kubectl logs -n media -l app.kubernetes.io/name=prowlarr --tail=50
```

If permission-denied errors appear, the config PVC data will need to be `chown`-ed to uid/gid 1000. The NFS mounts (TV, Movies, Music, Downloads) may also need remediation depending on the NAS export permissions.

Closes #2815