### PR TITLE
security: netpol phase 2a — home namespace policies

### DIFF
--- a/kubernetes/cluster0/apps/home/home-assistant/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/home/home-assistant/app/helm-release.yaml
@@ -74,6 +74,91 @@ spec:
           - backendRefs:
               - identifier: app
                 port: *port
+    networkpolicies:
+      default-deny:
+        controller: main
+        policyTypes: [Ingress, Egress]
+        rules: {}
+      allow-dns:
+        controller: main
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 53
+                  protocol: UDP
+                - port: 53
+                  protocol: TCP
+              to:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: kube-system
+      allow-traefik-ingress:
+        controller: main
+        policyTypes: [Ingress]
+        rules:
+          ingress:
+            - from:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: networking
+      allow-postgres-egress:
+        controller: main
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 5432
+                  protocol: TCP
+              to:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: databases
+                  podSelector:
+                    matchLabels:
+                      cnpg.io/cluster: home-assistant-postgres-v18
+      allow-mosquitto-egress:
+        controller: main
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 1883
+                  protocol: TCP
+              to:
+                - podSelector:
+                    matchLabels:
+                      app.kubernetes.io/instance: mosquitto
+      allow-zigbee2mqtt-egress:
+        controller: main
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 8080
+                  protocol: TCP
+              to:
+                - podSelector:
+                    matchLabels:
+                      app.kubernetes.io/instance: zigbee2mqtt
+      allow-external-egress:
+        controller: main
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 443
+                  protocol: TCP
+                - port: 22
+                  protocol: TCP
+              to:
+                - ipBlock:
+                    cidr: 0.0.0.0/0
+                    except:
+                      - 10.0.0.0/8
+                      - 172.16.0.0/12
+                      - 192.168.0.0/16
+
     persistence:
       config:
         existingClaim: pvc-home-assistant

--- a/kubernetes/cluster0/apps/home/home-assistant/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/home/home-assistant/app/helm-release.yaml
@@ -102,6 +102,18 @@ spec:
                 - namespaceSelector:
                     matchLabels:
                       kubernetes.io/metadata.name: networking
+      allow-monitoring-ingress:
+        controller: main
+        policyTypes: [Ingress]
+        rules:
+          ingress:
+            - from:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: monitoring
+              ports:
+                - port: 8123
+                  protocol: TCP
       allow-postgres-egress:
         controller: main
         policyTypes: [Egress]

--- a/kubernetes/cluster0/apps/home/home-assistant/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/home/home-assistant/app/helm-release.yaml
@@ -111,6 +111,9 @@ spec:
                 - namespaceSelector:
                     matchLabels:
                       kubernetes.io/metadata.name: monitoring
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/name: prometheus-blackbox-exporter
               ports:
                 - port: 8123
                   protocol: TCP

--- a/kubernetes/cluster0/apps/home/mosquitto/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/home/mosquitto/app/helm-release.yaml
@@ -58,6 +58,18 @@ spec:
                 - namespaceSelector:
                     matchLabels:
                       kubernetes.io/metadata.name: kube-system
+      allow-monitoring-ingress:
+        controller: main
+        policyTypes: [Ingress]
+        rules:
+          ingress:
+            - from:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: monitoring
+              ports:
+                - port: 1883
+                  protocol: TCP
       allow-home-assistant-ingress:
         controller: main
         policyTypes: [Ingress]

--- a/kubernetes/cluster0/apps/home/mosquitto/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/home/mosquitto/app/helm-release.yaml
@@ -67,6 +67,9 @@ spec:
                 - namespaceSelector:
                     matchLabels:
                       kubernetes.io/metadata.name: monitoring
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/name: prometheus-blackbox-exporter
               ports:
                 - port: 1883
                   protocol: TCP

--- a/kubernetes/cluster0/apps/home/mosquitto/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/home/mosquitto/app/helm-release.yaml
@@ -39,6 +39,49 @@ spec:
         ports:
           http:
             port: 1883
+    networkpolicies:
+      default-deny:
+        controller: main
+        policyTypes: [Ingress, Egress]
+        rules: {}
+      allow-dns:
+        controller: main
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 53
+                  protocol: UDP
+                - port: 53
+                  protocol: TCP
+              to:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: kube-system
+      allow-home-assistant-ingress:
+        controller: main
+        policyTypes: [Ingress]
+        rules:
+          ingress:
+            - from:
+                - podSelector:
+                    matchLabels:
+                      app.kubernetes.io/instance: home-assistant
+              ports:
+                - port: 1883
+                  protocol: TCP
+      allow-zigbee2mqtt-ingress:
+        controller: main
+        policyTypes: [Ingress]
+        rules:
+          ingress:
+            - from:
+                - podSelector:
+                    matchLabels:
+                      app.kubernetes.io/instance: zigbee2mqtt
+              ports:
+                - port: 1883
+                  protocol: TCP
     resources:
       requests:
         cpu: 10m

--- a/kubernetes/cluster0/apps/home/searxng/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/home/searxng/app/helm-release.yaml
@@ -58,6 +58,62 @@ spec:
                   group: 'traefik.io'
                   kind: 'Middleware'
                   name: 'forwardauth-authelia'
+    networkpolicies:
+      default-deny:
+        controller: searxng
+        policyTypes: [Ingress, Egress]
+        rules: {}
+      allow-dns:
+        controller: searxng
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 53
+                  protocol: UDP
+                - port: 53
+                  protocol: TCP
+              to:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: kube-system
+      allow-traefik-ingress:
+        controller: searxng
+        policyTypes: [Ingress]
+        rules:
+          ingress:
+            - from:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: networking
+      allow-valkey-egress:
+        controller: searxng
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 6379
+                  protocol: TCP
+              to:
+                - podSelector:
+                    matchLabels:
+                      app.kubernetes.io/instance: searxng-valkey
+      allow-external-egress:
+        controller: searxng
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 443
+                  protocol: TCP
+              to:
+                - ipBlock:
+                    cidr: 0.0.0.0/0
+                    except:
+                      - 10.0.0.0/8
+                      - 172.16.0.0/12
+                      - 192.168.0.0/16
+
     persistence:
       config:
         type: configMap

--- a/kubernetes/cluster0/apps/home/searxng/valkey/helm-release.yaml
+++ b/kubernetes/cluster0/apps/home/searxng/valkey/helm-release.yaml
@@ -24,6 +24,37 @@ spec:
             image:
               repository: valkey/valkey
               tag: 9.0.4-alpine@sha256:d1cc70645bbcef743615463a2fa4616e841407545e18f560aed0c49671a90147
+    networkpolicies:
+      default-deny:
+        controller: valkey
+        policyTypes: [Ingress, Egress]
+        rules: {}
+      allow-dns:
+        controller: valkey
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 53
+                  protocol: UDP
+                - port: 53
+                  protocol: TCP
+              to:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: kube-system
+      allow-searxng-ingress:
+        controller: valkey
+        policyTypes: [Ingress]
+        rules:
+          ingress:
+            - from:
+                - podSelector:
+                    matchLabels:
+                      app.kubernetes.io/instance: searxng
+              ports:
+                - port: 6379
+                  protocol: TCP
     persistence:
       data:
         type: emptyDir

--- a/kubernetes/cluster0/apps/home/zigbee2mqtt/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/home/zigbee2mqtt/app/helm-release.yaml
@@ -89,6 +89,18 @@ spec:
                 - namespaceSelector:
                     matchLabels:
                       kubernetes.io/metadata.name: networking
+      allow-monitoring-ingress:
+        controller: main
+        policyTypes: [Ingress]
+        rules:
+          ingress:
+            - from:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: monitoring
+              ports:
+                - port: 8080
+                  protocol: TCP
       allow-home-assistant-ingress:
         controller: main
         policyTypes: [Ingress]

--- a/kubernetes/cluster0/apps/home/zigbee2mqtt/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/home/zigbee2mqtt/app/helm-release.yaml
@@ -98,6 +98,9 @@ spec:
                 - namespaceSelector:
                     matchLabels:
                       kubernetes.io/metadata.name: monitoring
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/name: prometheus-blackbox-exporter
               ports:
                 - port: 8080
                   protocol: TCP

--- a/kubernetes/cluster0/apps/home/zigbee2mqtt/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/home/zigbee2mqtt/app/helm-release.yaml
@@ -61,6 +61,56 @@ spec:
                   group: 'traefik.io'
                   kind: 'Middleware'
                   name: 'forwardauth-authelia'
+    networkpolicies:
+      default-deny:
+        controller: main
+        policyTypes: [Ingress, Egress]
+        rules: {}
+      allow-dns:
+        controller: main
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 53
+                  protocol: UDP
+                - port: 53
+                  protocol: TCP
+              to:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: kube-system
+      allow-traefik-ingress:
+        controller: main
+        policyTypes: [Ingress]
+        rules:
+          ingress:
+            - from:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: networking
+      allow-home-assistant-ingress:
+        controller: main
+        policyTypes: [Ingress]
+        rules:
+          ingress:
+            - from:
+                - podSelector:
+                    matchLabels:
+                      app.kubernetes.io/instance: home-assistant
+      allow-mosquitto-egress:
+        controller: main
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 1883
+                  protocol: TCP
+              to:
+                - podSelector:
+                    matchLabels:
+                      app.kubernetes.io/instance: mosquitto
+
     persistence:
       # config:
       #   enabled: true


### PR DESCRIPTION
## Summary

Implements default-deny + targeted allow NetworkPolicies for all five workloads in the `home` namespace. This is Phase 2a of the cluster-wide NetworkPolicy rollout (child #1 of 3 under design doc #2810).

All policies are implemented via the `networkpolicies` chart values key in the bjw-s `app-template` chart — consistent with the Phase 1 pattern established in #2821.

## Policies added

| Workload | Default-deny | DNS egress | Ingress allowed from | Egress allowed to |
|---|---|---|---|---|
| `home-assistant` | ✅ | ✅ | `networking` ns (Traefik), `monitoring` ns blackbox-exporter :8123 | `mosquitto` :1883 (intra-ns), `zigbee2mqtt` :8080 (intra-ns), `databases/home-assistant-postgres-v18` :5432 (cross-ns), external :443/:22 (integrations + git-sync init) |
| `mosquitto` | ✅ | ✅ | `monitoring` ns blackbox-exporter :1883, `home-assistant` (intra-ns) :1883, `zigbee2mqtt` (intra-ns) :1883 | DNS only |
| `zigbee2mqtt` | ✅ | ✅ | `networking` ns (Traefik), `monitoring` ns blackbox-exporter :8080, `home-assistant` (intra-ns) | `mosquitto` :1883 (intra-ns) |
| `searxng` | ✅ | ✅ | `networking` ns (Traefik) | `searxng-valkey` :6379 (intra-ns), external :443 |
| `searxng-valkey` | ✅ | ✅ | `searxng` (intra-ns) :6379 | DNS only |

## Blackbox-exporter Probe resources

Three of the five home-ns pods have active `Probe` resources (monitoring.coreos.com/v1) that cause `blackbox-exporter` in the `monitoring` namespace to probe them:

- `probe/home-assistant`: HTTP probe of `:8123` via `http_2xx` module
- `probe/mosquitto`: TCP probe of `:1883` via `tcp_connect` module
- `probe/zigbee2mqtt`: HTTP probe of `:8080` via `http_2xx` module

All three policies include a tightened `allow-monitoring-ingress` rule scoped specifically to `app.kubernetes.io/name: prometheus-blackbox-exporter` (not the whole `monitoring` namespace), with a port-scoped allow matching the probe target. `searxng` and `searxng-valkey` have no Probe resources and receive no monitoring ingress rule.

## AC verification

- [x] All five pods have NetworkPolicy targeting them via pod selector ✅
- [x] All policies have `policyTypes: [Ingress, Egress]` and default-deny shape ✅
- [x] All policies include DNS egress block (53 UDP+TCP → kube-system) ✅
- [x] `home-assistant` egress to `databases` ns, pod selector `cnpg.io/cluster: home-assistant-postgres-v18`, port 5432 ✅
- [x] `home-assistant` egress to intra-ns `mosquitto` :1883 and intra-ns `zigbee2mqtt` :8080 ✅
- [x] `mosquitto` ingress only from intra-ns `home-assistant`, `zigbee2mqtt`, and blackbox-exporter (no Traefik) ✅
- [x] `zigbee2mqtt` ingress from `networking` ns (Traefik), intra-ns `home-assistant`, and blackbox-exporter ✅
- [x] `searxng` egress to intra-ns `searxng-valkey` :6379 and external :443; ingress from `networking` only ✅
- [x] `searxng-valkey` ingress only from intra-ns `searxng` ✅
- [x] All policies via `app-template` `networkpolicies` chart values (all five workloads use app-template v5.0.1) — no mixing ✅
- [x] Every cross-namespace rule has explicit `namespaceSelector` with `kubernetes.io/metadata.name` ✅
- [x] **Monitoring ingress**: `searxng` and `searxng-valkey` have no monitoring ingress rule (no Probe targeting them — confirmed via `kubectl get probe -A`). `home-assistant`, `mosquitto`, and `zigbee2mqtt` have a tightened `allow-monitoring-ingress` scoped to `prometheus-blackbox-exporter` pod + target port only. ✅
- [x] `kubectl kustomize kubernetes/cluster0/apps/home` builds cleanly ✅

## Phase 1 pattern notes

- DNS egress scoped to `kube-system` namespace with explicit `namespaceSelector` (the Phase 1 #2824 fix applied from the start)
- Intra-namespace rules use `podSelector` only (correct — same namespace)
- External egress uses `ipBlock: 0.0.0.0/0` with RFC1918 exceptions (same as Phase 1 style)
- CNPG egress uses the combined `namespaceSelector` + `podSelector` form from the issue body exactly
- Monitoring ingress uses combined `namespaceSelector` + `podSelector` (same Cilium identity-matching requirement as cross-ns egress)

## Post-merge verification (coordinator to run after merge)

```bash
# 1. Reconcile
flux reconcile kustomization cluster-apps-home-assistant
flux reconcile kustomization cluster-apps-mosquitto
flux reconcile kustomization cluster-apps-zigbee2mqtt
flux reconcile kustomization cluster-apps-searxng

# 2. Confirm policies created
kubectl -n home get networkpolicy

# 3. Watch for drops in home ns for a few minutes during normal traffic
hubble observe --namespace home --verdict DROPPED --since 5m

# 4. Functional smoke tests
#    - Home Assistant UI accessible
#    - Zigbee devices reporting state in HA
#    - HA → CNPG: check HA logs for DB connection errors
#    - SearXNG returns search results

# 5. Confirm Mosquitto is not reachable from outside home ns
kubectl -n media run mqtt-test --rm -it --restart=Never --image=alpine -- nc -zv -w 3 mosquitto.home.svc 1883
# Expected: connection refused or timeout, AND a DROPPED entry in `hubble observe --pod home/mosquitto-*`
```

Any DROPPED entries for legitimate flows become inputs to a follow-up fix PR (per the Phase 1 pattern).

Refs #2810
Closes #2932