### PR TITLE
fix(seaweedfs): add spec.upgrade.timeout: 15m to HelmRelease

### DIFF
--- a/kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/helm-release.yaml
@@ -21,6 +21,7 @@ spec:
     remediation:
       retries: 3
   upgrade:
+    timeout: 15m
     cleanupOnFail: true
     remediation:
       retries: 3


### PR DESCRIPTION
## Summary

Adds `spec.upgrade.timeout: 15m` to the SeaweedFS HelmRelease, matching `spec.install.timeout`.

**Root cause:** The upgrade timeout was not set, so it fell back to the Flux default of 5 minutes. Going 4.24→4.25 (and any similar minor bump) triggers a rolling restart of all four components — `seaweedfs-master` (StatefulSet), `seaweedfs-volume` (StatefulSet, 2 replicas), `seaweedfs-filer` (StatefulSet), and `seaweedfs-s3` (Deployment). With Longhorn PVC startup time included, the aggregate restart reliably exceeds 5 minutes, causing `RetriesExceeded` after four failed upgrade attempts.

**Change:** One line added inside the existing `spec.upgrade:` block alongside `cleanupOnFail: true` and `remediation.retries: 3`. No other fields touched — `chart.spec.version` stays at `4.25.0`, `values` unchanged.

## Post-merge verification

No operator restart, suspend, or manual reconcile is required. Flux will pick up the new spec on its normal reconcile cycle. The longer timeout takes effect the next time an upgrade is attempted (e.g. next Renovate bump).

To confirm the spec landed cleanly after merge:

**(a)** HelmRelease is healthy:
```bash
kubectl get helmrelease seaweedfs -n seaweedfs
# Expect: READY=True, STATUS=helm install succeeded / helm upgrade succeeded
```

**(b)** Flux re-applied the spec (generation advanced):
```bash
kubectl describe helmrelease seaweedfs -n seaweedfs | grep 'Last Attempted Generation'
# Expect: number incremented from its pre-merge value
```

**(c)** Running chart version is unchanged:
```bash
kubectl get helmrelease seaweedfs -n seaweedfs -o jsonpath='{.status.history[0].chartVersion}'
# Expect: 4.25.0 (no chart upgrade was triggered by this config-only change)
```

Closes #2928