### PR TITLE
fix(seaweedfs): remove redundant s3.createBuckets post-upgrade hook

### DIFF
--- a/kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/helm-release.yaml
@@ -69,6 +69,3 @@ spec:
       replicas: 1
       logs:
         type: emptyDir
-      createBuckets:
-        - name: postgresql
-          anonymousRead: false


### PR DESCRIPTION
## Summary

Removes the `s3.createBuckets` block from the SeaweedFS HelmRelease. The chart renders this as a `post-install,post-upgrade` Helm hook Job (`seaweedfs-bucket-hook`) that polls the master endpoint for up to 5 minutes before running `s3.bucket.create --name postgresql`. During chart upgrades the Longhorn-backed master pod startup exceeds that window, the hook times out, and Flux exhausts retries — which is exactly what stalled the 4.25.0 → 4.25.1 bump in #2964.

The `postgresql` bucket already exists and is in active use by all three CNPG clusters (WAL archiving working continuously since #2929 landed). The hook's only useful action is idempotent and unnecessary going forward.

## Change

3-line removal in `kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/helm-release.yaml`:

```diff
       logs:
         type: emptyDir
-      createBuckets:
-        - name: postgresql
-          anonymousRead: false
```

No other field is touched — chart version, timeouts, retries, `existingConfigSecret: seaweedfs-s3-config`, and all other `s3.*` keys are preserved unchanged.

## Verification

- `kubectl kustomize kubernetes/cluster0/apps/seaweedfs/seaweedfs/app` builds cleanly.
- `rg -n 'createBuckets|bucket-hook' kubernetes/cluster0/apps/seaweedfs/` returns no matches.
- No SOPS-encrypted material touched.

Post-merge recovery steps (job cleanup, `flux suspend/resume hr` to clear `RetriesExceeded`) are out of scope per the issue and will be performed by the coordinator.

Closes #2966