### PR TITLE
fix: point CNPG clusters at plain-HTTP SeaweedFS endpoint to restore WAL archiving

### DIFF
--- a/kubernetes/cluster0/apps/auth/authelia/db/cluster-v17.yaml
+++ b/kubernetes/cluster0/apps/auth/authelia/db/cluster-v17.yaml
@@ -9,13 +9,6 @@ spec:
   env:
     - name: TZ
       value: Pacific/Auckland
-    # Workaround for CloudNativePG endpointCA SSL validation issue
-    # The endpointCA feature mounts the CA cert but doesn't set SSL env vars
-    # See: https://github.com/cloudnative-pg/cloudnative-pg/issues/7946
-    - name: CURL_CA_BUNDLE
-      value: /run/certificates/backup-barman-ca.crt
-    - name: REQUESTS_CA_BUNDLE
-      value: /run/certificates/backup-barman-ca.crt
   imageName: ghcr.io/cloudnative-pg/postgresql:17.5-21
   primaryUpdateStrategy: unsupervised
   storage:
@@ -50,10 +43,7 @@ spec:
         compression: bzip2
         maxParallel: 4
       destinationPath: s3://postgresql/
-      endpointURL: https://seaweedfs-s3.seaweedfs.svc:8443
-      endpointCA:
-        name: internal-ca-bundle
-        key: ca.crt
+      endpointURL: http://seaweedfs-s3.seaweedfs.svc:8333
       serverName: authelia-postgres-v17
       s3Credentials:
         accessKeyId:

--- a/kubernetes/cluster0/apps/home/home-assistant/db/cluster-v18.yaml
+++ b/kubernetes/cluster0/apps/home/home-assistant/db/cluster-v18.yaml
@@ -9,13 +9,6 @@ spec:
   env:
     - name: TZ
       value: Pacific/Auckland
-    # Workaround for CloudNativePG endpointCA SSL validation issue
-    # The endpointCA feature mounts the CA cert but doesn't set SSL env vars
-    # See: https://github.com/cloudnative-pg/cloudnative-pg/issues/7946
-    - name: CURL_CA_BUNDLE
-      value: /run/certificates/backup-barman-ca.crt
-    - name: REQUESTS_CA_BUNDLE
-      value: /run/certificates/backup-barman-ca.crt
   imageName: ghcr.io/cloudnative-pg/postgresql:18.0
   primaryUpdateStrategy: unsupervised
   storage:
@@ -50,10 +43,7 @@ spec:
         compression: bzip2
         maxParallel: 4
       destinationPath: s3://postgresql/
-      endpointURL: https://seaweedfs-s3.seaweedfs.svc:8443
-      endpointCA:
-        name: internal-ca-bundle
-        key: ca.crt
+      endpointURL: http://seaweedfs-s3.seaweedfs.svc:8333
       serverName: home-assistant-postgres-v18
       s3Credentials:
         accessKeyId:

--- a/kubernetes/cluster0/apps/media/miniflux/db/cluster-v17.yaml
+++ b/kubernetes/cluster0/apps/media/miniflux/db/cluster-v17.yaml
@@ -9,13 +9,6 @@ spec:
   env:
     - name: TZ
       value: Pacific/Auckland
-    # Workaround for CloudNativePG endpointCA SSL validation issue
-    # The endpointCA feature mounts the CA cert but doesn't set SSL env vars
-    # See: https://github.com/cloudnative-pg/cloudnative-pg/issues/7946
-    - name: CURL_CA_BUNDLE
-      value: /run/certificates/backup-barman-ca.crt
-    - name: REQUESTS_CA_BUNDLE
-      value: /run/certificates/backup-barman-ca.crt
   imageName: ghcr.io/cloudnative-pg/postgresql:17.5-21
   primaryUpdateStrategy: unsupervised
   storage:
@@ -50,10 +43,7 @@ spec:
         compression: bzip2
         maxParallel: 4
       destinationPath: s3://postgresql/
-      endpointURL: https://seaweedfs-s3.seaweedfs.svc:8443
-      endpointCA:
-        name: internal-ca-bundle
-        key: ca.crt
+      endpointURL: http://seaweedfs-s3.seaweedfs.svc:8333
       serverName: miniflux-postgres-v17
       s3Credentials:
         accessKeyId:

--- a/kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/helm-release.yaml
@@ -72,8 +72,6 @@ spec:
 
     s3:
       enabled: true
-      httpsPort: 8443
-      tlsSecret: seaweedfs-s3-tls
       enableAuth: true
       replicas: 1
       logs:


### PR DESCRIPTION
Closes #2924

## Summary

All three CNPG clusters (`authelia-postgres-v17`, `miniflux-postgres-v17`, `home-assistant-postgres-v18`) are failing continuous archiving because they reference `https://seaweedfs-s3.seaweedfs.svc:8443` — a port that has never had a listener. SeaweedFS has `global.seaweedfs.enableSecurity: false` (set in #2859), which disables the HTTPS S3 listener. Only port 8333 (plain HTTP) is bound.

This PR points all three clusters at `http://seaweedfs-s3.seaweedfs.svc:8333` and removes the now-unnecessary TLS config.

## Changes

| File | Change |
|---|---|
| `auth/authelia/db/cluster-v17.yaml` | `endpointURL` → `http://seaweedfs-s3.seaweedfs.svc:8333`; remove `endpointCA`; remove `CURL_CA_BUNDLE`/`REQUESTS_CA_BUNDLE` env vars |
| `media/miniflux/db/cluster-v17.yaml` | `endpointURL` → `http://seaweedfs-s3.seaweedfs.svc:8333`; remove `endpointCA`; remove `CURL_CA_BUNDLE`/`REQUESTS_CA_BUNDLE` env vars |
| `home/home-assistant/db/cluster-v18.yaml` | `endpointURL` → `http://seaweedfs-s3.seaweedfs.svc:8333`; remove `endpointCA`; remove `CURL_CA_BUNDLE`/`REQUESTS_CA_BUNDLE` env vars |
| `seaweedfs/seaweedfs/app/helm-release.yaml` | Remove `s3.httpsPort: 8443` and `s3.tlsSecret` (no-ops with `enableSecurity: false`, but they encoded a false claim) |

`serverName` and `s3Credentials` are **unchanged** on all three clusters — WAL continuity and auth are preserved.

## Design note: plain HTTP is the right end state

Backup traffic from CNPG pods to SeaweedFS is plaintext HTTP within the cluster. This is not a tactical retreat pending a future HTTPS restoration — it is the considered correct configuration for this setup. Reasoning:

- The previous MinIO setup used HTTPS by choice, not requirement (`requestAutoCert: false` with an externally-provided cert — a self-imposed complexity).
- CNPG / barman-cloud has no TLS requirement; `--endpoint-url` accepts `http://` or `https://` equally.
- The barman/CNPG SSL bug ([cloudnative-pg#7946](https://github.com/cloudnative-pg/cloudnative-pg/issues/7946)) and the `CURL_CA_BUNDLE` workaround only exist when TLS is in use. Plain HTTP removes that entire class of failure permanently — today's debugging session was rooted in TLS-shaped failures that masked the actual root cause.
- The cert-manager + trust-manager + `endpointCA` + barman env-var workaround chain is real ongoing maintenance burden. Removing it is a net improvement.
- The threat model (an attacker already running a pod inside the cluster, sniffing the SeaweedFS service) is not meaningful for this homelab. Cilium does not have WireGuard or IPsec enabled, so HTTPS at the application layer would be the only protection for the pod-to-pod hop — and that risk does not justify the complexity.

There is no follow-up issue to restore HTTPS. Plain HTTP for intra-cluster backup traffic is the intended end state.

## Post-merge verification

```bash
# 1. Force Flux to reconcile immediately
flux reconcile source git home-ops-cluster0

# 2. Wait ~60s, then check HelmRelease and CNPG clusters
kubectl get helmrelease seaweedfs -n seaweedfs
kubectl get cluster -A

# 3. Confirm ContinuousArchiving=True on all three clusters
kubectl get cluster -A -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.conditions[?(@.type=="ContinuousArchiving")].status}{"\n"}{end}'

# 4. Check WAL archive logs on each primary pod (replace pod names with actual)
kubectl -n databases logs authelia-postgres-v17-1 -c postgres | grep -i "wal\|archiv" | tail -20
kubectl -n databases logs miniflux-postgres-v17-1 -c postgres | grep -i "wal\|archiv" | tail -20
kubectl -n databases logs home-assistant-postgres-v18-1 -c postgres | grep -i "wal\|archiv" | tail -20
# Expected: "Archived WAL file" lines referencing http://seaweedfs-s3.seaweedfs.svc:8333

# 5. Find actual primary pod names if needed
kubectl -n databases get pods -l cnpg.io/cluster=authelia-postgres-v17,role=primary
kubectl -n databases get pods -l cnpg.io/cluster=miniflux-postgres-v17,role=primary
kubectl -n databases get pods -l cnpg.io/cluster=home-assistant-postgres-v18,role=primary
```
