### PR TITLE
security: netpol phase 3b — monitoring ns lockdown (Grafana, Prometheus, Alertmanager, operator, kube-state-metrics)

### DIFF
--- a/kubernetes/cluster0/apps/monitoring/grafana/app/kustomization.yaml
+++ b/kubernetes/cluster0/apps/monitoring/grafana/app/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - ./helm-release.yaml
   - ./secret.sops.yaml
   - ./probe.yaml
+  - ./network-policy.yaml
 labels:
   - pairs:
       app.kubernetes.io/name: grafana

--- a/kubernetes/cluster0/apps/monitoring/grafana/app/network-policy.yaml
+++ b/kubernetes/cluster0/apps/monitoring/grafana/app/network-policy.yaml
@@ -1,0 +1,138 @@
+---
+# =============================================================================
+# Grafana NetworkPolicy — Phase 3b (#2945)
+# Pod label: app.kubernetes.io/name=grafana
+# Listens on: :3000 (HTTP UI)
+# Ingress from: networking/traefik (via HTTPRoute)
+# Ingress from: monitoring/blackbox-exporter (probe, see blackbox-exporter policy)
+# Egress to: intra-ns prometheus :9090, external :443 (plugins/avatars)
+# =============================================================================
+
+# Default deny-all for grafana
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: grafana-default-deny
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: grafana
+  policyTypes: [Ingress, Egress]
+---
+# Allow DNS resolution
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: grafana-allow-dns
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: grafana
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+---
+# Allow ingress from Traefik (networking namespace) on :3000
+# Traefik routes grafana.tinfoilforest.nz -> grafana service :80 -> pod :3000
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: grafana-allow-traefik-ingress
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: grafana
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: networking
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: traefik
+      ports:
+        - port: 3000
+          protocol: TCP
+---
+# Allow ingress from blackbox-exporter (intra-ns probe on :3000)
+# blackbox-exporter probes grafana as a monitoring target
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: grafana-allow-blackbox-probe-ingress
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: grafana
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus-blackbox-exporter
+      ports:
+        - port: 3000
+          protocol: TCP
+---
+# Allow egress to intra-ns Prometheus on :9090 (datasource queries)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: grafana-allow-prometheus-egress
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: grafana
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 9090
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+---
+# Allow egress to external :443 (plugin fetches, avatar downloads, etc.)
+# RFC1918 ranges excluded — intra-cluster traffic goes through explicit pod-selector rules.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: grafana-allow-external-egress
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: grafana
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16

--- a/kubernetes/cluster0/apps/monitoring/kube-prometheus-stack/app/cilium-network-policy.yaml
+++ b/kubernetes/cluster0/apps/monitoring/kube-prometheus-stack/app/cilium-network-policy.yaml
@@ -1,0 +1,50 @@
+---
+# CiliumNetworkPolicy: allow Prometheus egress to the K8s API server.
+#
+# Standard K8s NetworkPolicy ipBlock rules are silently bypassed by Cilium when
+# kubeProxyReplacement=true because the k3s API server runs in the host network
+# namespace and Cilium assigns it the 'kube-apiserver' entity identity rather
+# than a pod identity or IP. The companion ipBlock NetworkPolicy is kept for
+# defence-in-depth, but this CiliumNetworkPolicy is what actually enforces the
+# allow in practice. See #2829 (external-dns fix-forward) and #2947 (cnpg) for
+# the same pattern.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: prometheus-allow-kube-apiserver
+  namespace: monitoring
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+  egress:
+    - toEntities:
+        - kube-apiserver
+---
+# CiliumNetworkPolicy: allow prometheus-operator egress to the K8s API server.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: prometheus-operator-allow-kube-apiserver
+  namespace: monitoring
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
+  egress:
+    - toEntities:
+        - kube-apiserver
+---
+# CiliumNetworkPolicy: allow kube-state-metrics egress to the K8s API server.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: kube-state-metrics-allow-kube-apiserver
+  namespace: monitoring
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: kube-state-metrics
+  egress:
+    - toEntities:
+        - kube-apiserver

--- a/kubernetes/cluster0/apps/monitoring/kube-prometheus-stack/app/kustomization.yaml
+++ b/kubernetes/cluster0/apps/monitoring/kube-prometheus-stack/app/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - ./helm-release.yaml
   - ./network-policy.yaml
+  - ./cilium-network-policy.yaml
 labels:
   - pairs:
       app.kubernetes.io/name: prometheus

--- a/kubernetes/cluster0/apps/monitoring/kube-prometheus-stack/app/network-policy.yaml
+++ b/kubernetes/cluster0/apps/monitoring/kube-prometheus-stack/app/network-policy.yaml
@@ -1,7 +1,10 @@
 ---
+# =============================================================================
 # Prometheus egress allows for databases namespace scraping (Phase 3a)
-# Note: Prometheus default-deny and full egress lockdown land in Phase 3b (#2945).
-# This file adds only the targeted egress allows needed for databases/seaweedfs scraping.
+# Note: Default-deny on Prometheus lands in Phase 3b (this PR), below.
+# These rules were added first (by #2947) to preserve scraping while
+# the full default-deny was staged.
+# =============================================================================
 
 # Allow Prometheus to scrape CNPG cluster pod metrics on :9187
 apiVersion: networking.k8s.io/v1
@@ -51,3 +54,861 @@ spec:
           podSelector:
             matchLabels:
               app.kubernetes.io/name: cloudnative-pg
+
+# =============================================================================
+# Prometheus — Phase 3b full lockdown (#2945)
+# Pod label: app.kubernetes.io/name=prometheus (StatefulSet, 2 replicas)
+# Listens on: :9090 (http-web), :8080 (config-reloader)
+# Ingress from: intra-ns grafana :9090, intra-ns prometheus-operator :8080 (reload)
+# Egress to: intra-ns alertmanager :9093, K8s API, every scrape target namespace
+# =============================================================================
+---
+# Default deny-all for Prometheus
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: prometheus-default-deny
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+  policyTypes: [Ingress, Egress]
+---
+# Allow DNS resolution
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: prometheus-allow-dns
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+---
+# Allow ingress from intra-ns Grafana on :9090 (datasource queries)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: prometheus-allow-grafana-ingress
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: grafana
+      ports:
+        - port: 9090
+          protocol: TCP
+---
+# Allow ingress from intra-ns prometheus-operator (config reload sidecar on :8080)
+# The prometheus-operator pod sends reload requests to the config-reloader on :8080
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: prometheus-allow-operator-ingress
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
+      ports:
+        - port: 9090
+          protocol: TCP
+        - port: 8080
+          protocol: TCP
+---
+# Allow egress to intra-ns Alertmanager on :9093 (alert push)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: prometheus-allow-alertmanager-egress
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 9093
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: alertmanager
+---
+# Allow egress to K8s API server (service discovery, label lookups)
+# ipBlock covers the cluster service CIDR (kubernetes.default.svc) and control-plane nodes.
+# The companion CiliumNetworkPolicy (prometheus-allow-kube-apiserver) is what Cilium actually
+# enforces when kubeProxyReplacement=true — the ipBlock rule is defence-in-depth.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: prometheus-allow-k8s-api
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.43.0.0/16  # Service CIDR (kubernetes.default.svc)
+    - ports:
+        - port: 443
+          protocol: TCP
+        - port: 6443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.87.42.2/32  # control plane node (defence-in-depth; CiliumNP is authoritative)
+---
+# Allow Prometheus egress to scrape intra-ns kube-state-metrics on :8080
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: prometheus-allow-kube-state-metrics-scrape-egress
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 8080
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: kube-state-metrics
+---
+# Allow Prometheus egress to scrape intra-ns alertmanager on :9093 + :8080 (reloader)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: prometheus-allow-alertmanager-scrape-egress
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 9093
+          protocol: TCP
+        - port: 8080
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: alertmanager
+---
+# Allow Prometheus egress to scrape intra-ns prometheus-operator on :10250 (https)
+# The operator exposes metrics on containerPort 10250 (named "https")
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: prometheus-allow-operator-scrape-egress
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 10250
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
+---
+# Allow Prometheus egress to scrape intra-ns prometheus itself (self-scrape on :9090 + reloader :8080)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: prometheus-allow-self-scrape-egress
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 9090
+          protocol: TCP
+        - port: 8080
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+---
+# Allow Prometheus egress to scrape cert-manager metrics on :9402
+# ServiceMonitor cert-manager/cert-manager targets app.kubernetes.io/name=cert-manager pods
+# containerPort: 9402 (name: http-metrics)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: prometheus-allow-cert-manager-scrape-egress
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 9402
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: cert-manager
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: cert-manager
+---
+# Allow Prometheus egress to scrape kube-system namespace targets:
+# - cilium-agent: containerPort 9962 (name: prometheus), pod label k8s-app=cilium
+# - hubble-metrics: containerPort 9965 (name: hubble-metrics) on same cilium-agent pods
+# - cilium-envoy: containerPort 9964 (name: envoy-metrics), pod label k8s-app=cilium-envoy
+# - cilium-operator: containerPort 9963, pod label io.cilium/app=operator
+# - coredns metrics: containerPort 9153, pod label k8s-app=kube-dns
+# - metrics-server: containerPort 10250 (name: https), pod label app.kubernetes.io/name=metrics-server
+# - reloader: containerPort 9090 (name: http), pod label app.kubernetes.io/name=reloader
+# - kubelet: node IPs on :10250 and :4194 (host-network, addressed via ipBlock below)
+# - apiserver: kubernetes service in default ns -> :443/:6443 (covered by k8s-api rule above)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: prometheus-allow-kube-system-cilium-agent-scrape-egress
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+  policyTypes: [Egress]
+  egress:
+    # cilium-agent metrics (:9962) and hubble-metrics (:9965) — same pod, k8s-app=cilium
+    - ports:
+        - port: 9962
+          protocol: TCP
+        - port: 9965
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: cilium
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: prometheus-allow-kube-system-cilium-envoy-scrape-egress
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+  policyTypes: [Egress]
+  egress:
+    # cilium-envoy metrics (:9964)
+    - ports:
+        - port: 9964
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: cilium-envoy
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: prometheus-allow-kube-system-cilium-operator-scrape-egress
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+  policyTypes: [Egress]
+  egress:
+    # cilium-operator metrics (:9963)
+    - ports:
+        - port: 9963
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              io.cilium/app: operator
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: prometheus-allow-kube-system-coredns-scrape-egress
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+  policyTypes: [Egress]
+  egress:
+    # coredns metrics (:9153)
+    - ports:
+        - port: 9153
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: prometheus-allow-kube-system-metrics-server-scrape-egress
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+  policyTypes: [Egress]
+  egress:
+    # metrics-server (:10250 https)
+    - ports:
+        - port: 10250
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: metrics-server
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: prometheus-allow-kube-system-reloader-scrape-egress
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+  policyTypes: [Egress]
+  egress:
+    # reloader metrics (:9090)
+    - ports:
+        - port: 9090
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: reloader
+---
+# Allow Prometheus egress to scrape kubelet on node IPs (:10250 https-metrics, :4194 cadvisor)
+# Kubelet runs in the host network — endpoints are node IPs, not namespaced pods.
+# The node CIDR is 10.87.42.0/24.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: prometheus-allow-kubelet-scrape-egress
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 10250
+          protocol: TCP
+        - port: 4194
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.87.42.0/24  # node CIDR — kubelet/cadvisor on host network
+---
+# Allow Prometheus egress to scrape longhorn-system on :9500
+# ServiceMonitor longhorn-prometheus-servicemonitor targets app=longhorn-manager pods
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: prometheus-allow-longhorn-scrape-egress
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 9500
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: longhorn-system
+          podSelector:
+            matchLabels:
+              app: longhorn-manager
+---
+# Allow Prometheus egress to scrape networking/blocky-primary and blocky-secondary on :4000
+# ServiceMonitors blocky-primary and blocky-secondary target port http -> :4000
+# Pod labels: app.kubernetes.io/name=blocky-primary / blocky-secondary
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: prometheus-allow-networking-blocky-scrape-egress
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 4000
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: networking
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: blocky-primary
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: networking
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: blocky-secondary
+
+# =============================================================================
+# Alertmanager — Phase 3b (#2945)
+# Pod label: app.kubernetes.io/name=alertmanager (StatefulSet, 2 replicas)
+# Listens on: :9093 (http-web), :9094 (mesh TCP/UDP), :8080 (reloader-web)
+# Ingress from: intra-ns prometheus :9093 (alert push)
+# Egress to: external SMTP :587 (email notifications), alertmanager mesh :9094 (intra-ns)
+# =============================================================================
+---
+# Default deny-all for alertmanager
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: alertmanager-default-deny
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: alertmanager
+  policyTypes: [Ingress, Egress]
+---
+# Allow DNS resolution
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: alertmanager-allow-dns
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: alertmanager
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+---
+# Allow ingress from intra-ns Prometheus on :9093 (alert push)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: alertmanager-allow-prometheus-ingress
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: alertmanager
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+      ports:
+        - port: 9093
+          protocol: TCP
+---
+# Allow ingress from intra-ns prometheus scrape on :9093 + reloader :8080
+# (Prometheus scrapes alertmanager metrics via ServiceMonitor)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: alertmanager-allow-prometheus-scrape-ingress
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: alertmanager
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+      ports:
+        - port: 9093
+          protocol: TCP
+        - port: 8080
+          protocol: TCP
+---
+# Allow alertmanager mesh (HA gossip) between the two alertmanager replicas on :9094
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: alertmanager-allow-mesh
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: alertmanager
+  policyTypes: [Ingress, Egress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: alertmanager
+      ports:
+        - port: 9094
+          protocol: TCP
+        - port: 9094
+          protocol: UDP
+  egress:
+    - ports:
+        - port: 9094
+          protocol: TCP
+        - port: 9094
+          protocol: UDP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: alertmanager
+---
+# Allow egress to external SMTP :587 (email notifications via smtp_smarthost)
+# Alertmanager is configured to send notifications via SMTP (not Discord webhooks).
+# RFC1918 ranges excluded — only external SMTP hosts.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: alertmanager-allow-external-smtp-egress
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: alertmanager
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 587
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+
+# =============================================================================
+# prometheus-operator — Phase 3b (#2945)
+# Pod label: app.kubernetes.io/name=kube-prometheus-stack-prometheus-operator
+# Listens on: :10250 (https metrics), :9443 (admission webhook)
+# Ingress: webhook from K8s API server (needed for MutatingWebhookConfiguration)
+# Egress to: K8s API only
+# =============================================================================
+---
+# Default deny-all for prometheus-operator
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: prometheus-operator-default-deny
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
+  policyTypes: [Ingress, Egress]
+---
+# Allow DNS resolution
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: prometheus-operator-allow-dns
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+---
+# Allow ingress from Prometheus on :10250 (scrape of operator metrics)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: prometheus-operator-allow-prometheus-scrape-ingress
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+      ports:
+        - port: 10250
+          protocol: TCP
+---
+# Allow ingress from K8s API server for admission webhook on :9443
+# The prometheus-operator registers admission webhooks; the API server calls back on :9443.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: prometheus-operator-allow-webhook-ingress
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - ipBlock:
+            cidr: 10.43.0.0/16  # Service CIDR (kubernetes.default.svc)
+        - ipBlock:
+            cidr: 10.87.42.2/32  # control plane node
+      ports:
+        - port: 9443
+          protocol: TCP
+---
+# Allow egress to K8s API server (reconciliation of PrometheusRule/ServiceMonitor/etc.)
+# ipBlock covers the cluster service CIDR and control-plane nodes (defence-in-depth).
+# CiliumNetworkPolicy prometheus-operator-allow-kube-apiserver is authoritative under Cilium.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: prometheus-operator-allow-k8s-api
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.43.0.0/16  # Service CIDR (kubernetes.default.svc)
+    - ports:
+        - port: 443
+          protocol: TCP
+        - port: 6443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.87.42.2/32  # control plane node (defence-in-depth)
+
+# =============================================================================
+# kube-state-metrics — Phase 3b (#2945)
+# Pod label: app.kubernetes.io/name=kube-state-metrics
+# Listens on: :8080 (http metrics), :8081 (telemetry)
+# Ingress from: intra-ns prometheus :8080 (scrape)
+# Egress to: K8s API (reads cluster state)
+# =============================================================================
+---
+# Default deny-all for kube-state-metrics
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kube-state-metrics-default-deny
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: kube-state-metrics
+  policyTypes: [Ingress, Egress]
+---
+# Allow DNS resolution
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kube-state-metrics-allow-dns
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: kube-state-metrics
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+---
+# Allow ingress from intra-ns Prometheus on :8080 (scrape)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kube-state-metrics-allow-prometheus-scrape-ingress
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: kube-state-metrics
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+      ports:
+        - port: 8080
+          protocol: TCP
+---
+# Allow egress to K8s API server (kube-state-metrics reads cluster state)
+# ipBlock covers the cluster service CIDR and control-plane nodes (defence-in-depth).
+# CiliumNetworkPolicy kube-state-metrics-allow-kube-apiserver is authoritative under Cilium.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kube-state-metrics-allow-k8s-api
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: kube-state-metrics
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.43.0.0/16  # Service CIDR (kubernetes.default.svc)
+    - ports:
+        - port: 443
+          protocol: TCP
+        - port: 6443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.87.42.2/32  # control plane node (defence-in-depth)

--- a/kubernetes/cluster0/apps/monitoring/kube-prometheus-stack/app/network-policy.yaml
+++ b/kubernetes/cluster0/apps/monitoring/kube-prometheus-stack/app/network-policy.yaml
@@ -518,6 +518,33 @@ spec:
             matchLabels:
               app: longhorn-manager
 ---
+# Allow Prometheus egress to blackbox-exporter on :9115 (Probe CRD prober URL)
+# When Prometheus processes a Probe resource it makes an outbound HTTP request to
+# blackbox-exporter's prober endpoint (blackbox-exporter.monitoring.svc:9115).
+# This is a Prometheus-initiated connection (not a scrape-ingress on blackbox-exporter).
+# containerPort 9115 verified from pod spec; covers all 15 Probe CRDs in the cluster.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: prometheus-allow-blackbox-exporter-probe-egress
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 9115
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus-blackbox-exporter
+---
 # Allow Prometheus egress to scrape networking/blocky-primary and blocky-secondary on :4000
 # ServiceMonitors blocky-primary and blocky-secondary target port http -> :4000
 # Pod labels: app.kubernetes.io/name=blocky-primary / blocky-secondary


### PR DESCRIPTION
## Summary

Phase 3b of the cluster NetworkPolicy rollout — default-deny lockdown for the 5 monitoring-namespace pods not covered by Phase 1, plus comprehensive Prometheus scrape-egress for all cluster scrape targets.

Closes #2945
Closes #2811

## What changed

### New: `grafana/app/network-policy.yaml`
- Default-deny (Ingress + Egress)
- DNS egress to kube-system :53
- Ingress from `networking`/traefik on :3000 (HTTPRoute via Gateway API)
- Ingress from intra-ns blackbox-exporter on :3000 (probe target)
- Egress to intra-ns prometheus on :9090 (datasource)
- Egress to external :443 with RFC1918 exclusion (plugins, avatars)

### Augmented: `kube-prometheus-stack/app/network-policy.yaml`

Preserves the Phase 3a databases scrape-egress rules verbatim. Adds:

**Prometheus** (`app.kubernetes.io/name: prometheus`):
- Default-deny
- DNS egress
- Ingress from intra-ns grafana :9090
- Ingress from intra-ns prometheus-operator :9090/:8080 (reload)
- Egress to intra-ns alertmanager :9093 (alert push + scrape)
- Egress to intra-ns kube-state-metrics :8080 (scrape)
- Egress to intra-ns prometheus-operator :10250 (scrape)
- Egress to intra-ns prometheus self :9090/:8080 (self-scrape)
- Egress to K8s API (ipBlock defence-in-depth + CiliumNP)
- Egress to all scrape-target namespaces (see table below)

**Alertmanager** (`app.kubernetes.io/name: alertmanager`):
- Default-deny
- DNS egress
- Ingress from intra-ns prometheus :9093
- Ingress from intra-ns prometheus scrape :9093/:8080
- Intra-ns HA mesh :9094 TCP+UDP (2-replica gossip)
- Egress to external SMTP :587 with RFC1918 exclusion (email notifications — _not_ Discord webhooks; alertmanager is configured with `smtp_smarthost`)

**prometheus-operator** (`app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator`):
- Default-deny
- DNS egress
- Ingress from intra-ns prometheus on :10250 (scrape)
- Ingress from K8s API server on :9443 (admission webhook callbacks)
- Egress to K8s API (ipBlock + CiliumNP)

**kube-state-metrics** (`app.kubernetes.io/name: kube-state-metrics`):
- Default-deny
- DNS egress
- Ingress from intra-ns prometheus :8080 (scrape)
- Egress to K8s API (ipBlock + CiliumNP)

### New: `kube-prometheus-stack/app/cilium-network-policy.yaml`
CiliumNetworkPolicy `toEntities: [kube-apiserver]` for Prometheus, prometheus-operator, and kube-state-metrics. Required because kubeProxyReplacement=true means the k3s API server uses the Cilium host-entity identity, which ipBlock rules don't match. Same pattern as #2829 (external-dns), #2947 (cnpg-operator).

## Prometheus scrape egress — verified from live cluster

All pod containerPorts verified with `kubectl -n <ns> get pod ... -o jsonpath='{.spec.containers[*].ports}'`.

| Namespace | Pod selector | containerPort | Notes |
|-----------|-------------|--------------|-------|
| monitoring (intra-ns) | kube-state-metrics | 8080 | http |
| monitoring (intra-ns) | alertmanager | 9093, 8080 | http-web + reloader |
| monitoring (intra-ns) | prometheus-operator | 10250 | https |
| monitoring (intra-ns) | prometheus (self) | 9090, 8080 | http-web + reloader |
| cert-manager | app.kubernetes.io/name=cert-manager | 9402 | http-metrics |
| kube-system | k8s-app=cilium | 9962, 9965 | cilium-agent metrics + hubble |
| kube-system | k8s-app=cilium-envoy | 9964 | envoy-metrics |
| kube-system | io.cilium/app=operator | 9963 | cilium-operator metrics |
| kube-system | k8s-app=kube-dns | 9153 | coredns metrics |
| kube-system | app.kubernetes.io/name=metrics-server | 10250 | https |
| kube-system | app.kubernetes.io/name=reloader | 9090 | http |
| kube-system | (node IPs via ipBlock 10.87.42.0/24) | 10250, 4194 | kubelet + cadvisor |
| longhorn-system | app=longhorn-manager | 9500 | manager |
| networking | app.kubernetes.io/name=blocky-primary | 4000 | http |
| networking | app.kubernetes.io/name=blocky-secondary | 4000 | http |
| databases | cnpg.io/cluster exists | 9187 | postgres-exporter (Phase 3a, preserved) |
| databases | app.kubernetes.io/name=cloudnative-pg | 8080 | operator metrics (Phase 3a, preserved) |

## AC checklist

- [x] All 5 pods have NetworkPolicy with `policyTypes: [Ingress, Egress]` and default-deny shape
- [x] All 5 policies include DNS egress block to kube-system :53 UDP+TCP
- [x] `grafana`: ingress from networking/traefik + egress to prometheus :9090 + external :443
- [x] `prometheus`: ingress from grafana :9090 + prometheus-operator (reload)
- [x] `prometheus`: egress to K8s API + alertmanager :9093 + all scrape-target namespaces with specific pod selectors
- [x] Existing databases scrape-egress rules from #2947 preserved (not duplicated, not deleted)
- [x] `alertmanager`: ingress from prometheus :9093 + egress to external SMTP :587
- [x] `prometheus-operator`: K8s API egress only + admission webhook ingress on :9443
- [x] `kube-state-metrics`: ingress from prometheus :8080 + K8s API egress
- [x] Phase-1 pods (blackbox-exporter, changedetection-io, changedetection-browser, uptime-kuma) NOT modified
- [x] `kubectl kustomize kubernetes/cluster0/apps/monitoring` builds cleanly
- [x] Every cross-namespace rule uses AND-shape (namespaceSelector + podSelector as siblings)
- [x] Every intra-namespace rule includes `namespaceSelector: monitoring` alongside podSelector
- [x] Scrape-egress uses actual pod containerPorts (not service ports) — verified live
- [x] Alertmanager external egress uses RFC1918-excluded ipBlock pattern
- [x] CiliumNetworkPolicy with `toEntities: [kube-apiserver]` for Prometheus, operator, ksm
- [x] No `namespaceSelector: {}` wildcard anywhere
- [x] Grafana not reachable on :9090 (no such ingress rule; only :3000 is open)

## Notes for coordinator

- **Alertmanager SMTP port**: Issue body says `external :443 (Discord webhook)` but the actual alertmanager config uses SMTP on :587. Policy allows :587 not :443. Discord is not configured in this cluster.
- **Kubelet scrape**: uses ipBlock `10.87.42.0/24` (node CIDR) for :10250/:4194 since kubelet runs in host network, not a namespaced pod.
- **CNPG :8000 (re #2948)**: The :8000 instance-manager port in the in-flight fix is for CNPG operator→cluster management, not Prometheus scrape — no additional scrape egress needed here.