### PR TITLE
fix(netpol): use OpenLDAP unprivileged pod ports (1389/1636) in auth-ns policies

### DIFF
--- a/kubernetes/cluster0/apps/auth/authelia/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/auth/authelia/app/helm-release.yaml
@@ -136,7 +136,9 @@ spec:
         rules:
           egress:
             - ports:
-                - port: 389
+                - port: 1389
+                  protocol: TCP
+                - port: 1636
                   protocol: TCP
               to:
                 - namespaceSelector:

--- a/kubernetes/cluster0/apps/auth/openldap/app/networkpolicy.yaml
+++ b/kubernetes/cluster0/apps/auth/openldap/app/networkpolicy.yaml
@@ -1,7 +1,7 @@
 ---
 # NetworkPolicy: openldap (LDAP server pod)
-# Allows ingress from intra-ns authelia (LDAP queries :389)
-# and from intra-ns phpldapadmin (LDAP queries :389 — phpLDAPadmin is a separate pod in this chart)
+# Allows ingress from intra-ns authelia (LDAP queries :1389/:1636)
+# and from intra-ns phpldapadmin (LDAP queries :1389/:1636 — phpLDAPadmin is a separate pod in this chart)
 # Default-deny + DNS egress only
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -67,12 +67,14 @@ spec:
             matchLabels:
               app: phpldapadmin
       ports:
-        - port: 389
+        - port: 1389
+          protocol: TCP
+        - port: 1636
           protocol: TCP
 ---
 # NetworkPolicy: openldap-phpldapadmin (separate deployment pod)
 # Allows ingress from networking ns (Traefik — web UI access)
-# Default-deny + DNS egress + egress to openldap :389 (phpLDAPadmin needs to query LDAP)
+# Default-deny + DNS egress + egress to openldap :1389/:1636 (phpLDAPadmin needs to query LDAP)
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -141,7 +143,9 @@ spec:
     - Egress
   egress:
     - ports:
-        - port: 389
+        - port: 1389
+          protocol: TCP
+        - port: 1636
           protocol: TCP
       to:
         - namespaceSelector:


### PR DESCRIPTION
## Summary

Small fix-forward for Phase 2c (auth-ns NetworkPolicies, merged in #2942).

NetworkPolicy operates at the **pod port level**, not the Service port. The `openldap-stack-ha` chart binds to unprivileged ports `1389`/`1636` inside the pod (to avoid `CAP_NET_BIND_SERVICE`), while the Kubernetes Service exposes `389`/`636`. The Phase 2c policies were written against Service ports, so Authelia → OpenLDAP traffic was being dropped.

## Changes

Two files, port numbers only:

- `authelia/app/helm-release.yaml` — `authelia-allow-openldap-egress`: `389` → `1389` + `1636`
- `openldap/app/networkpolicy.yaml` — `openldap-allow-ldap-ingress`: `389` → `1389` + `1636`
- `openldap/app/networkpolicy.yaml` — `phpldapadmin-allow-openldap-egress`: `389` → `1389` + `1636`

Port 1636 (LDAPS) is added pre-emptively alongside 1389 — today `start_tls: false`, but adding it now prevents an identical fix-forward when LDAPS is eventually enabled (same belt-and-braces logic as opening both `:443`/`:22` on home-assistant external egress).

All AND-shape `namespaceSelector` + `podSelector` pairs are preserved. No Service ports, Authelia LDAP URL, or other fields are touched.

Closes #2943