### PR TITLE
fix(netpol): patch Phase 3a gaps — CNPG :8000 (instance manager) + operator egress

### DIFF
--- a/kubernetes/cluster0/apps/auth/authelia/db/network-policy.yaml
+++ b/kubernetes/cluster0/apps/auth/authelia/db/network-policy.yaml
@@ -76,6 +76,30 @@ spec:
             matchLabels:
               cnpg.io/cluster: authelia-postgres-v17
 ---
+# Allow ingress from cloudnative-pg operator on :8000 (instance manager HTTP endpoint)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: authelia-postgres-v17-allow-operator-ingress
+  namespace: databases
+spec:
+  podSelector:
+    matchLabels:
+      cnpg.io/cluster: authelia-postgres-v17
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: databases
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: cloudnative-pg
+      ports:
+        - port: 8000
+          protocol: TCP
+---
 # Allow ingress from auth/authelia on :5432
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/kubernetes/cluster0/apps/auth/authelia/db/network-policy.yaml
+++ b/kubernetes/cluster0/apps/auth/authelia/db/network-policy.yaml
@@ -36,7 +36,7 @@ spec:
             matchLabels:
               kubernetes.io/metadata.name: kube-system
 ---
-# Allow intra-namespace primary <-> replica replication on :5432
+# Allow intra-namespace primary <-> replica replication on :5432/:8000 (instance manager)
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -60,9 +60,13 @@ spec:
       ports:
         - port: 5432
           protocol: TCP
+        - port: 8000
+          protocol: TCP
   egress:
     - ports:
         - port: 5432
+          protocol: TCP
+        - port: 8000
           protocol: TCP
       to:
         - namespaceSelector:

--- a/kubernetes/cluster0/apps/databases/cloudnative-pg/chart/network-policy.yaml
+++ b/kubernetes/cluster0/apps/databases/cloudnative-pg/chart/network-policy.yaml
@@ -87,6 +87,32 @@ spec:
         - port: 9443
           protocol: TCP
 ---
+# Allow operator egress to CNPG cluster pods on :8000 (instance manager HTTP endpoint)
+# Used for failover, promote, restart, status checks, and base-backup coordination
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: cloudnative-pg-allow-instance-manager-egress
+  namespace: databases
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: cloudnative-pg
+  policyTypes:
+    - Egress
+  egress:
+    - ports:
+        - port: 8000
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: databases
+          podSelector:
+            matchExpressions:
+              - key: cnpg.io/cluster
+                operator: Exists
+---
 # Allow Prometheus to scrape cloudnative-pg operator metrics
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/kubernetes/cluster0/apps/home/home-assistant/db/network-policy.yaml
+++ b/kubernetes/cluster0/apps/home/home-assistant/db/network-policy.yaml
@@ -76,6 +76,30 @@ spec:
             matchLabels:
               cnpg.io/cluster: home-assistant-postgres-v18
 ---
+# Allow ingress from cloudnative-pg operator on :8000 (instance manager HTTP endpoint)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: home-assistant-postgres-v18-allow-operator-ingress
+  namespace: databases
+spec:
+  podSelector:
+    matchLabels:
+      cnpg.io/cluster: home-assistant-postgres-v18
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: databases
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: cloudnative-pg
+      ports:
+        - port: 8000
+          protocol: TCP
+---
 # Allow ingress from home/home-assistant on :5432
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/kubernetes/cluster0/apps/home/home-assistant/db/network-policy.yaml
+++ b/kubernetes/cluster0/apps/home/home-assistant/db/network-policy.yaml
@@ -36,7 +36,7 @@ spec:
             matchLabels:
               kubernetes.io/metadata.name: kube-system
 ---
-# Allow intra-namespace primary <-> replica replication on :5432
+# Allow intra-namespace primary <-> replica replication on :5432/:8000 (instance manager)
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -60,9 +60,13 @@ spec:
       ports:
         - port: 5432
           protocol: TCP
+        - port: 8000
+          protocol: TCP
   egress:
     - ports:
         - port: 5432
+          protocol: TCP
+        - port: 8000
           protocol: TCP
       to:
         - namespaceSelector:

--- a/kubernetes/cluster0/apps/media/miniflux/db/network-policy.yaml
+++ b/kubernetes/cluster0/apps/media/miniflux/db/network-policy.yaml
@@ -76,6 +76,30 @@ spec:
             matchLabels:
               cnpg.io/cluster: miniflux-postgres-v17
 ---
+# Allow ingress from cloudnative-pg operator on :8000 (instance manager HTTP endpoint)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: miniflux-postgres-v17-allow-operator-ingress
+  namespace: databases
+spec:
+  podSelector:
+    matchLabels:
+      cnpg.io/cluster: miniflux-postgres-v17
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: databases
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: cloudnative-pg
+      ports:
+        - port: 8000
+          protocol: TCP
+---
 # Allow ingress from media/miniflux on :5432
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/kubernetes/cluster0/apps/media/miniflux/db/network-policy.yaml
+++ b/kubernetes/cluster0/apps/media/miniflux/db/network-policy.yaml
@@ -36,7 +36,7 @@ spec:
             matchLabels:
               kubernetes.io/metadata.name: kube-system
 ---
-# Allow intra-namespace primary <-> replica replication on :5432
+# Allow intra-namespace primary <-> replica replication on :5432/:8000 (instance manager)
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -60,9 +60,13 @@ spec:
       ports:
         - port: 5432
           protocol: TCP
+        - port: 8000
+          protocol: TCP
   egress:
     - ports:
         - port: 5432
+          protocol: TCP
+        - port: 8000
           protocol: TCP
       to:
         - namespaceSelector:


### PR DESCRIPTION
## Summary

Small fix-forward for Phase 3a (#2947). Three port-list gaps Hubble surfaced post-merge.

### Changes

**1. CNPG replication policies (+:8000 to ingress + egress)**

Added `:8000/TCP` (CNPG instance manager HTTP endpoint) to both ingress and egress of the `*-allow-replication` policy in all three CNPG cluster network-policy files:
- `apps/auth/authelia/db/network-policy.yaml`
- `apps/home/home-assistant/db/network-policy.yaml`
- `apps/media/miniflux/db/network-policy.yaml`

Required for primary↔replica bookkeeping and switchover negotiation.

**2. New operator → cluster-pods egress policy (cloudnative-pg)**

Added `cloudnative-pg-allow-instance-manager-egress` to `apps/databases/cloudnative-pg/chart/network-policy.yaml`. Allows the operator pod egress to all CNPG cluster pods (`cnpg.io/cluster: Exists` via `matchExpressions`) on `:8000/TCP`, scoped to the `databases` namespace with AND-shape selector. Required for failover, promote, restart, status checks, and base-backup coordination.

**3. SeaweedFS volume :18080**

The `seaweedfs-volume-allow-intra-ingress` policy already contains both `:8080` and `:18080` — AC3 is satisfied by the current file state.

### Verification

- `kubectl kustomize kubernetes/cluster0/apps/databases` ✅
- `kubectl kustomize kubernetes/cluster0/apps/seaweedfs` ✅
- Live pod port verification confirms `:8000` on CNPG pods and `:8080`/`:18080` on SeaweedFS volume pod ✅
- All added rules use AND-shape `namespaceSelector` + `podSelector` ✅
- Operator egress scoped by `cnpg.io/cluster: Exists` matchExpression (not wildcard) ✅

Closes #2948