### PR TITLE
fix(netpol): complete SeaweedFS mesh policy source-list gaps

### DIFF
--- a/kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/network-policy.yaml
+++ b/kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/network-policy.yaml
@@ -45,7 +45,7 @@ spec:
             matchLabels:
               kubernetes.io/metadata.name: kube-system
 ---
-# Allow intra-ns ingress from volume/filer/s3 on :9333/:19333
+# Allow intra-ns ingress from volume/filer/s3/master on :9333/:19333
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -81,6 +81,13 @@ spec:
             matchLabels:
               app.kubernetes.io/name: seaweedfs
               app.kubernetes.io/component: s3
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: seaweedfs
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: seaweedfs
+              app.kubernetes.io/component: master
       ports:
         - port: 9333
           protocol: TCP
@@ -133,7 +140,7 @@ spec:
             matchLabels:
               kubernetes.io/metadata.name: kube-system
 ---
-# Allow intra-ns ingress from filer and peer volume pods
+# Allow intra-ns ingress from master/filer/s3/volume pods on :8080/:18080
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -162,11 +169,53 @@ spec:
             matchLabels:
               app.kubernetes.io/name: seaweedfs
               app.kubernetes.io/component: volume
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: seaweedfs
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: seaweedfs
+              app.kubernetes.io/component: s3
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: seaweedfs
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: seaweedfs
+              app.kubernetes.io/component: master
       ports:
         - port: 8080
           protocol: TCP
         - port: 18080
           protocol: TCP
+---
+# Allow egress from master to volume (admin/health) on :8080/:18080
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: seaweedfs-master-allow-intra-egress
+  namespace: seaweedfs
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: seaweedfs
+      app.kubernetes.io/component: master
+  policyTypes:
+    - Egress
+  egress:
+    - ports:
+        - port: 8080
+          protocol: TCP
+        - port: 18080
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: seaweedfs
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: seaweedfs
+              app.kubernetes.io/component: volume
 ---
 # Allow egress from volume to master (register/heartbeat) and peer volumes
 apiVersion: networking.k8s.io/v1
@@ -255,7 +304,7 @@ spec:
             matchLabels:
               kubernetes.io/metadata.name: kube-system
 ---
-# Allow intra-ns ingress from s3 pod on :8888/:18888
+# Allow intra-ns ingress from master/volume/s3/filer on :8888/:18888
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -277,6 +326,27 @@ spec:
             matchLabels:
               app.kubernetes.io/name: seaweedfs
               app.kubernetes.io/component: s3
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: seaweedfs
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: seaweedfs
+              app.kubernetes.io/component: master
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: seaweedfs
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: seaweedfs
+              app.kubernetes.io/component: volume
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: seaweedfs
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: seaweedfs
+              app.kubernetes.io/component: filer
       ports:
         - port: 8888
           protocol: TCP
@@ -448,7 +518,7 @@ spec:
         - port: 8333
           protocol: TCP
 ---
-# Allow egress from s3 to filer and master
+# Allow egress from s3 to filer, master, and volume (direct object reads)
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -488,3 +558,16 @@ spec:
             matchLabels:
               app.kubernetes.io/name: seaweedfs
               app.kubernetes.io/component: master
+    - ports:
+        - port: 8080
+          protocol: TCP
+        - port: 18080
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: seaweedfs
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: seaweedfs
+              app.kubernetes.io/component: volume


### PR DESCRIPTION
## Summary

Full mesh-completeness sweep of all four SeaweedFS component ingress/egress policies, triggered by Hubble showing `seaweedfs-s3 → seaweedfs-volume:8080 DROPPED`.

Closes #2954

## Gaps found and fixed

### `seaweedfs-volume-allow-intra-ingress`
- ✅ Added **s3** as source — direct object reads bypass filer for already-located objects
- ✅ Added **master** as source — admin/health calls to volume pods

### `seaweedfs-master-allow-intra-ingress`
- ✅ Added **master** as source — peer election traffic between master replicas

### `seaweedfs-filer-allow-intra-ingress`
- ✅ Added **master** as source — admin callbacks from master to filer
- ✅ Added **volume** as source — metadata callbacks from volume to filer
- ✅ Added **filer** as source — peer replication between filer replicas

### `seaweedfs-master-allow-intra-egress` (NEW policy)
- ✅ New policy added — master → volume :8080/:18080 (admin/health)
- Previously missing entirely; master default-deny was blocking these flows

### `seaweedfs-s3-allow-intra-egress`
- ✅ Added **volume** as egress target on :8080/:18080 (direct object reads)

## Already correct (no change)

- `seaweedfs-s3-allow-intra-ingress`: only external sources (Traefik/CNPG) — no intra-ns ingress needed
- `seaweedfs-volume-allow-intra-egress`: master + peer volume already present
- `seaweedfs-filer-allow-intra-egress`: master + volume already present

## Mesh completeness after this PR

| Receiver | Sources | Status |
|---|---|---|
| master | volume ✅, filer ✅, s3 ✅, master ✅ | Complete |
| volume | master ✅, filer ✅, s3 ✅, volume ✅ | Complete |
| filer | master ✅, volume ✅, s3 ✅, filer ✅ | Complete |
| s3 | external only (Traefik, CNPG) ✅ | Complete |

## Files changed

- `kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/network-policy.yaml` — only file modified

## Verification

`kubectl kustomize kubernetes/cluster0/apps/seaweedfs/seaweedfs/app` builds cleanly (18 NetworkPolicy resources).