### PR TITLE
security: netpol phase 2c — auth namespace policies

### DIFF
--- a/kubernetes/cluster0/apps/auth/authelia/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/auth/authelia/app/helm-release.yaml
@@ -99,6 +99,99 @@ spec:
           - backendRefs:
               - identifier: app
                 port: *port
+    networkpolicies:
+      default-deny:
+        controller: authelia
+        policyTypes: [Ingress, Egress]
+        rules: {}
+      allow-dns:
+        controller: authelia
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 53
+                  protocol: UDP
+                - port: 53
+                  protocol: TCP
+              to:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: kube-system
+      allow-traefik-ingress:
+        controller: authelia
+        policyTypes: [Ingress]
+        rules:
+          ingress:
+            - from:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: networking
+              ports:
+                - port: 80
+                  protocol: TCP
+      allow-openldap-egress:
+        controller: authelia
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 389
+                  protocol: TCP
+              to:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: auth
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/instance: openldap
+      allow-valkey-egress:
+        controller: authelia
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 6379
+                  protocol: TCP
+              to:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: auth
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/instance: valkey
+      allow-postgres-egress:
+        controller: authelia
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 5432
+                  protocol: TCP
+              to:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: databases
+                  podSelector:
+                    matchLabels:
+                      cnpg.io/cluster: authelia-postgres-v17
+      allow-external-egress:
+        controller: authelia
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 443
+                  protocol: TCP
+                - port: 587
+                  protocol: TCP
+              to:
+                - ipBlock:
+                    cidr: 0.0.0.0/0
+                    except:
+                      - 10.0.0.0/8
+                      - 172.16.0.0/12
+                      - 192.168.0.0/16
     persistence:
       config:
         type: configMap

--- a/kubernetes/cluster0/apps/auth/authelia/valkey/helm-release.yaml
+++ b/kubernetes/cluster0/apps/auth/authelia/valkey/helm-release.yaml
@@ -27,6 +27,40 @@ spec:
             env:
               VALKEY_PASSWORD_FILE: /secret/valkey-password
               VALKEY_PORT: &port 6379
+    networkpolicies:
+      default-deny:
+        controller: valkey
+        policyTypes: [Ingress, Egress]
+        rules: {}
+      allow-dns:
+        controller: valkey
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 53
+                  protocol: UDP
+                - port: 53
+                  protocol: TCP
+              to:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: kube-system
+      allow-authelia-ingress:
+        controller: valkey
+        policyTypes: [Ingress]
+        rules:
+          ingress:
+            - from:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: auth
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/instance: authelia
+              ports:
+                - port: 6379
+                  protocol: TCP
     persistence:
       data:
         type: emptyDir

--- a/kubernetes/cluster0/apps/auth/openldap/app/kustomization.yaml
+++ b/kubernetes/cluster0/apps/auth/openldap/app/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - ./helm-release.yaml
   - ./secret.sops.yaml
+  - ./networkpolicy.yaml
 labels:
   - pairs:
       app.kubernetes.io/name: openldap

--- a/kubernetes/cluster0/apps/auth/openldap/app/networkpolicy.yaml
+++ b/kubernetes/cluster0/apps/auth/openldap/app/networkpolicy.yaml
@@ -1,0 +1,153 @@
+---
+# NetworkPolicy: openldap (LDAP server pod)
+# Allows ingress from intra-ns authelia (LDAP queries :389)
+# and from intra-ns phpldapadmin (LDAP queries :389 — phpLDAPadmin is a separate pod in this chart)
+# Default-deny + DNS egress only
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: openldap-default-deny
+  namespace: auth
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: openldap
+      app.kubernetes.io/component: openldap
+  policyTypes:
+    - Ingress
+    - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: openldap-allow-dns
+  namespace: auth
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: openldap
+      app.kubernetes.io/component: openldap
+  policyTypes:
+    - Egress
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: openldap-allow-ldap-ingress
+  namespace: auth
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: openldap
+      app.kubernetes.io/component: openldap
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: auth
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: authelia
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: auth
+          podSelector:
+            matchLabels:
+              app: phpldapadmin
+      ports:
+        - port: 389
+          protocol: TCP
+---
+# NetworkPolicy: openldap-phpldapadmin (separate deployment pod)
+# Allows ingress from networking ns (Traefik — web UI access)
+# Default-deny + DNS egress + egress to openldap :389 (phpLDAPadmin needs to query LDAP)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: phpldapadmin-default-deny
+  namespace: auth
+spec:
+  podSelector:
+    matchLabels:
+      app: phpldapadmin
+  policyTypes:
+    - Ingress
+    - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: phpldapadmin-allow-dns
+  namespace: auth
+spec:
+  podSelector:
+    matchLabels:
+      app: phpldapadmin
+  policyTypes:
+    - Egress
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: phpldapadmin-allow-traefik-ingress
+  namespace: auth
+spec:
+  podSelector:
+    matchLabels:
+      app: phpldapadmin
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: networking
+      ports:
+        - port: 80
+          protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: phpldapadmin-allow-openldap-egress
+  namespace: auth
+spec:
+  podSelector:
+    matchLabels:
+      app: phpldapadmin
+  policyTypes:
+    - Egress
+  egress:
+    - ports:
+        - port: 389
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: auth
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: openldap
+              app.kubernetes.io/component: openldap


### PR DESCRIPTION
## Summary

Apply default-deny + targeted allow NetworkPolicies to all workloads in the `auth` namespace: `authelia`, `valkey`, `openldap`, and `openldap-phpldapadmin`.

This is the final Phase 2 child PR. Closes both the child issue and the parent design doc.

Closes #2933
Closes #2810

---

## Changes

### `authelia` (app-template `networkpolicies` values)

| Policy | Type | Rule |
|--------|------|------|
| `default-deny` | Ingress+Egress | deny all |
| `allow-dns` | Egress | kube-system :53 UDP+TCP |
| `allow-traefik-ingress` | Ingress | networking ns (Traefik) → :80 |
| `allow-openldap-egress` | Egress | → auth/openldap :389 (AND-shape) |
| `allow-valkey-egress` | Egress | → auth/valkey :6379 (AND-shape) |
| `allow-postgres-egress` | Egress | → databases/authelia-postgres-v17 :5432 |
| `allow-external-egress` | Egress | external :443 (OIDC) + :587 (SMTP notifier) |

Note: Authelia listens on port 80 in this cluster (AUTHELIA_SERVER_ADDRESS: tcp://0.0.0.0:80). The issue body mentions :9091, but the actual service port is 80 — confirmed via `kubectl -n auth get svc authelia` and the forward-auth middleware URL.

### `valkey` (app-template `networkpolicies` values)

| Policy | Type | Rule |
|--------|------|------|
| `default-deny` | Ingress+Egress | deny all |
| `allow-dns` | Egress | kube-system :53 UDP+TCP |
| `allow-authelia-ingress` | Ingress | auth/authelia → :6379 (AND-shape) |

### `openldap` + `phpldapadmin` (standalone `NetworkPolicy` manifests)

The `openldap-stack-ha` chart is not app-template, so policies are standalone manifests added to `openldap/app/networkpolicy.yaml`.

> **Topology note**: The issue body states phpLDAPadmin runs as a container in the openldap pod — this is incorrect per the actual cluster. `kubectl -n auth get pods` reveals a separate `openldap-phpldapadmin-*` deployment (label: `app=phpldapadmin`). The policies cover both pods separately.

**openldap pod** (`app.kubernetes.io/instance=openldap, app.kubernetes.io/component=openldap`):

| Policy | Type | Rule |
|--------|------|------|
| `openldap-default-deny` | Ingress+Egress | deny all |
| `openldap-allow-dns` | Egress | kube-system :53 UDP+TCP |
| `openldap-allow-ldap-ingress` | Ingress | auth/authelia → :389 AND auth/phpldapadmin → :389 (both AND-shape) |

**phpldapadmin pod** (`app=phpldapadmin`):

| Policy | Type | Rule |
|--------|------|------|
| `phpldapadmin-default-deny` | Ingress+Egress | deny all |
| `phpldapadmin-allow-dns` | Egress | kube-system :53 UDP+TCP |
| `phpldapadmin-allow-traefik-ingress` | Ingress | networking ns (Traefik) → :80 |
| `phpldapadmin-allow-openldap-egress` | Egress | → auth/openldap :389 (AND-shape) |

---

## No monitoring-ingress rules — verification

The issue requires no monitoring-ingress rules on any pod:

```bash
# Confirm no ServiceMonitor/PodMonitor for auth ns
kubectl get servicemonitor,podmonitor -n auth
# (no output — none exist)

# Confirm the one Probe targets an external URL, not in-cluster
kubectl get probe authelia-public -n auth -o jsonpath='{.spec.targets.staticConfig.static}'
# [https://auth.tinfoilforest.nz] — external URL, probed via Traefik

# Confirm uptime-kuma does NOT probe auth namespace
kubectl get networkpolicy -n monitoring uptime-kuma-allow-monitored-egress -o yaml | grep -A5 namespaceSelector
# Egress allows networking, media, home, monitoring — not auth
```

---

## kustomize build verification

```bash
kubectl kustomize kubernetes/cluster0/apps/auth
# exits 0
```

---

## Post-merge verification (coordinator will run)

```bash
# 1. Reconcile
flux reconcile kustomization cluster-apps-authelia
flux reconcile kustomization cluster-apps-authelia-valkey
flux reconcile kustomization cluster-apps-openldap

# 2. Confirm policies created
kubectl -n auth get networkpolicy

# 3. Watch for drops — especially the forward-auth path
hubble observe --namespace auth --verdict DROPPED --since 10m
hubble observe --pod networking/traefik-* --verdict DROPPED --since 10m

# 4. Functional smoke tests
#    - Hit a protected service (e.g. home-assistant) — confirm Authelia challenge appears, login succeeds
#    - Hit Authelia login directly — should return 200
#    - Hit phpLDAPadmin — should be reachable through Traefik
#    - Confirm authelia-public blackbox probe still passes

# 5. Confirm openldap not reachable from non-allowed namespace
kubectl -n media run ldap-test --rm -it --restart=Never --image=alpine -- nc -zv -w 3 openldap.auth.svc 389
# Expected: connection refused/timeout + DROPPED in Hubble
```