### PR TITLE
fix(mosquitto): tighten password file permissions to silence broker startup warnings

### DIFF
--- a/kubernetes/cluster0/apps/home/mosquitto/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/home/mosquitto/app/helm-release.yaml
@@ -26,6 +26,10 @@ spec:
   values:
     controllers:
       main:
+        pod:
+          securityContext:
+            fsGroup: 1883
+            fsGroupChangePolicy: OnRootMismatch
         containers:
           app:
             image:
@@ -135,6 +139,7 @@ spec:
       passwd:
         type: secret
         name: mosquitto-passwd
+        defaultMode: 0400
         advancedMounts:
           main:
             app:

--- a/kubernetes/cluster0/apps/home/mosquitto/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/home/mosquitto/app/helm-release.yaml
@@ -139,7 +139,7 @@ spec:
       passwd:
         type: secret
         name: mosquitto-passwd
-        defaultMode: 0400
+        defaultMode: 0440
         advancedMounts:
           main:
             app:


### PR DESCRIPTION
## Summary

Silences two of the three Mosquitto startup warnings introduced after password authentication was enabled in #2938:

```
Warning: File /mosquitto/secret/passwd has world readable permissions. Future versions will refuse to load this file.
Warning: File /mosquitto/secret/passwd group is not mosquitto. Future versions will refuse to load this file.
```

> **Note:** The third warning — `owner is not mosquitto` — is an inherent Kubernetes limitation: secret volumes always create files as uid=root regardless of any pod securityContext. `fsGroup` only changes the *group* ownership, not the *user* ownership. This warning cannot be silenced without running a privileged init container or using a custom entrypoint; that is out of scope here and arguably unnecessary since the broker still loads the file correctly via group-read access.

## Changes

Two surgical additions to `kubernetes/cluster0/apps/home/mosquitto/app/helm-release.yaml` (+5 lines, 0 deletions):

1. **`controllers.main.pod.securityContext.fsGroup: 1883`** — kubelet chowns all mounted volumes to gid 1883 (the mosquitto process uid/gid) before the container starts, resolving the "group is not mosquitto" warning.
2. **`controllers.main.pod.securityContext.fsGroupChangePolicy: OnRootMismatch`** — skips re-chowning on subsequent restarts if the volume group already matches.
3. **`persistence.passwd.defaultMode: 0440`** — sets the Secret mount to owner-read + group-read (vs the Kubernetes default of 0644). Mode 0440 is used rather than 0400 because Kubernetes secret volumes set uid=root; mosquitto (uid=1883) reads via its supplemental gid=1883. This resolves the "world readable permissions" warning while preserving broker access to the file.

## Operational note

⚠️ This change will cause a **Mosquitto pod restart** (~30s MQTT downtime) when Flux applies it. No manual client preparation is required — the credentials themselves are unchanged; only the file permissions and group ownership are corrected.

## Post-merge verification

```bash
# Check logs — two warnings should be gone; one owner warning may remain (Kubernetes limitation)
kubectl -n home logs deploy/mosquitto --tail=20 | grep -iE 'warning|world readable|owner is not|group is not'

# Confirm file permissions: should show -r--r----- root 1883 (mode 0440, gid 1883)
kubectl exec deploy/mosquitto -n home -- ls -la /mosquitto/secret/passwd
```

Closes #2939