### PR TITLE
fix(netpol): patch Phase 3b gaps — grafana uptime-kuma, cert-manager pod-selector, prometheus self-scrape ingress

### DIFF
--- a/kubernetes/cluster0/apps/monitoring/grafana/app/network-policy.yaml
+++ b/kubernetes/cluster0/apps/monitoring/grafana/app/network-policy.yaml
@@ -90,6 +90,30 @@ spec:
         - port: 3000
           protocol: TCP
 ---
+# Allow ingress from uptime-kuma (intra-ns probe on :3000)
+# uptime-kuma probes grafana directly from the monitoring namespace
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: grafana-allow-uptime-kuma-ingress
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: grafana
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: uptime-kuma
+      ports:
+        - port: 3000
+          protocol: TCP
+---
 # Allow egress to intra-ns Prometheus on :9090 (datasource queries)
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/kubernetes/cluster0/apps/monitoring/kube-prometheus-stack/app/network-policy.yaml
+++ b/kubernetes/cluster0/apps/monitoring/kube-prometheus-stack/app/network-policy.yaml
@@ -297,8 +297,8 @@ spec:
               app.kubernetes.io/name: prometheus
 ---
 # Allow Prometheus egress to scrape cert-manager metrics on :9402
-# ServiceMonitor cert-manager/cert-manager targets app.kubernetes.io/name=cert-manager pods
-# containerPort: 9402 (name: http-metrics)
+# All three cert-manager pods (controller, cainjector, webhook) share
+# app.kubernetes.io/instance=cert-manager and expose :9402 (http-metrics)
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -319,7 +319,33 @@ spec:
               kubernetes.io/metadata.name: cert-manager
           podSelector:
             matchLabels:
-              app.kubernetes.io/name: cert-manager
+              app.kubernetes.io/instance: cert-manager
+---
+# Allow Prometheus self-scrape ingress — receiving end of the self-scrape
+# (egress is already covered by prometheus-allow-self-scrape-egress)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: prometheus-allow-self-scrape-ingress
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+      ports:
+        - port: 9090
+          protocol: TCP
+        - port: 8080
+          protocol: TCP
 ---
 # Allow Prometheus egress to scrape kube-system namespace targets:
 # - cilium-agent: containerPort 9962 (name: prometheus), pod label k8s-app=cilium


### PR DESCRIPTION
## Summary

Three surgical fix-forward changes to Phase 3b network policies in `kubernetes/cluster0/apps/monitoring/`.

### 1. Grafana — add uptime-kuma ingress (`grafana/app/network-policy.yaml`)

Added `grafana-allow-uptime-kuma-ingress` policy allowing intra-ns uptime-kuma → grafana on :3000. Uses AND-shape `namespaceSelector: monitoring` + `podSelector: app.kubernetes.io/name=uptime-kuma`. Existing blackbox-exporter and Traefik allows are untouched.

### 2. Cert-manager scrape egress — fix pod selector (`kube-prometheus-stack/app/network-policy.yaml`)

Changed `prometheus-allow-cert-manager-scrape-egress` to match by `app.kubernetes.io/instance: cert-manager` (Option A). This catches all three cert-manager pods: controller (`name=cert-manager`), cainjector (`name=cainjector`), and webhook (`name=webhook`). Previously only the controller matched.

### 3. Prometheus self-scrape ingress (`kube-prometheus-stack/app/network-policy.yaml`)

Added `prometheus-allow-self-scrape-ingress` policy — the receiving-end counterpart to the existing `prometheus-allow-self-scrape-egress`. AND-shape, intra-ns prometheus → prometheus on :9090+:8080.

### trust-manager check

`kubectl get servicemonitor -n cert-manager` returns only `cert-manager` (no trust-manager ServiceMonitor). No additional egress rule needed.

Closes #2958