### PR TITLE
fix(netpol): add K8s API egress to CNPG cluster pods

### DIFF
--- a/kubernetes/cluster0/apps/auth/authelia/db/cilium-network-policy.yaml
+++ b/kubernetes/cluster0/apps/auth/authelia/db/cilium-network-policy.yaml
@@ -1,0 +1,22 @@
+---
+# CiliumNetworkPolicy: allow authelia-postgres-v17 cluster pods egress to the K8s API server.
+#
+# Standard K8s NetworkPolicy ipBlock rules are silently bypassed by Cilium when
+# kubeProxyReplacement=true because the k3s API server runs in the host network
+# namespace and Cilium assigns it the 'kube-apiserver' entity identity rather
+# than a pod identity or IP. The companion ipBlock NetworkPolicy is still kept
+# for defence-in-depth, but this CiliumNetworkPolicy is what actually enforces
+# the allow in practice. Required by CNPG instance-manager wait-for-get-cluster
+# init step. See #2960.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: authelia-postgres-v17-allow-kube-apiserver-egress
+  namespace: databases
+spec:
+  endpointSelector:
+    matchLabels:
+      cnpg.io/cluster: authelia-postgres-v17
+  egress:
+    - toEntities:
+        - kube-apiserver

--- a/kubernetes/cluster0/apps/auth/authelia/db/kustomization.yaml
+++ b/kubernetes/cluster0/apps/auth/authelia/db/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - cluster-v17.yaml
   - scheduled-backup.yaml
   - network-policy.yaml
+  - cilium-network-policy.yaml

--- a/kubernetes/cluster0/apps/auth/authelia/db/network-policy.yaml
+++ b/kubernetes/cluster0/apps/auth/authelia/db/network-policy.yaml
@@ -171,3 +171,28 @@ spec:
       ports:
         - port: 9187
           protocol: TCP
+---
+# Allow egress to Kubernetes API server (in-cluster service CIDR + control-plane CIDR)
+# Required by CNPG instance-manager wait-for-get-cluster init step
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: authelia-postgres-v17-allow-k8s-api-egress
+  namespace: databases
+spec:
+  podSelector:
+    matchLabels:
+      cnpg.io/cluster: authelia-postgres-v17
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 10.43.0.0/16  # K8s service CIDR (kubernetes.default.svc)
+        - ipBlock:
+            cidr: 10.87.42.0/24  # control-plane node CIDR
+      ports:
+        - port: 443
+          protocol: TCP
+        - port: 6443
+          protocol: TCP

--- a/kubernetes/cluster0/apps/home/home-assistant/db/cilium-network-policy.yaml
+++ b/kubernetes/cluster0/apps/home/home-assistant/db/cilium-network-policy.yaml
@@ -1,0 +1,22 @@
+---
+# CiliumNetworkPolicy: allow home-assistant-postgres-v18 cluster pods egress to the K8s API server.
+#
+# Standard K8s NetworkPolicy ipBlock rules are silently bypassed by Cilium when
+# kubeProxyReplacement=true because the k3s API server runs in the host network
+# namespace and Cilium assigns it the 'kube-apiserver' entity identity rather
+# than a pod identity or IP. The companion ipBlock NetworkPolicy is still kept
+# for defence-in-depth, but this CiliumNetworkPolicy is what actually enforces
+# the allow in practice. Required by CNPG instance-manager wait-for-get-cluster
+# init step. See #2960.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: home-assistant-postgres-v18-allow-kube-apiserver-egress
+  namespace: databases
+spec:
+  endpointSelector:
+    matchLabels:
+      cnpg.io/cluster: home-assistant-postgres-v18
+  egress:
+    - toEntities:
+        - kube-apiserver

--- a/kubernetes/cluster0/apps/home/home-assistant/db/kustomization.yaml
+++ b/kubernetes/cluster0/apps/home/home-assistant/db/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ./scheduled-backup.yaml
   - ./cluster-v18.yaml
   - ./network-policy.yaml
+  - ./cilium-network-policy.yaml
 labels:
   - pairs:
       app.kubernetes.io/name: home-assistant

--- a/kubernetes/cluster0/apps/home/home-assistant/db/network-policy.yaml
+++ b/kubernetes/cluster0/apps/home/home-assistant/db/network-policy.yaml
@@ -171,3 +171,28 @@ spec:
       ports:
         - port: 9187
           protocol: TCP
+---
+# Allow egress to Kubernetes API server (in-cluster service CIDR + control-plane CIDR)
+# Required by CNPG instance-manager wait-for-get-cluster init step
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: home-assistant-postgres-v18-allow-k8s-api-egress
+  namespace: databases
+spec:
+  podSelector:
+    matchLabels:
+      cnpg.io/cluster: home-assistant-postgres-v18
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 10.43.0.0/16  # K8s service CIDR (kubernetes.default.svc)
+        - ipBlock:
+            cidr: 10.87.42.0/24  # control-plane node CIDR
+      ports:
+        - port: 443
+          protocol: TCP
+        - port: 6443
+          protocol: TCP

--- a/kubernetes/cluster0/apps/media/miniflux/db/cilium-network-policy.yaml
+++ b/kubernetes/cluster0/apps/media/miniflux/db/cilium-network-policy.yaml
@@ -1,0 +1,22 @@
+---
+# CiliumNetworkPolicy: allow miniflux-postgres-v17 cluster pods egress to the K8s API server.
+#
+# Standard K8s NetworkPolicy ipBlock rules are silently bypassed by Cilium when
+# kubeProxyReplacement=true because the k3s API server runs in the host network
+# namespace and Cilium assigns it the 'kube-apiserver' entity identity rather
+# than a pod identity or IP. The companion ipBlock NetworkPolicy is still kept
+# for defence-in-depth, but this CiliumNetworkPolicy is what actually enforces
+# the allow in practice. Required by CNPG instance-manager wait-for-get-cluster
+# init step. See #2960.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: miniflux-postgres-v17-allow-kube-apiserver-egress
+  namespace: databases
+spec:
+  endpointSelector:
+    matchLabels:
+      cnpg.io/cluster: miniflux-postgres-v17
+  egress:
+    - toEntities:
+        - kube-apiserver

--- a/kubernetes/cluster0/apps/media/miniflux/db/kustomization.yaml
+++ b/kubernetes/cluster0/apps/media/miniflux/db/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - scheduled-backup.yaml
   - secret.sops.yaml
   - network-policy.yaml
+  - cilium-network-policy.yaml

--- a/kubernetes/cluster0/apps/media/miniflux/db/network-policy.yaml
+++ b/kubernetes/cluster0/apps/media/miniflux/db/network-policy.yaml
@@ -171,3 +171,28 @@ spec:
       ports:
         - port: 9187
           protocol: TCP
+---
+# Allow egress to Kubernetes API server (in-cluster service CIDR + control-plane CIDR)
+# Required by CNPG instance-manager wait-for-get-cluster init step
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: miniflux-postgres-v17-allow-k8s-api-egress
+  namespace: databases
+spec:
+  podSelector:
+    matchLabels:
+      cnpg.io/cluster: miniflux-postgres-v17
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 10.43.0.0/16  # K8s service CIDR (kubernetes.default.svc)
+        - ipBlock:
+            cidr: 10.87.42.0/24  # control-plane node CIDR
+      ports:
+        - port: 443
+          protocol: TCP
+        - port: 6443
+          protocol: TCP


### PR DESCRIPTION
## Summary

CNPG instance-manager's `wait-for-get-cluster` init step needs to reach the K8s API server to read its own Cluster spec before postgres starts. Phase 3a (#2947) default-denied all CNPG cluster pod egress but missed the K8s API allow, causing new/replacement pods (`authelia-postgres-v17-7`, `miniflux-postgres-v17-2`) to loop on connection timeouts.

## Changes

Adds the dual-policy pattern (standard NetworkPolicy + CiliumNetworkPolicy) per cluster, consistent with how the operator was fixed in #2947:

**Per cluster (authelia-postgres-v17, home-assistant-postgres-v18, miniflux-postgres-v17):**
- **`*-allow-k8s-api-egress`** NetworkPolicy: TCP :443/:6443 to service CIDR `10.43.0.0/16` and control-plane CIDR `10.87.42.0/24`
- **`*-allow-kube-apiserver-egress`** CiliumNetworkPolicy: `toEntities: [kube-apiserver]` — required under `kubeProxyReplacement=true` where Cilium assigns the API server an entity identity, not an IP

Files modified:
- `apps/auth/authelia/db/network-policy.yaml` (appended policy)
- `apps/auth/authelia/db/cilium-network-policy.yaml` (new file)
- `apps/auth/authelia/db/kustomization.yaml` (added cilium-network-policy.yaml)
- `apps/home/home-assistant/db/network-policy.yaml` (appended policy)
- `apps/home/home-assistant/db/cilium-network-policy.yaml` (new file)
- `apps/home/home-assistant/db/kustomization.yaml` (added cilium-network-policy.yaml)
- `apps/media/miniflux/db/network-policy.yaml` (appended policy)
- `apps/media/miniflux/db/cilium-network-policy.yaml` (new file)
- `apps/media/miniflux/db/kustomization.yaml` (added cilium-network-policy.yaml)

## Post-merge verification

```bash
flux reconcile source git home-ops-cluster0
kubectl -n databases get networkpolicy | grep k8s-api-egress
kubectl -n databases get ciliumnetworkpolicy | grep kube-apiserver-egress
kubectl -n databases get pods -l cnpg.io/cluster -o wide
kubectl get cluster -A
```

Closes #2960