### PR TITLE
fix(netpol): allow Prometheus scrape egress to host-networked targets (Cilium/envoy/Hubble/kubelet)

### DIFF
--- a/kubernetes/cluster0/apps/monitoring/kube-prometheus-stack/app/cilium-network-policy.yaml
+++ b/kubernetes/cluster0/apps/monitoring/kube-prometheus-stack/app/cilium-network-policy.yaml
@@ -20,6 +20,19 @@ spec:
   egress:
     - toEntities:
         - kube-apiserver
+    - toEntities:           # host-networked scrape targets (Cilium agent/envoy/Hubble/kubelet)
+        - host
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "9962"
+              protocol: TCP
+            - port: "9964"
+              protocol: TCP
+            - port: "9965"
+              protocol: TCP
+            - port: "10250"
+              protocol: TCP
 ---
 # CiliumNetworkPolicy: allow prometheus-operator egress to the K8s API server.
 apiVersion: cilium.io/v2

--- a/kubernetes/cluster0/apps/monitoring/kube-prometheus-stack/app/cilium-network-policy.yaml
+++ b/kubernetes/cluster0/apps/monitoring/kube-prometheus-stack/app/cilium-network-policy.yaml
@@ -20,12 +20,14 @@ spec:
   egress:
     - toEntities:
         - kube-apiserver
-    - toEntities:           # host-networked scrape targets (Cilium agent/envoy/Hubble/kubelet)
+    - toEntities:           # host-networked scrape targets (Cilium agent/envoy/Hubble/operator/kubelet)
         - host
         - remote-node
       toPorts:
         - ports:
             - port: "9962"
+              protocol: TCP
+            - port: "9963"
               protocol: TCP
             - port: "9964"
               protocol: TCP

--- a/kubernetes/cluster0/apps/monitoring/kube-prometheus-stack/app/network-policy.yaml
+++ b/kubernetes/cluster0/apps/monitoring/kube-prometheus-stack/app/network-policy.yaml
@@ -521,8 +521,9 @@ spec:
             cidr: 10.87.42.0/24  # node CIDR — kubelet/cadvisor on host network
 ---
 # Allow Prometheus egress to host-networked scrape targets on the node CIDR (defence-in-depth).
-# Cilium agent (:9962), Cilium envoy (:9964), Hubble (:9965), kubelet/metrics-server (:10250)
-# all run with hostNetwork=true; Cilium assigns them the 'host'/'remote-node' entity identity.
+# Cilium agent (:9962), Cilium operator (:9963), Cilium envoy (:9964), Hubble (:9965),
+# kubelet/metrics-server (:10250) all run with hostNetwork=true; Cilium assigns them the
+# 'host'/'remote-node' entity identity, so podSelector rules don't match.
 # The CiliumNetworkPolicy prometheus-allow-kube-apiserver (egress block 2) is authoritative;
 # this ipBlock rule is the standard-NetworkPolicy companion for defence-in-depth. See #2962.
 apiVersion: networking.k8s.io/v1
@@ -538,6 +539,8 @@ spec:
   egress:
     - ports:
         - port: 9962
+          protocol: TCP
+        - port: 9963
           protocol: TCP
         - port: 9964
           protocol: TCP

--- a/kubernetes/cluster0/apps/monitoring/kube-prometheus-stack/app/network-policy.yaml
+++ b/kubernetes/cluster0/apps/monitoring/kube-prometheus-stack/app/network-policy.yaml
@@ -520,6 +520,35 @@ spec:
         - ipBlock:
             cidr: 10.87.42.0/24  # node CIDR — kubelet/cadvisor on host network
 ---
+# Allow Prometheus egress to host-networked scrape targets on the node CIDR (defence-in-depth).
+# Cilium agent (:9962), Cilium envoy (:9964), Hubble (:9965), kubelet/metrics-server (:10250)
+# all run with hostNetwork=true; Cilium assigns them the 'host'/'remote-node' entity identity.
+# The CiliumNetworkPolicy prometheus-allow-kube-apiserver (egress block 2) is authoritative;
+# this ipBlock rule is the standard-NetworkPolicy companion for defence-in-depth. See #2962.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: prometheus-allow-host-network-scrape-egress
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 9962
+          protocol: TCP
+        - port: 9964
+          protocol: TCP
+        - port: 9965
+          protocol: TCP
+        - port: 10250
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.87.42.0/24  # node CIDR — host-networked targets (Cilium/Hubble/kubelet)
+---
 # Allow Prometheus egress to scrape longhorn-system on :9500
 # ServiceMonitor longhorn-prometheus-servicemonitor targets app=longhorn-manager pods
 apiVersion: networking.k8s.io/v1


### PR DESCRIPTION
## Summary

Prometheus was silently dropping scrape connections to four host-networked metrics endpoints every cycle. The drops started at the merge of #2953, which added comprehensive pod-selector-based scrape egress rules but did not cover host-networked targets.

For host-networked pods, Cilium assigns the identity `reserved:host` or `reserved:remote-node` (same-node vs remote node). Standard `podSelector` egress rules don't match these entities — only a `toEntities` block in a CiliumNetworkPolicy does.

## Changes

### `cilium-network-policy.yaml`
Added a second `egress` block to the existing `prometheus-allow-kube-apiserver` CiliumNetworkPolicy, permitting egress to `toEntities: [host, remote-node]` scoped to the four affected ports:
- `:9962` — Cilium agent metrics
- `:9964` — Cilium envoy metrics
- `:9965` — Hubble metrics
- `:10250` — kubelet / metrics-server

The existing `toEntities: [kube-apiserver]` block is preserved unchanged.

### `network-policy.yaml`
Added a new `prometheus-allow-host-network-scrape-egress` standard NetworkPolicy permitting egress on the same four ports to node CIDR `10.87.42.0/24` (defence-in-depth ipBlock companion — same dual-policy pattern as the kubelet scrape rule).

## Verification

`kubectl kustomize kubernetes/cluster0/apps/monitoring` builds cleanly (exit 0).

Closes #2962