### PR TITLE
fix(netpol): add CiliumNetworkPolicy ingress fromEntities:kube-apiserver on cnpg webhook

### DIFF
--- a/kubernetes/cluster0/apps/databases/cloudnative-pg/chart/cilium-network-policy.yaml
+++ b/kubernetes/cluster0/apps/databases/cloudnative-pg/chart/cilium-network-policy.yaml
@@ -19,3 +19,10 @@ spec:
   egress:
     - toEntities:
         - kube-apiserver
+  ingress:
+    - fromEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "9443"
+              protocol: TCP


### PR DESCRIPTION
## Problem

Three Flux Kustomizations are stuck `Ready=False` because the K8s apiserver cannot reach the CNPG mutating webhook (`mscheduledbackup.cnpg.io`) at port 9443. Cilium silently bypasses `ipBlock` rules for `kube-apiserver` entity traffic when `kubeProxyReplacement=true`, so the existing `cloudnative-pg-allow-webhook-ingress` NetworkPolicy (ipBlock) has no effect in practice.

## Fix

Adds an `ingress` block to the existing `cloudnative-pg-allow-kube-apiserver` CiliumNetworkPolicy, scoped to:
- **from**: `kube-apiserver` entity only
- **to**: port 9443 TCP only (webhook port)

The standard NetworkPolicy `cloudnative-pg-allow-webhook-ingress` (ipBlock) is left untouched for defence-in-depth.

## Pattern

This is the same Cilium-vs-ipBlock root cause fixed previously:
- #2829 — external-dns egress to apiserver
- #2947 — cnpg egress to apiserver (Phase 3a)

The same pattern will apply to cert-manager-webhook in Phase 4b (#2951).

## Changes

Single file: `kubernetes/cluster0/apps/databases/cloudnative-pg/chart/cilium-network-policy.yaml`
Diff: +7 lines (ingress block added after existing egress block).

Closes #2956