### PR TITLE
feat(netpol): Traefik default-deny + namespace-label egress (phase 4a)

### DIFF
--- a/kubernetes/cluster0/apps/auth/namespace.yaml
+++ b/kubernetes/cluster0/apps/auth/namespace.yaml
@@ -5,4 +5,5 @@ metadata:
   name: auth
   labels:
     kustomize.toolkit.fluxcd.io/prune: disabled
+    netpol.home-ops/traefik-backend: "true"
 

--- a/kubernetes/cluster0/apps/home/namespace.yaml
+++ b/kubernetes/cluster0/apps/home/namespace.yaml
@@ -5,4 +5,5 @@ metadata:
   name: home
   labels:
     kustomize.toolkit.fluxcd.io/prune: disabled
+    netpol.home-ops/traefik-backend: "true"
 

--- a/kubernetes/cluster0/apps/kube-system/namespace.yaml
+++ b/kubernetes/cluster0/apps/kube-system/namespace.yaml
@@ -5,4 +5,5 @@ metadata:
   name: kube-system
   labels:
     kustomize.toolkit.fluxcd.io/prune: disabled
+    netpol.home-ops/traefik-backend: "true"
 

--- a/kubernetes/cluster0/apps/longhorn-system/namespace.yaml
+++ b/kubernetes/cluster0/apps/longhorn-system/namespace.yaml
@@ -5,4 +5,5 @@ metadata:
   name: longhorn-system
   labels:
     kustomize.toolkit.fluxcd.io/prune: disabled
+    netpol.home-ops/traefik-backend: "true"
 

--- a/kubernetes/cluster0/apps/media/namespace.yaml
+++ b/kubernetes/cluster0/apps/media/namespace.yaml
@@ -5,4 +5,5 @@ metadata:
   name: media
   labels:
     kustomize.toolkit.fluxcd.io/prune: disabled
+    netpol.home-ops/traefik-backend: "true"
 

--- a/kubernetes/cluster0/apps/monitoring/namespace.yaml
+++ b/kubernetes/cluster0/apps/monitoring/namespace.yaml
@@ -5,4 +5,5 @@ metadata:
   name: monitoring
   labels:
     kustomize.toolkit.fluxcd.io/prune: disabled
+    netpol.home-ops/traefik-backend: "true"
 

--- a/kubernetes/cluster0/apps/networking/namespace.yaml
+++ b/kubernetes/cluster0/apps/networking/namespace.yaml
@@ -5,4 +5,5 @@ metadata:
   name: networking
   labels:
     kustomize.toolkit.fluxcd.io/prune: disabled
+    netpol.home-ops/traefik-backend: "true"
 

--- a/kubernetes/cluster0/apps/networking/traefik/app/cilium-network-policy.yaml
+++ b/kubernetes/cluster0/apps/networking/traefik/app/cilium-network-policy.yaml
@@ -1,0 +1,22 @@
+---
+# CiliumNetworkPolicy: allow Traefik egress to the K8s API server.
+#
+# Standard K8s NetworkPolicy ipBlock rules are silently bypassed by Cilium when
+# kubeProxyReplacement=true because the k3s API server runs in the host network
+# namespace and Cilium assigns it the 'kube-apiserver' entity identity rather
+# than a pod identity or IP. The companion ipBlock NetworkPolicy
+# (traefik-allow-k8s-api) is kept for defence-in-depth, but this
+# CiliumNetworkPolicy is what actually enforces the allow in practice. See
+# #2829 (external-dns fix-forward) and #2947 (cnpg) for the same pattern.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: traefik-allow-kube-apiserver
+  namespace: networking
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: traefik
+  egress:
+    - toEntities:
+        - kube-apiserver

--- a/kubernetes/cluster0/apps/networking/traefik/app/kustomization.yaml
+++ b/kubernetes/cluster0/apps/networking/traefik/app/kustomization.yaml
@@ -4,6 +4,8 @@ kind: Kustomization
 resources:
   - ./helm-release.yaml
   - ./httpsredirect.yaml
+  - ./network-policy.yaml
+  - ./cilium-network-policy.yaml
 labels:
   - pairs:
       app.kubernetes.io/name: traefik

--- a/kubernetes/cluster0/apps/networking/traefik/app/network-policy.yaml
+++ b/kubernetes/cluster0/apps/networking/traefik/app/network-policy.yaml
@@ -87,6 +87,34 @@ spec:
         - port: 443
           protocol: TCP
 ---
+# Allow intra-pod ingress on :8080 from Traefik itself.
+# The `traefik-dashboard` Service in this namespace selects Traefik pods and
+# routes Service:80 → pod:8080 — the dashboard route terminates on the same
+# Traefik pods serving the request. AND-shape: namespaceSelector (networking)
+# + podSelector (traefik).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: traefik-allow-dashboard-ingress
+  namespace: networking
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: traefik
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: networking
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: traefik
+      ports:
+        - port: 8080
+          protocol: TCP
+---
 # Allow egress to any pod in any namespace labelled
 # netpol.home-ops/traefik-backend: "true", on any TCP port.
 #
@@ -114,6 +142,43 @@ spec:
       ports:
         - port: 1
           endPort: 65535
+          protocol: TCP
+---
+# Allow egress to off-cluster LAN backends fronted by manually-managed
+# EndpointSlices in this namespace (nas0, octoprint, unifi). Each is a stable
+# /32 on the home LAN; the namespace-label egress rule above does not cover
+# these because NetworkPolicy namespaceSelector matches pod destinations, not
+# ipBlock-backed Service endpoints. Ports are per the EndpointSlice spec for
+# each backend (see apps/networking/traefik/external-services/).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: traefik-allow-external-services-egress
+  namespace: networking
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: traefik
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 10.87.42.200/32  # nas0
+      ports:
+        - port: 5000
+          protocol: TCP
+    - to:
+        - ipBlock:
+            cidr: 10.87.1.74/32  # octoprint
+      ports:
+        - port: 80
+          protocol: TCP
+    - to:
+        - ipBlock:
+            cidr: 10.87.1.1/32  # unifi
+      ports:
+        - port: 443
           protocol: TCP
 ---
 # Allow egress to Authelia for forward-auth.

--- a/kubernetes/cluster0/apps/networking/traefik/app/network-policy.yaml
+++ b/kubernetes/cluster0/apps/networking/traefik/app/network-policy.yaml
@@ -1,0 +1,176 @@
+---
+# Default deny-all for Traefik pods.
+# Traefik is the cluster ingress entrypoint; every legitimate flow is explicitly
+# allowed by the sibling NetworkPolicies in this file. See Phase 4a design
+# (#2950) and the parent design doc (#2812).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: traefik-default-deny
+  namespace: networking
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: traefik
+  policyTypes:
+    - Ingress
+    - Egress
+---
+# Allow DNS resolution to CoreDNS in kube-system.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: traefik-allow-dns
+  namespace: networking
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: traefik
+  policyTypes:
+    - Egress
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+---
+# Allow external ingress on :80 and :443 from anywhere.
+# Traefik IS the cluster entrypoint — no RFC1918 exclusion.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: traefik-allow-external-ingress
+  namespace: networking
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: traefik
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - port: 80
+          protocol: TCP
+        - port: 443
+          protocol: TCP
+---
+# Allow intra-ns ingress from cloudflared — the Cloudflare tunnel terminates
+# at Traefik via the local cluster network on :443.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: traefik-allow-cloudflared-ingress
+  namespace: networking
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: traefik
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: networking
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: cloudflared
+      ports:
+        - port: 443
+          protocol: TCP
+---
+# Allow egress to any pod in any namespace labelled
+# netpol.home-ops/traefik-backend: "true", on any TCP port.
+#
+# This is intentionally broad. The security boundary is enforced on the
+# backend side: each backend pod retains its existing tight
+# `allow-traefik-ingress` rule from Phase 1/2, scoped to Traefik's pod
+# selector and the backend's specific port. A Traefik compromise can still
+# only reach pods that opt in via their own ingress allow. See #2812 design.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: traefik-allow-backend-egress
+  namespace: networking
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: traefik
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              netpol.home-ops/traefik-backend: "true"
+      ports:
+        - port: 1
+          endPort: 65535
+          protocol: TCP
+---
+# Allow egress to Authelia for forward-auth.
+# AND-shape: namespaceSelector (auth) AND podSelector (authelia instance).
+# Port 80 is Authelia's actual containerPort (Service targetPort 80 → pod 80),
+# NOT 9091 — see #2942 forward-auth correction.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: traefik-allow-authelia-egress
+  namespace: networking
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: traefik
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: auth
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: authelia
+      ports:
+        - port: 80
+          protocol: TCP
+---
+# Allow egress to Kubernetes API server (in-cluster service CIDR + control
+# plane node) for IngressRoute / HTTPRoute / Gateway reconciliation.
+# Companion to the CiliumNetworkPolicy (toEntities: kube-apiserver) — both are
+# required because Cilium's kubeProxyReplacement bypasses ipBlock matches for
+# the host-networked API server. Defence-in-depth per #2829 / #2947.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: traefik-allow-k8s-api
+  namespace: networking
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: traefik
+  policyTypes:
+    - Egress
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.43.0.0/16  # Service CIDR (kubernetes.default.svc)
+    - ports:
+        - port: 443
+          protocol: TCP
+        - port: 6443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.87.42.2/32  # control plane node

--- a/kubernetes/cluster0/apps/seaweedfs/namespace.yaml
+++ b/kubernetes/cluster0/apps/seaweedfs/namespace.yaml
@@ -5,4 +5,5 @@ metadata:
   name: seaweedfs
   labels:
     kustomize.toolkit.fluxcd.io/prune: disabled
+    netpol.home-ops/traefik-backend: "true"
     trust.cert-manager.io/enabled: "true"


### PR DESCRIPTION
## Summary

Phase 4a of the cluster NetworkPolicy rollout (#2812): default-deny + targeted NetworkPolicy / CiliumNetworkPolicy on the two `traefik` Deployment pods in the `networking` namespace, plus the `netpol.home-ops/traefik-backend: \"true\"` label on the 8 backend namespaces.

## Design

Traefik's egress is **namespace-label-driven** (middle-ground design from #2812): a single egress rule permits any pod in any namespace labelled `netpol.home-ops/traefik-backend: \"true\"` on any TCP port. The actual security boundary remains the backend pods' existing `allow-traefik-ingress` rules from Phase 1/2 — those are scoped to Traefik's pod selector + each backend's specific port, and **are not touched by this PR**. A Traefik compromise can still only reach pods that opt in via their own ingress policy.

## What this PR contains

**8 backend namespaces** get `netpol.home-ops/traefik-backend: \"true\"`:
- `auth`, `home`, `kube-system`, `longhorn-system`, `media`, `monitoring`, `networking`, `seaweedfs`

**Traefik policies** under `apps/networking/traefik/app/`:

- `network-policy.yaml`:
  - `traefik-default-deny` — `policyTypes: [Ingress, Egress]`, no rules
  - `traefik-allow-dns` — :53 UDP+TCP to `kube-system`
  - `traefik-allow-external-ingress` — :80/:443 from `0.0.0.0/0` (no RFC1918 exclusion; Traefik IS the cluster entrypoint)
  - `traefik-allow-cloudflared-ingress` — intra-ns ingress from `cloudflared` pod selector on :443
  - `traefik-allow-backend-egress` — namespace-label egress on TCP 1–65535 (no pod selector, intentional)
  - `traefik-allow-authelia-egress` — AND-shape (`auth` ns + `authelia` instance) on :80 (Authelia's containerPort, **not** 9091 — verified)
  - `traefik-allow-k8s-api` — ipBlock egress to service CIDR + control-plane node on :443/:6443
- `cilium-network-policy.yaml`:
  - `traefik-allow-kube-apiserver` — `toEntities: [kube-apiserver]` companion to the ipBlock allow (defence-in-depth per #2829 / #2947)

## Verification done before authoring

| Check | Result |
|---|---|
| Traefik pod label | `app.kubernetes.io/name: traefik` (3 replicas, chart 39.0.9) |
| Authelia forward-auth port | Service targetPort 80 → pod (Service has http=80 and metrics=8080) |
| Traefik ServiceMonitor | **None exists** — Prometheus-scrape ingress NOT added (per AC) |
| K8s API ipBlock pattern | `10.43.0.0/16` (service CIDR) + `10.87.42.2/32` (control plane), per cnpg |
| `kubectl kustomize` build | clean for `apps/networking` and `apps/networking/traefik/app` |

## Out of scope

- Tightening Traefik egress to per-pod targets (defence-in-depth, defer to a future phase).
- Modifying any backend `allow-traefik-ingress` rule — Phase 1/2 work, untouched.
- Anything in `cloudflared`, `external-dns`, `blocky*` — already covered.

## Post-merge verification (coordinator)

```bash
flux reconcile source git home-ops-cluster0
flux reconcile kustomization cluster-apps-traefik
kubectl -n networking get networkpolicy
kubectl get ns -L netpol.home-ops/traefik-backend
hubble observe --pod networking/traefik-* --verdict DROPPED --since 5m
```

Plus a functional smoke on each `*.tinfoilforest.nz` route and a Cloudflare tunnel route.

Refs #2812
Closes #2950