### PR TITLE
feat(mosquitto): enable MQTT password authentication

### DIFF
--- a/kubernetes/cluster0/apps/home/mosquitto/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/home/mosquitto/app/helm-release.yaml
@@ -119,7 +119,8 @@ spec:
         data:
           mosquitto.conf: |
             listener 1883
-            allow_anonymous true
+            allow_anonymous false
+            password_file /mosquitto/secret/passwd
             persistence false
             connection_messages false
     persistence:
@@ -131,3 +132,12 @@ spec:
             app:
               - path: /mosquitto/config/mosquitto.conf
                 subPath: mosquitto.conf
+      passwd:
+        type: secret
+        name: mosquitto-passwd
+        advancedMounts:
+          main:
+            app:
+              - path: /mosquitto/secret/passwd
+                subPath: passwd
+                readOnly: true

--- a/kubernetes/cluster0/apps/home/mosquitto/app/kustomization.yaml
+++ b/kubernetes/cluster0/apps/home/mosquitto/app/kustomization.yaml
@@ -3,6 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helm-release.yaml
+  - ./passwd.sops.yaml
   - ./probe.yaml
 labels:
   - pairs:

--- a/kubernetes/cluster0/apps/home/mosquitto/app/passwd.sops.yaml
+++ b/kubernetes/cluster0/apps/home/mosquitto/app/passwd.sops.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: mosquitto-passwd
+    namespace: home
+stringData:
+    passwd: ENC[AES256_GCM,data:t8m+9LxwcY1r7zqS0GyqY1hKbBNvFWY6UA14XXgt4+nVz7OgNsMxykAnzyGXb0doIIklKEECDxMMLgcoXfhkAGGI4KftPoqqLrPGhP3OmJGv6v/Nxp5KQFdDE14oJZFE4rWPr8crFWR6esAylFo2lwbQW1gfjEb7dmrphLZ3dP6uVRqK8QQyarxNtZatdIFqva1WHMS4qOsQ6QrdwJsFWaWRXXmkCEGNenXfVwIix0JIMzrWwJxU8u65yPERqHfzV/QifpxG9Qbsi9FQAzz7KjeW5+/3Q4XxXUTIMQ8MxTAEAh9kSIHlC/uO2dvlu/r2SzPWXwpvKbzHocYr,iv:3RosywFt3fZJOiaT8brj/tliunZZaeFeFTZl063MRo0=,tag:TVFWW9R6LcVssUHslucd3g==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBUcFZyVjdUSjNqTGk3QnV0
+            akZucEJaMG94dXpxQWo2ZlhnWXRseXN5NG5BCk9YR2lDOXV3c0pIN0hqNVJLUzQ3
+            RksyM0ViZ053eFhrTTUyNFBXTUpjNHcKLS0tIDhGcXByZ2J5Z255bVJyQ3VBWFFZ
+            L2ZxRkt0ekRLbjQzbTVpQ1lWZllkcHcK/x5y9IaXNunhatFHopaCiPFVX/d5qBlV
+            IeGV6o4Aok1XHmTiuCqqx/IfXWzNAz2ldjzAr4WdWAQ/T6xGIJFmfQ==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1582vh25trj6w7klwt38d44n5nr8njr8rrxxx5kcfu3y2ezx9ss3s6j24ex
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBLUFFNenNPOWlwTTZGZGRw
+            K241OXJ6VnJrMVdDak5hQ0x6RFo2U2F4d2lJCmF6aDBVSU1GcTAxU0JsOUdGNDN1
+            NUpHYkU0dzd4V2JjUCtRTG5lclQ3VXcKLS0tIGdiRS9rOTlheGo0ZWhPQ1A1OUJQ
+            V1prWkJVVTdsL0NrMDg2aWd1b3lnRkEKcHDdj3i7KfqF8pa5zdQ8p2HimnD9np+Z
+            5r/6LDOPgB+PEDhOGN3LiBZn9aANzIJnszqPnjROBSdA0Nt7XABfaA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age185kanaq3uw2gjx5enu2v69nk9ner3lamdevrfgx3wqucsl9ewa2qlt2gf7
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-05-15T08:10:55Z"
+    mac: ENC[AES256_GCM,data:3XV857DGL5zwN2fVxu0OXo5um0TJrE+bJvoHyqPxV+2yLq8hcf4Y5IzX5O2gNxFeNd8ouN7f0Bm6JeysiBDlpXQpJJi7+l0gSH79eAEAYeyBMYJcMSrLPfyk1oCx0A5cyVTinTo9OAsol1uQXmVPZwACjcPnSawi0UorRz3ZFB8=,iv:VcLcyz03vaysxMZO++AUPC/VirXVVnEEOHgDziOJw90=,tag:oPAhxA/YNQo0+HMAwMtiFA==,type:str]
+    version: 3.13.0

--- a/kubernetes/cluster0/apps/home/mosquitto/app/passwd.sops.yaml
+++ b/kubernetes/cluster0/apps/home/mosquitto/app/passwd.sops.yaml
@@ -1,31 +1,31 @@
 apiVersion: v1
 kind: Secret
 metadata:
-    name: mosquitto-passwd
-    namespace: home
+  name: mosquitto-passwd
+  namespace: home
 stringData:
-    passwd: ENC[AES256_GCM,data:t8m+9LxwcY1r7zqS0GyqY1hKbBNvFWY6UA14XXgt4+nVz7OgNsMxykAnzyGXb0doIIklKEECDxMMLgcoXfhkAGGI4KftPoqqLrPGhP3OmJGv6v/Nxp5KQFdDE14oJZFE4rWPr8crFWR6esAylFo2lwbQW1gfjEb7dmrphLZ3dP6uVRqK8QQyarxNtZatdIFqva1WHMS4qOsQ6QrdwJsFWaWRXXmkCEGNenXfVwIix0JIMzrWwJxU8u65yPERqHfzV/QifpxG9Qbsi9FQAzz7KjeW5+/3Q4XxXUTIMQ8MxTAEAh9kSIHlC/uO2dvlu/r2SzPWXwpvKbzHocYr,iv:3RosywFt3fZJOiaT8brj/tliunZZaeFeFTZl063MRo0=,tag:TVFWW9R6LcVssUHslucd3g==,type:str]
+  passwd: ENC[AES256_GCM,data:THDgQ4T5p1ON4W5LjZcDWCh5/DiPEXJLBxJ4rLFurZxyVlLs7fGZxbc93vPJ6luuxBWUNjyeREIOoqF0n/kcsy/YQewyFvUobMqhRjCRKfqd46E1eY2Yx6pqk8p+OMmQgz+7IlreNevtaL5rep4j6awLI/H+Rj49lbZtKcsyx6rfotxWXJ0N2DlcuqrO5RPwytuxIa1h7RBwr37AENWUexADxGme3qyPrHn7KsZUxGU+8jKWlZf0l/D0HrXofQ8js2iamUx1I9fIHedgZaUAeQWHy/ovbVtC3DpY/UMYLra1AV8lua5EAxOv4xsI6XFvhQIcThdJ6vu92KQy,iv:RYRACKIurMw43wWQ9Sfk0b/dPNRilgFBYR4GW/NPLwM=,tag:M6A0Jetr84vr/3r5UCluaw==,type:str]
 sops:
-    age:
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBUcFZyVjdUSjNqTGk3QnV0
-            akZucEJaMG94dXpxQWo2ZlhnWXRseXN5NG5BCk9YR2lDOXV3c0pIN0hqNVJLUzQ3
-            RksyM0ViZ053eFhrTTUyNFBXTUpjNHcKLS0tIDhGcXByZ2J5Z255bVJyQ3VBWFFZ
-            L2ZxRkt0ekRLbjQzbTVpQ1lWZllkcHcK/x5y9IaXNunhatFHopaCiPFVX/d5qBlV
-            IeGV6o4Aok1XHmTiuCqqx/IfXWzNAz2ldjzAr4WdWAQ/T6xGIJFmfQ==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1582vh25trj6w7klwt38d44n5nr8njr8rrxxx5kcfu3y2ezx9ss3s6j24ex
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBLUFFNenNPOWlwTTZGZGRw
-            K241OXJ6VnJrMVdDak5hQ0x6RFo2U2F4d2lJCmF6aDBVSU1GcTAxU0JsOUdGNDN1
-            NUpHYkU0dzd4V2JjUCtRTG5lclQ3VXcKLS0tIGdiRS9rOTlheGo0ZWhPQ1A1OUJQ
-            V1prWkJVVTdsL0NrMDg2aWd1b3lnRkEKcHDdj3i7KfqF8pa5zdQ8p2HimnD9np+Z
-            5r/6LDOPgB+PEDhOGN3LiBZn9aANzIJnszqPnjROBSdA0Nt7XABfaA==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age185kanaq3uw2gjx5enu2v69nk9ner3lamdevrfgx3wqucsl9ewa2qlt2gf7
-    encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-05-15T08:10:55Z"
-    mac: ENC[AES256_GCM,data:3XV857DGL5zwN2fVxu0OXo5um0TJrE+bJvoHyqPxV+2yLq8hcf4Y5IzX5O2gNxFeNd8ouN7f0Bm6JeysiBDlpXQpJJi7+l0gSH79eAEAYeyBMYJcMSrLPfyk1oCx0A5cyVTinTo9OAsol1uQXmVPZwACjcPnSawi0UorRz3ZFB8=,iv:VcLcyz03vaysxMZO++AUPC/VirXVVnEEOHgDziOJw90=,tag:oPAhxA/YNQo0+HMAwMtiFA==,type:str]
-    version: 3.13.0
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwQS9uNGpVUW1YMk1HUUVQ
+        a283RUVMRE5NV01wRlpBcTkraWErK1pHTzFZCmdOVm9nM0NjOS9KNHlKb003bnRS
+        YlJVSmhJQXhNUXl1NUd0d3FwWmtTclkKLS0tIDhZRkk1SlYzLzh1WGt4V2JJWGtx
+        S3JBcWZKK3dHWUhLd3Z5Z1lnbkJCQVUKEXwPRg1dgVxX6QSazcds6yHeYWJmWngk
+        De2cc/3s1D+Bw4tUMtD4Nr7KCdqjVnm8Jirg0wUUlxewZamQq7jcRw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1582vh25trj6w7klwt38d44n5nr8njr8rrxxx5kcfu3y2ezx9ss3s6j24ex
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZUlY0amcrY3ZralpTQzVj
+        Q0NXYjI2dTFvdDhGZWxpVCtWbDlleFNVTGlRCjA3V2h3K1RVRml2RGc1Ky9ZbTJp
+        NEFOellmbGppdHRiTG5ZMDJKQUFEdW8KLS0tIE5HSFJDZk1ZSjlTUm9qUkZYMzNU
+        TW5FbENlT3c0WmsvcVlrYmhGc1hYRmsKTdcViX/HqWBo+RHiJJE4PVDVdlEUIi7M
+        JSfmbhb6S6aabtQsDxmDVd75McwjLiRxeG0DTNe2YEjexaXv07oL5Q==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age185kanaq3uw2gjx5enu2v69nk9ner3lamdevrfgx3wqucsl9ewa2qlt2gf7
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-05-15T08:19:09Z"
+  mac: ENC[AES256_GCM,data:wMvz85tOG8UjvN6W/nzqcHaprkWs3jlpnfNRBOpDzd0B7MaKn7y3TrkVG3ckY7Ga0Q3/6v9oX97BJTQDJynhYU1025Gz2edFQ4e/wP7vADVFVtQDEXb7NjdUvfpHKauSC2peHKkzMp7Qp0idq7XUa61B15TiTWsarIbu+Q09Aq8=,iv:+fUEROPE9ld+lSv3rB5zslT+WYzc1E1e3QRWeL6eS/M=,tag:bmw8GTfLQYDVkdLb6tTdmA==,type:str]
+  version: 3.13.0


### PR DESCRIPTION
## Summary

Enables username/password authentication on the Mosquitto MQTT broker by:

1. Adding a SOPS-encrypted Secret (`mosquitto-passwd`) containing pre-hashed credentials for `homeassistant` and `zigbee2mqtt` (generated with `mosquitto_passwd` from `eclipse-mosquitto:2.0.22`, `$7$` PBKDF2-SHA512 format).
2. Mounting the secret read-only into the `app` container at `/mosquitto/secret/passwd` via `advancedMounts` + `subPath`.
3. Updating `mosquitto.conf`: replaces `allow_anonymous true` with `allow_anonymous false` and adds `password_file /mosquitto/secret/passwd`.
4. Adding `passwd.sops.yaml` to `kustomization.yaml` resources.

Home Assistant and Zigbee2MQTT credential updates are the user's manual responsibility (UI work) and are explicitly out of scope for this PR.

## Files changed

- `kubernetes/cluster0/apps/home/mosquitto/app/passwd.sops.yaml` — new SOPS-encrypted Secret
- `kubernetes/cluster0/apps/home/mosquitto/app/helm-release.yaml` — updated `mosquitto.conf` + added `passwd` persistence mount
- `kubernetes/cluster0/apps/home/mosquitto/app/kustomization.yaml` — added `passwd.sops.yaml` to resources

## Pre-merge user actions

Before this PR is merged, the user must:
1. Decrypt the `passwd.sops.yaml` locally to recover the plaintext passwords (`sops --decrypt` + reverse the hashes is not possible; the user retrieves plaintexts from the original generation step or by re-running `mosquitto_passwd` with new plaintexts and updating the secret).
2. Enter the credentials into the Home Assistant MQTT integration via the UI.
3. Enter the credentials into the Zigbee2MQTT MQTT settings via the UI.
4. Confirm both clients show "Connected" while Mosquitto is still allowing anonymous (current state) — credentials are inert until merge.

After merge:
- Flux reconciles, Mosquitto restarts (~30s MQTT downtime), both clients reconnect using the credentials set above.

Closes #2806
