### PR TITLE
fix(netpol): widen seaweedfs intra-ns policies to accept helm-managed pods

### DIFF
--- a/kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/network-policy.yaml
+++ b/kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/network-policy.yaml
@@ -88,6 +88,13 @@ spec:
             matchLabels:
               app.kubernetes.io/name: seaweedfs
               app.kubernetes.io/component: master
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: seaweedfs
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: seaweedfs
+              app.kubernetes.io/managed-by: Helm
       ports:
         - port: 9333
           protocol: TCP
@@ -183,6 +190,13 @@ spec:
             matchLabels:
               app.kubernetes.io/name: seaweedfs
               app.kubernetes.io/component: master
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: seaweedfs
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: seaweedfs
+              app.kubernetes.io/managed-by: Helm
       ports:
         - port: 8080
           protocol: TCP
@@ -216,6 +230,13 @@ spec:
             matchLabels:
               app.kubernetes.io/name: seaweedfs
               app.kubernetes.io/component: volume
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: seaweedfs
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: seaweedfs
+              app.kubernetes.io/managed-by: Helm
 ---
 # Allow egress from volume to master (register/heartbeat) and peer volumes
 apiVersion: networking.k8s.io/v1
@@ -244,6 +265,13 @@ spec:
             matchLabels:
               app.kubernetes.io/name: seaweedfs
               app.kubernetes.io/component: master
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: seaweedfs
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: seaweedfs
+              app.kubernetes.io/managed-by: Helm
     - ports:
         - port: 8080
           protocol: TCP
@@ -257,6 +285,13 @@ spec:
             matchLabels:
               app.kubernetes.io/name: seaweedfs
               app.kubernetes.io/component: volume
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: seaweedfs
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: seaweedfs
+              app.kubernetes.io/managed-by: Helm
 ---
 # =============================================================================
 # seaweedfs-filer
@@ -347,6 +382,13 @@ spec:
             matchLabels:
               app.kubernetes.io/name: seaweedfs
               app.kubernetes.io/component: filer
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: seaweedfs
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: seaweedfs
+              app.kubernetes.io/managed-by: Helm
       ports:
         - port: 8888
           protocol: TCP
@@ -406,6 +448,13 @@ spec:
             matchLabels:
               app.kubernetes.io/name: seaweedfs
               app.kubernetes.io/component: master
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: seaweedfs
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: seaweedfs
+              app.kubernetes.io/managed-by: Helm
     - ports:
         - port: 8080
           protocol: TCP
@@ -419,6 +468,13 @@ spec:
             matchLabels:
               app.kubernetes.io/name: seaweedfs
               app.kubernetes.io/component: volume
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: seaweedfs
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: seaweedfs
+              app.kubernetes.io/managed-by: Helm
 ---
 # =============================================================================
 # seaweedfs-s3
@@ -514,6 +570,13 @@ spec:
             matchLabels:
               app.kubernetes.io/name: seaweedfs
               app.kubernetes.io/component: master
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: seaweedfs
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: seaweedfs
+              app.kubernetes.io/managed-by: Helm
       ports:
         - port: 8333
           protocol: TCP
@@ -545,6 +608,13 @@ spec:
             matchLabels:
               app.kubernetes.io/name: seaweedfs
               app.kubernetes.io/component: filer
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: seaweedfs
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: seaweedfs
+              app.kubernetes.io/managed-by: Helm
     - ports:
         - port: 9333
           protocol: TCP
@@ -558,6 +628,13 @@ spec:
             matchLabels:
               app.kubernetes.io/name: seaweedfs
               app.kubernetes.io/component: master
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: seaweedfs
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: seaweedfs
+              app.kubernetes.io/managed-by: Helm
     - ports:
         - port: 8080
           protocol: TCP
@@ -571,3 +648,10 @@ spec:
             matchLabels:
               app.kubernetes.io/name: seaweedfs
               app.kubernetes.io/component: volume
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: seaweedfs
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: seaweedfs
+              app.kubernetes.io/managed-by: Helm


### PR DESCRIPTION
## What

Widen the eight `seaweedfs-*-allow-intra-{ingress,egress}` NetworkPolicies in `kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/network-policy.yaml` so they also accept pods carrying both `app.kubernetes.io/instance: seaweedfs` AND `app.kubernetes.io/managed-by: Helm` in the `seaweedfs` namespace.

Each new `from`/`to` list entry uses the AND-shape convention (`namespaceSelector` + `podSelector` siblings under a single list entry) established in #2937:

```yaml
- namespaceSelector:
    matchLabels:
      kubernetes.io/metadata.name: seaweedfs
  podSelector:
    matchLabels:
      app.kubernetes.io/instance: seaweedfs
      app.kubernetes.io/managed-by: Helm
```

## Why

The current intra-ns policies treat "is one of the four data-plane components" as the security boundary, but the operational reality is "anything Helm renders in this namespace as part of the seaweedfs release is co-trusted with the data plane". The bucket-hook Job pod surfaced this concretely (12 `POLICY_DENIED` flows to `seaweedfs-master:9333` per Hubble), and #2967 worked around it by removing `s3.createBuckets` — but the underlying mismatch will keep biting on any future chart-rendered pod (migration hooks, post-upgrade jobs, new sidecars).

## Scope

- **8 policies modified**, all in `network-policy.yaml`. 12 new selector entries total (4 ingress + 8 egress, since multi-rule egress policies get one entry per `to:` block).
- **Per-component port restrictions unchanged**: helm-managed pods get the same port surface as the data-plane components, not a wider one.
- **Untouched**: default-deny policies, DNS allow policies, cross-namespace policies (`seaweedfs-s3-allow-cnpg-ingress`, `seaweedfs-filer-allow-traefik-ingress`), and all existing per-component `from`/`to` entries.

## Verification

- `kubectl kustomize kubernetes/cluster0/apps/seaweedfs` exits 0 with no schema errors.
- `kubectl kustomize kubernetes/cluster0/apps/seaweedfs/seaweedfs/app` contains exactly 12 `managed-by: Helm` entries (4 ingress + 8 egress) — matches the expected count.

Post-merge verification steps (helm-pod smoke test + negative control) are documented in #2969.

Closes #2969
