### PR TITLE
feat(netpol): phase 2b media namespace NetworkPolicies

### DIFF
--- a/kubernetes/cluster0/apps/media/lidarr/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/lidarr/app/helm-release.yaml
@@ -63,6 +63,124 @@ spec:
                   group: 'traefik.io'
                   kind: 'Middleware'
                   name: 'forwardauth-authelia'
+    networkpolicies:
+      default-deny:
+        controller: main
+        policyTypes: [Ingress, Egress]
+        rules: {}
+      allow-dns:
+        controller: main
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 53
+                  protocol: UDP
+                - port: 53
+                  protocol: TCP
+              to:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: kube-system
+      allow-traefik-ingress:
+        controller: main
+        policyTypes: [Ingress]
+        rules:
+          ingress:
+            - from:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: networking
+      allow-auth-ingress:
+        controller: main
+        policyTypes: [Ingress]
+        rules:
+          ingress:
+            - from:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: auth
+      allow-monitoring-ingress:
+        controller: main
+        policyTypes: [Ingress]
+        rules:
+          ingress:
+            - from:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: monitoring
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/name: prometheus-blackbox-exporter
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: monitoring
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/name: uptime-kuma
+              ports:
+                - port: 8686
+                  protocol: TCP
+      allow-sabnzbd-egress:
+        controller: main
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 8080
+                  protocol: TCP
+              to:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: media
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/instance: sabnzbd
+      allow-qbittorrent-egress:
+        controller: main
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 8080
+                  protocol: TCP
+              to:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: media
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/instance: qbittorrent
+      allow-prowlarr-egress:
+        controller: main
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 9696
+                  protocol: TCP
+              to:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: media
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/instance: prowlarr
+      allow-external-egress:
+        controller: main
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 443
+                  protocol: TCP
+              to:
+                - ipBlock:
+                    cidr: 0.0.0.0/0
+                    except:
+                      - 10.0.0.0/8
+                      - 172.16.0.0/12
+                      - 192.168.0.0/16
     persistence:
       config:
         existingClaim: pvc-lidarr

--- a/kubernetes/cluster0/apps/media/miniflux/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/miniflux/app/helm-release.yaml
@@ -76,6 +76,75 @@ spec:
               startup:
                 enabled: false
 
+    networkpolicies:
+      default-deny:
+        controller: miniflux
+        policyTypes: [Ingress, Egress]
+        rules: {}
+      allow-dns:
+        controller: miniflux
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 53
+                  protocol: UDP
+                - port: 53
+                  protocol: TCP
+              to:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: kube-system
+      allow-traefik-ingress:
+        controller: miniflux
+        policyTypes: [Ingress]
+        rules:
+          ingress:
+            - from:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: networking
+      allow-auth-ingress:
+        controller: miniflux
+        policyTypes: [Ingress]
+        rules:
+          ingress:
+            - from:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: auth
+      allow-postgres-egress:
+        controller: miniflux
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 5432
+                  protocol: TCP
+              to:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: databases
+                  podSelector:
+                    matchLabels:
+                      cnpg.io/cluster: miniflux-postgres-v17
+      allow-external-egress:
+        controller: miniflux
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 80
+                  protocol: TCP
+                - port: 443
+                  protocol: TCP
+              to:
+                - ipBlock:
+                    cidr: 0.0.0.0/0
+                    except:
+                      - 10.0.0.0/8
+                      - 172.16.0.0/12
+                      - 192.168.0.0/16
     service:
       app:
         ports:

--- a/kubernetes/cluster0/apps/media/prowlarr/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/prowlarr/app/helm-release.yaml
@@ -63,6 +63,106 @@ spec:
                   group: 'traefik.io'
                   kind: 'Middleware'
                   name: 'forwardauth-authelia'
+    networkpolicies:
+      default-deny:
+        controller: main
+        policyTypes: [Ingress, Egress]
+        rules: {}
+      allow-dns:
+        controller: main
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 53
+                  protocol: UDP
+                - port: 53
+                  protocol: TCP
+              to:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: kube-system
+      allow-traefik-ingress:
+        controller: main
+        policyTypes: [Ingress]
+        rules:
+          ingress:
+            - from:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: networking
+      allow-auth-ingress:
+        controller: main
+        policyTypes: [Ingress]
+        rules:
+          ingress:
+            - from:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: auth
+      allow-arr-ingress:
+        controller: main
+        policyTypes: [Ingress]
+        rules:
+          ingress:
+            - from:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: media
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/instance: sonarr
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: media
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/instance: radarr
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: media
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/instance: lidarr
+              ports:
+                - port: 9696
+                  protocol: TCP
+      allow-monitoring-ingress:
+        controller: main
+        policyTypes: [Ingress]
+        rules:
+          ingress:
+            - from:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: monitoring
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/name: prometheus-blackbox-exporter
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: monitoring
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/name: uptime-kuma
+              ports:
+                - port: 9696
+                  protocol: TCP
+      allow-external-egress:
+        controller: main
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 443
+                  protocol: TCP
+              to:
+                - ipBlock:
+                    cidr: 0.0.0.0/0
+                    except:
+                      - 10.0.0.0/8
+                      - 172.16.0.0/12
+                      - 192.168.0.0/16
     persistence:
       config:
         existingClaim: pvc-prowlarr

--- a/kubernetes/cluster0/apps/media/qbittorrent/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/qbittorrent/app/helm-release.yaml
@@ -101,6 +101,99 @@ spec:
                   group: 'traefik.io'
                   kind: 'Middleware'
                   name: 'forwardauth-authelia'
+    networkpolicies:
+      default-deny:
+        controller: main
+        policyTypes: [Ingress, Egress]
+        rules: {}
+      allow-dns:
+        controller: main
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 53
+                  protocol: UDP
+                - port: 53
+                  protocol: TCP
+              to:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: kube-system
+      allow-traefik-ingress:
+        controller: main
+        policyTypes: [Ingress]
+        rules:
+          ingress:
+            - from:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: networking
+      allow-auth-ingress:
+        controller: main
+        policyTypes: [Ingress]
+        rules:
+          ingress:
+            - from:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: auth
+      allow-arr-ingress:
+        controller: main
+        policyTypes: [Ingress]
+        rules:
+          ingress:
+            - from:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: media
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/instance: sonarr
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: media
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/instance: radarr
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: media
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/instance: lidarr
+              ports:
+                - port: 8080
+                  protocol: TCP
+      allow-monitoring-ingress:
+        controller: main
+        policyTypes: [Ingress]
+        rules:
+          ingress:
+            - from:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: monitoring
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/name: prometheus-blackbox-exporter
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: monitoring
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/name: uptime-kuma
+              ports:
+                - port: 8080
+                  protocol: TCP
+      allow-external-egress:
+        controller: main
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - to:
+                - ipBlock:
+                    cidr: 0.0.0.0/0
     persistence:
       config:
         existingClaim: pvc-qbittorrent

--- a/kubernetes/cluster0/apps/media/radarr/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/radarr/app/helm-release.yaml
@@ -63,6 +63,124 @@ spec:
                   group: 'traefik.io'
                   kind: 'Middleware'
                   name: 'forwardauth-authelia'
+    networkpolicies:
+      default-deny:
+        controller: main
+        policyTypes: [Ingress, Egress]
+        rules: {}
+      allow-dns:
+        controller: main
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 53
+                  protocol: UDP
+                - port: 53
+                  protocol: TCP
+              to:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: kube-system
+      allow-traefik-ingress:
+        controller: main
+        policyTypes: [Ingress]
+        rules:
+          ingress:
+            - from:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: networking
+      allow-auth-ingress:
+        controller: main
+        policyTypes: [Ingress]
+        rules:
+          ingress:
+            - from:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: auth
+      allow-monitoring-ingress:
+        controller: main
+        policyTypes: [Ingress]
+        rules:
+          ingress:
+            - from:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: monitoring
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/name: prometheus-blackbox-exporter
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: monitoring
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/name: uptime-kuma
+              ports:
+                - port: 7878
+                  protocol: TCP
+      allow-sabnzbd-egress:
+        controller: main
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 8080
+                  protocol: TCP
+              to:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: media
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/instance: sabnzbd
+      allow-qbittorrent-egress:
+        controller: main
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 8080
+                  protocol: TCP
+              to:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: media
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/instance: qbittorrent
+      allow-prowlarr-egress:
+        controller: main
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 9696
+                  protocol: TCP
+              to:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: media
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/instance: prowlarr
+      allow-external-egress:
+        controller: main
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 443
+                  protocol: TCP
+              to:
+                - ipBlock:
+                    cidr: 0.0.0.0/0
+                    except:
+                      - 10.0.0.0/8
+                      - 172.16.0.0/12
+                      - 192.168.0.0/16
     persistence:
       config:
         existingClaim: pvc-radarr

--- a/kubernetes/cluster0/apps/media/radarr/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/radarr/app/helm-release.yaml
@@ -121,6 +121,21 @@ spec:
               ports:
                 - port: 7878
                   protocol: TCP
+      allow-overseerr-ingress:
+        controller: main
+        policyTypes: [Ingress]
+        rules:
+          ingress:
+            - from:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: media
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/instance: overseerr
+              ports:
+                - port: 7878
+                  protocol: TCP
       allow-sabnzbd-egress:
         controller: main
         policyTypes: [Egress]

--- a/kubernetes/cluster0/apps/media/sabnzbd/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/sabnzbd/app/helm-release.yaml
@@ -62,6 +62,108 @@ spec:
                   group: 'traefik.io'
                   kind: 'Middleware'
                   name: 'forwardauth-authelia'
+    networkpolicies:
+      default-deny:
+        controller: main
+        policyTypes: [Ingress, Egress]
+        rules: {}
+      allow-dns:
+        controller: main
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 53
+                  protocol: UDP
+                - port: 53
+                  protocol: TCP
+              to:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: kube-system
+      allow-traefik-ingress:
+        controller: main
+        policyTypes: [Ingress]
+        rules:
+          ingress:
+            - from:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: networking
+      allow-auth-ingress:
+        controller: main
+        policyTypes: [Ingress]
+        rules:
+          ingress:
+            - from:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: auth
+      allow-arr-ingress:
+        controller: main
+        policyTypes: [Ingress]
+        rules:
+          ingress:
+            - from:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: media
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/instance: sonarr
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: media
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/instance: radarr
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: media
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/instance: lidarr
+              ports:
+                - port: 8080
+                  protocol: TCP
+      allow-monitoring-ingress:
+        controller: main
+        policyTypes: [Ingress]
+        rules:
+          ingress:
+            - from:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: monitoring
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/name: prometheus-blackbox-exporter
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: monitoring
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/name: uptime-kuma
+              ports:
+                - port: 8080
+                  protocol: TCP
+      allow-external-egress:
+        controller: main
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 119
+                  protocol: TCP
+                - port: 563
+                  protocol: TCP
+              to:
+                - ipBlock:
+                    cidr: 0.0.0.0/0
+                    except:
+                      - 10.0.0.0/8
+                      - 172.16.0.0/12
+                      - 192.168.0.0/16
     persistence:
       config:
         existingClaim: pvc-sabnzbd

--- a/kubernetes/cluster0/apps/media/sonarr/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/sonarr/app/helm-release.yaml
@@ -121,6 +121,21 @@ spec:
               ports:
                 - port: 8989
                   protocol: TCP
+      allow-overseerr-ingress:
+        controller: main
+        policyTypes: [Ingress]
+        rules:
+          ingress:
+            - from:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: media
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/instance: overseerr
+              ports:
+                - port: 8989
+                  protocol: TCP
       allow-sabnzbd-egress:
         controller: main
         policyTypes: [Egress]

--- a/kubernetes/cluster0/apps/media/sonarr/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/sonarr/app/helm-release.yaml
@@ -63,6 +63,124 @@ spec:
                   group: 'traefik.io'
                   kind: 'Middleware'
                   name: 'forwardauth-authelia'
+    networkpolicies:
+      default-deny:
+        controller: main
+        policyTypes: [Ingress, Egress]
+        rules: {}
+      allow-dns:
+        controller: main
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 53
+                  protocol: UDP
+                - port: 53
+                  protocol: TCP
+              to:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: kube-system
+      allow-traefik-ingress:
+        controller: main
+        policyTypes: [Ingress]
+        rules:
+          ingress:
+            - from:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: networking
+      allow-auth-ingress:
+        controller: main
+        policyTypes: [Ingress]
+        rules:
+          ingress:
+            - from:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: auth
+      allow-monitoring-ingress:
+        controller: main
+        policyTypes: [Ingress]
+        rules:
+          ingress:
+            - from:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: monitoring
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/name: prometheus-blackbox-exporter
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: monitoring
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/name: uptime-kuma
+              ports:
+                - port: 8989
+                  protocol: TCP
+      allow-sabnzbd-egress:
+        controller: main
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 8080
+                  protocol: TCP
+              to:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: media
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/instance: sabnzbd
+      allow-qbittorrent-egress:
+        controller: main
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 8080
+                  protocol: TCP
+              to:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: media
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/instance: qbittorrent
+      allow-prowlarr-egress:
+        controller: main
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 9696
+                  protocol: TCP
+              to:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: media
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/instance: prowlarr
+      allow-external-egress:
+        controller: main
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 443
+                  protocol: TCP
+              to:
+                - ipBlock:
+                    cidr: 0.0.0.0/0
+                    except:
+                      - 10.0.0.0/8
+                      - 172.16.0.0/12
+                      - 192.168.0.0/16
     persistence:
       config:
         existingClaim: pvc-sonarr


### PR DESCRIPTION
## Summary

Implements default-deny + targeted allow NetworkPolicies for all seven in-scope `media` namespace workloads: `sonarr`, `radarr`, `lidarr`, `prowlarr`, `sabnzbd`, `qbittorrent`, `miniflux`. This is Phase 2b of the cluster-wide NetworkPolicy rollout.

All policies are implemented via the `networkpolicies` chart values key in the bjw-s `app-template` chart — consistent with the Phase 1 and Phase 2a patterns.

## Policies added

| Workload | Default-deny | DNS egress | Traefik+Auth ingress | Monitoring ingress | Special rules |
|---|---|---|---|---|---|
| `sonarr` | ✅ | ✅ | ✅ | ✅ :8989 (blackbox-exporter + uptime-kuma) | Egress → sabnzbd:8080, qbittorrent:8080, prowlarr:9696, external:443 |
| `radarr` | ✅ | ✅ | ✅ | ✅ :7878 (blackbox-exporter + uptime-kuma) | Same egress as sonarr |
| `lidarr` | ✅ | ✅ | ✅ | ✅ :8686 (blackbox-exporter + uptime-kuma) | Same egress as sonarr |
| `prowlarr` | ✅ | ✅ | ✅ | ✅ :9696 (blackbox-exporter + uptime-kuma) | Ingress from intra-ns arrs on :9696; egress → external:443 |
| `sabnzbd` | ✅ | ✅ | ✅ | ✅ :8080 (blackbox-exporter + uptime-kuma) | Ingress from intra-ns arrs on :8080; egress → external:119+563 (usenet) |
| `qbittorrent` | ✅ | ✅ | ✅ | ✅ :8080 (blackbox-exporter + uptime-kuma) | Ingress from intra-ns arrs on :8080; egress wide-open (Gluetun VPN) |
| `miniflux` | ✅ | ✅ | ✅ | ❌ not probed | Egress → databases/miniflux-postgres-v17:5432, external:80+443 |

## Phase 2a lessons applied pre-emptively

All three Phase 2a fix-forward patterns (#2937) are baked in from the start:

1. **Intra-namespace AND-shape**: every intra-namespace `to:`/`from:` entry includes both `namespaceSelector: {matchLabels: {kubernetes.io/metadata.name: media}}` AND `podSelector` as siblings (Cilium endpoint-identity requirement).
2. **Two-`from` monitoring-ingress**: each probed pod's `allow-monitoring-ingress` rule has TWO `from` entries — one for `prometheus-blackbox-exporter` and one for `uptime-kuma` — both AND-scoped to the `monitoring` namespace. The monitoring port matches the Probe's target port, not a metrics port.
3. **Explicit `namespaceSelector`** on all cross-namespace rules (auth ingress, traefik ingress, miniflux→databases egress).

## AC verification

- [x] All seven pods have NetworkPolicy via `app-template` `networkpolicies` values ✅
- [x] All policies have `policyTypes: [Ingress, Egress]` and default-deny shape ✅
- [x] All policies include DNS egress (53 UDP+TCP → kube-system) ✅
- [x] All seven pods allow ingress from `auth` (Authelia) and `networking` (Traefik) ✅
- [x] `prowlarr` allows intra-ns arr ingress on :9696 with AND-shape namespaceSelector ✅
- [x] `sabnzbd` allows intra-ns arr ingress on :8080 with AND-shape namespaceSelector ✅
- [x] `qbittorrent` allows intra-ns arr ingress on :8080 with AND-shape namespaceSelector ✅
- [x] Each arr egress allows sabnzbd:8080, qbittorrent:8080, prowlarr:9696 + external:443 ✅
- [x] `qbittorrent` egress is wide-open (any external, any port) for Gluetun VPN ✅
- [x] `miniflux` egress allows `databases` ns, pod selector `cnpg.io/cluster: miniflux-postgres-v17`, port 5432 ✅
- [x] Six probed pods have two-`from` monitoring-ingress (blackbox-exporter + uptime-kuma) on correct probe ports ✅
- [x] `miniflux` has NO monitoring-ingress rule (not probed) ✅
- [x] All cross-namespace rules include explicit `namespaceSelector` ✅
- [x] All intra-namespace rules include `namespaceSelector: {matchLabels: {kubernetes.io/metadata.name: media}}` alongside `podSelector` ✅
- [x] No Phase 1 policy on jellyfin/overseerr/plex/syncthing modified ✅
- [x] `kubectl kustomize kubernetes/cluster0/apps/media` builds cleanly ✅

## Post-merge verification (coordinator to run after merge)

```bash
# 1. Reconcile
for ks in sonarr radarr lidarr prowlarr sabnzbd qbittorrent miniflux; do
  flux reconcile kustomization cluster-apps-$ks
done

# 2. Confirm policies created
kubectl -n media get networkpolicy

# 3. Watch for drops in media ns
hubble observe --namespace media --verdict DROPPED --since 10m

# 4. Functional smoke tests
#    - All four arr UIs accessible via Traefik + Authelia
#    - SABnzbd and qBittorrent UIs accessible
#    - Prowlarr indexer test succeeds (external :443)
#    - Sonarr/Radarr/Lidarr can list categories from Prowlarr (intra-ns :9696)
#    - Sonarr/Radarr/Lidarr can queue a download to SABnzbd (intra-ns :8080)
#    - Miniflux page loads and feed fetch succeeds
#    - qBittorrent reports active peers (external egress through Gluetun works)
#    - All six blackbox probes still UP
```

Refs #2810
Closes #2934