### PR TITLE
fix(netpol): patch home-ns policy gaps from Phase 2a rollout (LAN egress, namespaceSelector, uptime-kuma)

### DIFF
--- a/kubernetes/cluster0/apps/home/home-assistant/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/home/home-assistant/app/helm-release.yaml
@@ -114,6 +114,12 @@ spec:
                   podSelector:
                     matchLabels:
                       app.kubernetes.io/name: prometheus-blackbox-exporter
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: monitoring
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/name: uptime-kuma
               ports:
                 - port: 8123
                   protocol: TCP
@@ -141,7 +147,10 @@ spec:
                 - port: 1883
                   protocol: TCP
               to:
-                - podSelector:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: home
+                  podSelector:
                     matchLabels:
                       app.kubernetes.io/instance: mosquitto
       allow-zigbee2mqtt-egress:
@@ -153,9 +162,24 @@ spec:
                 - port: 8080
                   protocol: TCP
               to:
-                - podSelector:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: home
+                  podSelector:
                     matchLabels:
                       app.kubernetes.io/instance: zigbee2mqtt
+      allow-lan-egress:
+        controller: main
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - to:
+                - ipBlock:
+                    cidr: 10.0.0.0/8
+                - ipBlock:
+                    cidr: 172.16.0.0/12
+                - ipBlock:
+                    cidr: 192.168.0.0/16
       allow-external-egress:
         controller: main
         policyTypes: [Egress]

--- a/kubernetes/cluster0/apps/home/mosquitto/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/home/mosquitto/app/helm-release.yaml
@@ -70,6 +70,12 @@ spec:
                   podSelector:
                     matchLabels:
                       app.kubernetes.io/name: prometheus-blackbox-exporter
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: monitoring
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/name: uptime-kuma
               ports:
                 - port: 1883
                   protocol: TCP
@@ -79,7 +85,10 @@ spec:
         rules:
           ingress:
             - from:
-                - podSelector:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: home
+                  podSelector:
                     matchLabels:
                       app.kubernetes.io/instance: home-assistant
               ports:
@@ -91,7 +100,10 @@ spec:
         rules:
           ingress:
             - from:
-                - podSelector:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: home
+                  podSelector:
                     matchLabels:
                       app.kubernetes.io/instance: zigbee2mqtt
               ports:

--- a/kubernetes/cluster0/apps/home/searxng/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/home/searxng/app/helm-release.yaml
@@ -95,7 +95,10 @@ spec:
                 - port: 6379
                   protocol: TCP
               to:
-                - podSelector:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: home
+                  podSelector:
                     matchLabels:
                       app.kubernetes.io/instance: searxng-valkey
       allow-external-egress:

--- a/kubernetes/cluster0/apps/home/searxng/valkey/helm-release.yaml
+++ b/kubernetes/cluster0/apps/home/searxng/valkey/helm-release.yaml
@@ -49,7 +49,10 @@ spec:
         rules:
           ingress:
             - from:
-                - podSelector:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: home
+                  podSelector:
                     matchLabels:
                       app.kubernetes.io/instance: searxng
               ports:

--- a/kubernetes/cluster0/apps/home/zigbee2mqtt/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/home/zigbee2mqtt/app/helm-release.yaml
@@ -101,6 +101,12 @@ spec:
                   podSelector:
                     matchLabels:
                       app.kubernetes.io/name: prometheus-blackbox-exporter
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: monitoring
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/name: uptime-kuma
               ports:
                 - port: 8080
                   protocol: TCP
@@ -110,7 +116,10 @@ spec:
         rules:
           ingress:
             - from:
-                - podSelector:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: home
+                  podSelector:
                     matchLabels:
                       app.kubernetes.io/instance: home-assistant
       allow-mosquitto-egress:
@@ -122,7 +131,10 @@ spec:
                 - port: 1883
                   protocol: TCP
               to:
-                - podSelector:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: home
+                  podSelector:
                     matchLabels:
                       app.kubernetes.io/instance: mosquitto
 


### PR DESCRIPTION
## Summary

Fix-forward patch on top of PR #2935 (Phase 2a netpol rollout), addressing three drop patterns Hubble surfaced post-merge.

Closes #2936

## Changes

### 1. New `allow-lan-egress` on home-assistant

HA legitimately needs to reach IoT devices on RFC1918 subnets (e.g. `10.87.30.37:8443` for the Zigbee-blind hub on the IoT VLAN). The existing `allow-external-egress` explicitly excludes RFC1918, so LAN traffic was being dropped. New policy allows TCP egress to all three RFC1918 ranges with no port restriction. This coexists cleanly with `allow-external-egress` — the external policy governs internet traffic, the new LAN policy governs RFC1918.

### 2. `namespaceSelector` AND-fix on all eight intra-namespace rules

Cilium's endpoint-identity matching requires `namespaceSelector` even for intra-namespace rules (same lesson as Phase 1 / #2824 applied to intra-ns). Every bare `podSelector`-only `to:`/`from:` entry in the home-ns policies now has a sibling `namespaceSelector: {matchLabels: {kubernetes.io/metadata.name: home}}`.

Both selectors are siblings under a single list entry (AND semantics — grants access only to matching pods in the home namespace), **not** two separate list entries (which would be OR — too permissive):

```yaml
to:
  - namespaceSelector:           # AND: must match BOTH
      matchLabels:
        kubernetes.io/metadata.name: home
    podSelector:
      matchLabels:
        app.kubernetes.io/instance: zigbee2mqtt
```

Affected policies:
| HelmRelease | Policy | Field |
|---|---|---|
| home-assistant | `allow-mosquitto-egress` | `egress.to` |
| home-assistant | `allow-zigbee2mqtt-egress` | `egress.to` |
| mosquitto | `allow-home-assistant-ingress` | `ingress.from` |
| mosquitto | `allow-zigbee2mqtt-ingress` | `ingress.from` |
| zigbee2mqtt | `allow-home-assistant-ingress` | `ingress.from` |
| zigbee2mqtt | `allow-mosquitto-egress` | `egress.to` |
| searxng | `allow-valkey-egress` | `egress.to` |
| searxng-valkey | `allow-searxng-ingress` | `ingress.from` |

### 3. uptime-kuma added to `allow-monitoring-ingress` on mosquitto, zigbee2mqtt, and home-assistant

uptime-kuma probes these services independently of blackbox-exporter (it has its own Phase 1 `uptime-kuma-allow-monitored-egress` policy that allows egress to the whole `home` namespace). The Phase 2a policies scoped `allow-monitoring-ingress` to `prometheus-blackbox-exporter` only, which correctly dropped uptime-kuma traffic.

Verified uptime-kuma label: `app.kubernetes.io/name: uptime-kuma` (confirmed via `kubectl -n monitoring get pods -l app.kubernetes.io/name=uptime-kuma --show-labels`).

**HA decision — uptime-kuma added on :8123:** The `uptime-kuma-allow-monitored-egress` policy already allows broad egress to the `home` namespace (namespace-level allow, no pod selector), confirming uptime-kuma is configured to probe HA. `hubble` CLI is not available in this environment (`hubble: command not found`; relay pod access restricted), so a live dropped-flow check could not be run. However the egress policy intent is clear, so HA gets the same two-`from` shape on :8123 as mosquitto and z2m.

Verification command for post-merge: `hubble observe --namespace home --verdict DROPPED --since 5m | grep uptime`

## Quality gate

`kubectl kustomize kubernetes/cluster0/apps/home` builds cleanly ✓

## Post-merge reconciliation

```bash
flux reconcile source git home-ops-cluster0
for ks in home-assistant mosquitto zigbee2mqtt searxng searxng-valkey; do
  flux reconcile kustomization cluster-apps-$ks
done
```
