### PR TITLE
feat(netpol): phase 4b — cert-manager ns + kube-system minor services (excl. CoreDNS)

### DIFF
--- a/kubernetes/cluster0/apps/cert-manager/cert-manager/app/cilium-network-policy.yaml
+++ b/kubernetes/cluster0/apps/cert-manager/cert-manager/app/cilium-network-policy.yaml
@@ -1,0 +1,74 @@
+---
+# CiliumNetworkPolicy: allow cert-manager controller egress to the K8s API server.
+#
+# Standard K8s NetworkPolicy ipBlock rules are silently bypassed by Cilium when
+# kubeProxyReplacement=true because the k3s API server runs in the host network
+# namespace and Cilium assigns it the 'kube-apiserver' entity identity rather
+# than a pod identity or IP. The companion ipBlock NetworkPolicy
+# (cert-manager-allow-k8s-api) is kept for defence-in-depth, but this
+# CiliumNetworkPolicy is what actually enforces the allow in practice. See
+# #2829 (external-dns) and #2947 (cnpg) for the same pattern.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: cert-manager-allow-kube-apiserver
+  namespace: cert-manager
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: cert-manager
+      app.kubernetes.io/component: controller
+  egress:
+    - toEntities:
+        - kube-apiserver
+---
+# CiliumNetworkPolicy: allow cert-manager-cainjector egress to the K8s API server.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: cert-manager-cainjector-allow-kube-apiserver
+  namespace: cert-manager
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: cainjector
+      app.kubernetes.io/component: cainjector
+  egress:
+    - toEntities:
+        - kube-apiserver
+---
+# CiliumNetworkPolicy: cert-manager-webhook bi-directional K8s API allow.
+#
+# *** THIS IS THE MOST CRITICAL RULE IN PHASE 4b ***
+# kube-apiserver calls the webhook whenever any Certificate, Issuer,
+# ClusterIssuer, CertificateRequest, etc. is created or modified anywhere in
+# the cluster. The ingress allow must use `fromEntities: [kube-apiserver]` —
+# ipBlock alone is silently bypassed by Cilium because the API server runs in
+# the host network namespace under kubeProxyReplacement=true.
+#
+# Webhook containerPort is 10250 (name: https) — verified on the running pod.
+# Service-side port (cert-manager-webhook Service :443) does NOT apply here —
+# NetworkPolicy and CiliumNetworkPolicy both enforce on pod containerPorts.
+#
+# The egress allow (toEntities: kube-apiserver) covers the webhook's outbound
+# lookups for referenced Issuers/Secrets.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: cert-manager-webhook-allow-kube-apiserver
+  namespace: cert-manager
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: webhook
+      app.kubernetes.io/component: webhook
+  egress:
+    - toEntities:
+        - kube-apiserver
+  ingress:
+    - fromEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "10250"
+              protocol: TCP

--- a/kubernetes/cluster0/apps/cert-manager/cert-manager/app/kustomization.yaml
+++ b/kubernetes/cluster0/apps/cert-manager/cert-manager/app/kustomization.yaml
@@ -5,6 +5,8 @@ kind: Kustomization
 namespace: cert-manager
 resources:
   - ./helm-release.yaml
+  - ./network-policy.yaml
+  - ./cilium-network-policy.yaml
 labels:
   - pairs:
       app.kubernetes.io/name: cert-manager

--- a/kubernetes/cluster0/apps/cert-manager/cert-manager/app/network-policy.yaml
+++ b/kubernetes/cluster0/apps/cert-manager/cert-manager/app/network-policy.yaml
@@ -1,0 +1,366 @@
+---
+# =============================================================================
+# cert-manager controller — Phase 4b (#2951)
+# Pod label: app.kubernetes.io/name=cert-manager,
+#            app.kubernetes.io/component=controller (Deployment, 1 replica)
+# Listens on: :9402 (http-metrics), :9403 (http-healthz)
+# Ingress from: intra-ns monitoring scrape on :9402 (ServiceMonitor)
+# Egress to: K8s API, external :443 (ACME challenges), DNS
+# =============================================================================
+---
+# Default deny-all for cert-manager controller
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: cert-manager-default-deny
+  namespace: cert-manager
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: cert-manager
+      app.kubernetes.io/component: controller
+  policyTypes: [Ingress, Egress]
+---
+# Allow DNS resolution to CoreDNS in kube-system
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: cert-manager-allow-dns
+  namespace: cert-manager
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: cert-manager
+      app.kubernetes.io/component: controller
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+---
+# Allow Prometheus to scrape cert-manager controller metrics on :9402
+# ServiceMonitor "cert-manager" targets all three cert-manager components by
+# app.kubernetes.io/instance=cert-manager on the http-metrics port (9402).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: cert-manager-allow-prometheus-scrape
+  namespace: cert-manager
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: cert-manager
+      app.kubernetes.io/component: controller
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+      ports:
+        - port: 9402
+          protocol: TCP
+---
+# Allow egress to Kubernetes API server (Issuer/Certificate/CertificateRequest
+# reconciliation).  ipBlock covers the cluster Service CIDR and control-plane
+# nodes.  Companion CiliumNetworkPolicy (cert-manager-allow-kube-apiserver) is
+# what Cilium actually enforces under kubeProxyReplacement=true; this rule is
+# defence-in-depth per #2829 / #2947.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: cert-manager-allow-k8s-api
+  namespace: cert-manager
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: cert-manager
+      app.kubernetes.io/component: controller
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.43.0.0/16  # Service CIDR (kubernetes.default.svc)
+    - ports:
+        - port: 443
+          protocol: TCP
+        - port: 6443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.87.42.2/32  # control plane node (defence-in-depth)
+---
+# Allow egress to external :443 for ACME HTTP-01 / DNS-01 challenges
+# (Let's Encrypt, ZeroSSL, etc.). Let's Encrypt and similar CAs are fronted by
+# Cloudflare CDN — IPs change frequently. Keeping this wide is intentional per
+# #2951 "Out of scope" — restricting to specific ACME endpoints isn't tractable.
+# RFC1918 ranges are excluded so this rule cannot reach internal services.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: cert-manager-allow-external-acme-egress
+  namespace: cert-manager
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: cert-manager
+      app.kubernetes.io/component: controller
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP
+        - port: 80
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+# =============================================================================
+# cert-manager-cainjector — Phase 4b (#2951)
+# Pod label: app.kubernetes.io/name=cainjector (Deployment, 1 replica)
+# Listens on: :9402 (http-metrics)
+# Ingress: monitoring scrape on :9402 (ServiceMonitor selects all three
+#          cert-manager components)
+# Egress to: K8s API, DNS
+# =============================================================================
+---
+# Default deny-all for cert-manager-cainjector
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: cert-manager-cainjector-default-deny
+  namespace: cert-manager
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: cainjector
+      app.kubernetes.io/component: cainjector
+  policyTypes: [Ingress, Egress]
+---
+# Allow DNS resolution to CoreDNS in kube-system
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: cert-manager-cainjector-allow-dns
+  namespace: cert-manager
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: cainjector
+      app.kubernetes.io/component: cainjector
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+---
+# Allow Prometheus to scrape cainjector metrics on :9402
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: cert-manager-cainjector-allow-prometheus-scrape
+  namespace: cert-manager
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: cainjector
+      app.kubernetes.io/component: cainjector
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+      ports:
+        - port: 9402
+          protocol: TCP
+---
+# Allow egress to Kubernetes API server (cainjector injects CA bundles into
+# Mutating/ValidatingWebhookConfigurations, APIServices, and CRDs).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: cert-manager-cainjector-allow-k8s-api
+  namespace: cert-manager
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: cainjector
+      app.kubernetes.io/component: cainjector
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.43.0.0/16  # Service CIDR (kubernetes.default.svc)
+    - ports:
+        - port: 443
+          protocol: TCP
+        - port: 6443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.87.42.2/32  # control plane node (defence-in-depth)
+# =============================================================================
+# cert-manager-webhook — Phase 4b (#2951)
+# Pod label: app.kubernetes.io/name=webhook (Deployment, 1 replica)
+# Listens on: :10250 (https — the webhook port), :6080 (healthcheck),
+#             :9402 (http-metrics)
+# Ingress from:
+#   - kube-apiserver on :10250 (ValidatingWebhookConfiguration callbacks) —
+#     authoritative rule is the CiliumNetworkPolicy
+#     `cert-manager-webhook-allow-kube-apiserver` (fromEntities: kube-apiserver).
+#     The ipBlock rule here is defence-in-depth only.
+#   - monitoring scrape on :9402 (ServiceMonitor selects all three cert-manager
+#     components by instance label).
+# Egress to: K8s API, DNS
+# =============================================================================
+---
+# Default deny-all for cert-manager-webhook
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: cert-manager-webhook-default-deny
+  namespace: cert-manager
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: webhook
+      app.kubernetes.io/component: webhook
+  policyTypes: [Ingress, Egress]
+---
+# Allow DNS resolution to CoreDNS in kube-system
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: cert-manager-webhook-allow-dns
+  namespace: cert-manager
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: webhook
+      app.kubernetes.io/component: webhook
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+---
+# Allow ingress from kube-apiserver to the webhook on :10250
+# (ValidatingWebhookConfiguration callbacks).
+# Standard NetworkPolicy ipBlock rule — defence-in-depth companion to the
+# CiliumNetworkPolicy `cert-manager-webhook-allow-kube-apiserver` which is
+# what Cilium actually enforces under kubeProxyReplacement=true (the API
+# server is host-networked and Cilium assigns it the `kube-apiserver` entity
+# identity, bypassing ipBlock matches). See #2947 / #2829.
+#
+# *** CRITICAL ***: if this allow is broken, kube-apiserver cannot call the
+# webhook and ALL cert-manager Issuer/Certificate/CertificateRequest
+# operations stall cluster-wide. Verified on the running pod that
+# containerPort 10250 (name: https) is the webhook port.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: cert-manager-webhook-allow-kube-apiserver-ingress
+  namespace: cert-manager
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: webhook
+      app.kubernetes.io/component: webhook
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - ipBlock:
+            cidr: 10.43.0.0/16  # Service CIDR (kubernetes.default.svc)
+        - ipBlock:
+            cidr: 10.87.42.2/32  # control plane node
+      ports:
+        - port: 10250
+          protocol: TCP
+---
+# Allow Prometheus to scrape webhook metrics on :9402
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: cert-manager-webhook-allow-prometheus-scrape
+  namespace: cert-manager
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: webhook
+      app.kubernetes.io/component: webhook
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+      ports:
+        - port: 9402
+          protocol: TCP
+---
+# Allow egress to Kubernetes API server (webhook resolves the requesting
+# resource and looks up referenced Issuers/Secrets).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: cert-manager-webhook-allow-k8s-api
+  namespace: cert-manager
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: webhook
+      app.kubernetes.io/component: webhook
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.43.0.0/16  # Service CIDR (kubernetes.default.svc)
+    - ports:
+        - port: 443
+          protocol: TCP
+        - port: 6443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.87.42.2/32  # control plane node (defence-in-depth)

--- a/kubernetes/cluster0/apps/cert-manager/trust-manager/app/cilium-network-policy.yaml
+++ b/kubernetes/cluster0/apps/cert-manager/trust-manager/app/cilium-network-policy.yaml
@@ -1,0 +1,27 @@
+---
+# CiliumNetworkPolicy: trust-manager bi-directional K8s API allow.
+#
+# Egress: standard kube-apiserver entity allow (same pattern as #2829 / #2947).
+# Ingress: trust-manager registers a ValidatingWebhookConfiguration for the
+# Bundle CRD; kube-apiserver calls back on the pod's :6443 (verified
+# containerPort, name: webhook). The companion ipBlock NetworkPolicy
+# (trust-manager-allow-kube-apiserver-ingress) is kept for defence-in-depth.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: trust-manager-allow-kube-apiserver
+  namespace: cert-manager
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: trust-manager
+  egress:
+    - toEntities:
+        - kube-apiserver
+  ingress:
+    - fromEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "6443"
+              protocol: TCP

--- a/kubernetes/cluster0/apps/cert-manager/trust-manager/app/kustomization.yaml
+++ b/kubernetes/cluster0/apps/cert-manager/trust-manager/app/kustomization.yaml
@@ -4,3 +4,5 @@ kind: Kustomization
 namespace: cert-manager
 resources:
   - ./helm-release.yaml
+  - ./network-policy.yaml
+  - ./cilium-network-policy.yaml

--- a/kubernetes/cluster0/apps/cert-manager/trust-manager/app/network-policy.yaml
+++ b/kubernetes/cluster0/apps/cert-manager/trust-manager/app/network-policy.yaml
@@ -1,0 +1,103 @@
+---
+# =============================================================================
+# trust-manager — Phase 4b (#2951)
+# Pod label: app=trust-manager,
+#            app.kubernetes.io/name=trust-manager (Deployment, 1 replica)
+# Listens on: :6443 (webhook), :9402 (metrics)
+# Ingress from:
+#   - kube-apiserver on :6443 (ValidatingWebhookConfiguration for the Bundle
+#     CRD — verified via `kubectl get validatingwebhookconfiguration
+#     trust-manager`). Authoritative rule lives in the sibling
+#     CiliumNetworkPolicy `trust-manager-allow-kube-apiserver`.
+# Egress to: K8s API (Bundle reconciliation, ConfigMap/Secret writes
+#            cluster-wide), DNS.
+# Note: no ServiceMonitor selects trust-manager today (the
+#       `trust-manager-metrics` Service exists but isn't scraped) — no
+#       Prometheus-scrape ingress added per the issue guidance.
+# =============================================================================
+---
+# Default deny-all for trust-manager
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: trust-manager-default-deny
+  namespace: cert-manager
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: trust-manager
+  policyTypes: [Ingress, Egress]
+---
+# Allow DNS resolution to CoreDNS in kube-system
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: trust-manager-allow-dns
+  namespace: cert-manager
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: trust-manager
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+---
+# Allow ingress from kube-apiserver to the trust-manager webhook on :6443.
+# Defence-in-depth ipBlock companion to the CiliumNetworkPolicy
+# `trust-manager-allow-kube-apiserver` (fromEntities: kube-apiserver). The
+# webhook validates Bundle resources — if blocked, Bundle reconciliation halts.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: trust-manager-allow-kube-apiserver-ingress
+  namespace: cert-manager
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: trust-manager
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - ipBlock:
+            cidr: 10.43.0.0/16  # Service CIDR (kubernetes.default.svc)
+        - ipBlock:
+            cidr: 10.87.42.2/32  # control plane node
+      ports:
+        - port: 6443
+          protocol: TCP
+---
+# Allow egress to Kubernetes API server (Bundle reconciliation, ConfigMap/
+# Secret writes cluster-wide).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: trust-manager-allow-k8s-api
+  namespace: cert-manager
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: trust-manager
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.43.0.0/16  # Service CIDR (kubernetes.default.svc)
+    - ports:
+        - port: 443
+          protocol: TCP
+        - port: 6443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.87.42.2/32  # control plane node (defence-in-depth)

--- a/kubernetes/cluster0/apps/kube-system/cilium/app/cilium-network-policy.yaml
+++ b/kubernetes/cluster0/apps/kube-system/cilium/app/cilium-network-policy.yaml
@@ -1,0 +1,28 @@
+---
+# CiliumNetworkPolicy: hubble-relay egress to host-networked cilium-agent
+# pods' hubble-peer endpoint on :4244.
+#
+# Cilium agents run with hostNetwork=true and Cilium assigns them the
+# `reserved:host` / `reserved:remote-node` entity identities. Standard
+# NetworkPolicy podSelector rules don't match these entities, so the egress
+# allow on :4244 must use `toEntities: [host, remote-node]`. The companion
+# ipBlock NetworkPolicy `hubble-relay-allow-cilium-agents-egress` is kept
+# for defence-in-depth. Pattern parallels #2965 (Prometheus → host-network
+# scrape targets) and #2962.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: hubble-relay-allow-cilium-agents
+  namespace: kube-system
+spec:
+  endpointSelector:
+    matchLabels:
+      k8s-app: hubble-relay
+  egress:
+    - toEntities:
+        - host
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "4244"
+              protocol: TCP

--- a/kubernetes/cluster0/apps/kube-system/cilium/app/kustomization.yaml
+++ b/kubernetes/cluster0/apps/kube-system/cilium/app/kustomization.yaml
@@ -4,3 +4,5 @@ kind: Kustomization
 resources:
   - helm-release.yaml
   - hubble-httproute.yaml
+  - network-policy.yaml
+  - cilium-network-policy.yaml

--- a/kubernetes/cluster0/apps/kube-system/cilium/app/network-policy.yaml
+++ b/kubernetes/cluster0/apps/kube-system/cilium/app/network-policy.yaml
@@ -1,0 +1,201 @@
+---
+# =============================================================================
+# Phase 4b (#2951): NetworkPolicies for hubble-relay and hubble-ui only.
+#
+# The Cilium agent (cilium-* daemonset), Cilium operator, Cilium envoy, and
+# kube-vip pods all run with hostNetwork=true and NetworkPolicy does NOT apply
+# to them. Only the two non-host-networked Hubble pods are in scope here.
+# =============================================================================
+
+# =============================================================================
+# hubble-relay
+# Pod label: k8s-app=hubble-relay (Deployment, 1 replica)
+# Listens on: :4245 (grpc — the relay port; verified containerPort name=grpc)
+# Ingress from: intra-ns hubble-ui only on :4245
+# Egress to:
+#   - cilium-agent hubble-peer endpoint on :4244 (cilium agents are host-
+#     networked across all nodes; authoritative allow lives in the sibling
+#     CiliumNetworkPolicy with toEntities: [host, remote-node]).
+#   - DNS to kube-system.
+# =============================================================================
+---
+# Default deny-all for hubble-relay
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: hubble-relay-default-deny
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      k8s-app: hubble-relay
+  policyTypes: [Ingress, Egress]
+---
+# Allow DNS resolution to CoreDNS in kube-system (AND-shape: namespaceSelector
+# matches this namespace explicitly per Phase 2/3 lessons — bare selectors
+# silently drop).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: hubble-relay-allow-dns
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      k8s-app: hubble-relay
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+---
+# Allow ingress from intra-ns hubble-ui only on :4245 (AND-shape with explicit
+# kube-system namespaceSelector per Phase 2 lessons).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: hubble-relay-allow-hubble-ui-ingress
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      k8s-app: hubble-relay
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: hubble-ui
+      ports:
+        - port: 4245
+          protocol: TCP
+---
+# Allow egress to the cilium-agent hubble-peer endpoint on :4244 on every
+# node — defence-in-depth ipBlock companion. Cilium agents are host-networked
+# across the node CIDR 10.87.42.0/24. The authoritative allow lives in the
+# sibling CiliumNetworkPolicy `hubble-relay-allow-cilium-agents`
+# (toEntities: [host, remote-node]); ipBlock is bypassed by Cilium for host-
+# network identities under kubeProxyReplacement=true. See #2965 for the same
+# pattern on prometheus → host-network scrape targets.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: hubble-relay-allow-cilium-agents-egress
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      k8s-app: hubble-relay
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 4244
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.87.42.0/24  # node CIDR — cilium agents on host network
+
+# =============================================================================
+# hubble-ui
+# Pod label: k8s-app=hubble-ui (Deployment, 1 replica, 2 containers)
+# Listens on:
+#   - frontend container: :8081 (http)  — served to clients via Service:80
+#   - backend container:  :8090 (grpc)  — internal to the pod, frontend->backend
+# Ingress from: networking ns Traefik on :8081 (UI frontend)
+# Egress to: intra-ns hubble-relay :4245 (backend gRPC client), DNS
+#
+# The intra-pod frontend->backend traffic on :8090 stays within the pod and
+# does not traverse NetworkPolicy enforcement.
+# =============================================================================
+---
+# Default deny-all for hubble-ui
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: hubble-ui-default-deny
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      k8s-app: hubble-ui
+  policyTypes: [Ingress, Egress]
+---
+# Allow DNS resolution to CoreDNS in kube-system
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: hubble-ui-allow-dns
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      k8s-app: hubble-ui
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+---
+# Allow ingress from Traefik (networking ns) on :8081 (frontend HTTP).
+# AND-shape: namespaceSelector + podSelector under a single list entry.
+# Service hubble-ui :80 -> pod :8081 (verified Service spec + pod containerPort).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: hubble-ui-allow-traefik-ingress
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      k8s-app: hubble-ui
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: networking
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: traefik
+      ports:
+        - port: 8081
+          protocol: TCP
+---
+# Allow egress to intra-ns hubble-relay :4245 (backend gRPC client).
+# AND-shape with explicit kube-system namespaceSelector per Phase 2 lessons.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: hubble-ui-allow-hubble-relay-egress
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      k8s-app: hubble-ui
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 4245
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: hubble-relay

--- a/kubernetes/cluster0/apps/kube-system/intel-device-plugin/app/cilium-network-policy.yaml
+++ b/kubernetes/cluster0/apps/kube-system/intel-device-plugin/app/cilium-network-policy.yaml
@@ -1,0 +1,24 @@
+---
+# CiliumNetworkPolicy: inteldeviceplugins-controller-manager bi-directional
+# K8s API allow. Egress = kube-apiserver entity (CRD reconciliation), ingress
+# = kube-apiserver entity on :9443 (admission webhook). Same dual-policy
+# pattern as cnpg-operator (#2947) and cert-manager-webhook in this PR.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: inteldeviceplugins-controller-manager-allow-kube-apiserver
+  namespace: kube-system
+spec:
+  endpointSelector:
+    matchLabels:
+      control-plane: controller-manager
+  egress:
+    - toEntities:
+        - kube-apiserver
+  ingress:
+    - fromEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "9443"
+              protocol: TCP

--- a/kubernetes/cluster0/apps/kube-system/intel-device-plugin/app/kustomization.yaml
+++ b/kubernetes/cluster0/apps/kube-system/intel-device-plugin/app/kustomization.yaml
@@ -3,4 +3,6 @@ kind: Kustomization
 namespace: kube-system
 resources:
   - helm-release.yaml
+  - network-policy.yaml
+  - cilium-network-policy.yaml
 

--- a/kubernetes/cluster0/apps/kube-system/intel-device-plugin/app/network-policy.yaml
+++ b/kubernetes/cluster0/apps/kube-system/intel-device-plugin/app/network-policy.yaml
@@ -1,0 +1,98 @@
+---
+# =============================================================================
+# inteldeviceplugins-controller-manager — Phase 4b (#2951)
+# Pod label: control-plane=controller-manager (Deployment, 1 replica)
+# Listens on: :9443 (webhook-server)
+# Ingress from:
+#   - kube-apiserver on :9443 (registers ValidatingWebhookConfiguration for
+#     the Intel device-plugin CRDs). Authoritative allow is the sibling
+#     CiliumNetworkPolicy.
+# Egress to: K8s API (reconciles GpuDevicePlugin CRD → DaemonSet), DNS.
+#
+# Note: the selector `control-plane=controller-manager` is unusually generic.
+# Today only this one Deployment in the kube-system ns matches it. The Intel
+# operator chart uses this label; we keep it to match the actual pod.
+# =============================================================================
+---
+# Default deny-all for inteldeviceplugins-controller-manager
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: inteldeviceplugins-controller-manager-default-deny
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+  policyTypes: [Ingress, Egress]
+---
+# Allow DNS resolution to CoreDNS in kube-system
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: inteldeviceplugins-controller-manager-allow-dns
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+---
+# Allow ingress from kube-apiserver on :9443 (admission webhook).
+# Defence-in-depth ipBlock companion to the CiliumNetworkPolicy.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: inteldeviceplugins-controller-manager-allow-kube-apiserver-ingress
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - ipBlock:
+            cidr: 10.43.0.0/16  # Service CIDR (kubernetes.default.svc)
+        - ipBlock:
+            cidr: 10.87.42.2/32  # control plane node
+      ports:
+        - port: 9443
+          protocol: TCP
+---
+# Allow egress to Kubernetes API server (CRD reconciliation).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: inteldeviceplugins-controller-manager-allow-k8s-api
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.43.0.0/16  # Service CIDR (kubernetes.default.svc)
+    - ports:
+        - port: 443
+          protocol: TCP
+        - port: 6443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.87.42.2/32  # control plane node (defence-in-depth)

--- a/kubernetes/cluster0/apps/kube-system/intel-device-plugin/gpu/kustomization.yaml
+++ b/kubernetes/cluster0/apps/kube-system/intel-device-plugin/gpu/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 namespace: kube-system
 resources:
   - helm-release.yaml
+  - network-policy.yaml

--- a/kubernetes/cluster0/apps/kube-system/intel-device-plugin/gpu/network-policy.yaml
+++ b/kubernetes/cluster0/apps/kube-system/intel-device-plugin/gpu/network-policy.yaml
@@ -1,0 +1,47 @@
+---
+# =============================================================================
+# intel-gpu-plugin — Phase 4b (#2951)
+# Pod label: app=intel-gpu-plugin (DaemonSet, runs on every GPU-equipped node)
+# Listens on: nothing (no containerPort exposed — verified)
+# Ingress: none required (node-local only — the plugin communicates with the
+#          local kubelet device-plugin manager over a unix socket mounted
+#          from the host, not via the pod network).
+# Egress to: DNS only (no K8s API access from the plugin itself; CRD work
+#            happens in inteldeviceplugins-controller-manager).
+# =============================================================================
+---
+# Default deny-all for intel-gpu-plugin
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: intel-gpu-plugin-default-deny
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      app: intel-gpu-plugin
+  policyTypes: [Ingress, Egress]
+---
+# Allow DNS resolution to CoreDNS in kube-system (kept for completeness even
+# though the plugin doesn't do meaningful network egress — DNS is the
+# Phase-2/3 baseline applied uniformly per the AC).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: intel-gpu-plugin-allow-dns
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      app: intel-gpu-plugin
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system

--- a/kubernetes/cluster0/apps/kube-system/kustomization.yaml
+++ b/kubernetes/cluster0/apps/kube-system/kustomization.yaml
@@ -10,7 +10,10 @@ resources:
   # I manged to with cilium, but when there is no coredns, things fall apart
   # - ./coredns/ks.yaml
   - ./intel-device-plugin/ks.yaml
-  # - ./local-path-provisioner/ks.yaml
+  # Phase 4b (#2951): re-enabled but pointing at a NetworkPolicy-only path —
+  # the actual local-path-provisioner running in the cluster is the k3s
+  # built-in addon, not the Helm release in ./local-path-provisioner/app/.
+  - ./local-path-provisioner/ks.yaml
   - ./node-feature-discovery/ks.yaml
   - ./metrics-server/ks.yaml
   - ./reloader/ks.yaml

--- a/kubernetes/cluster0/apps/kube-system/local-path-provisioner/ks.yaml
+++ b/kubernetes/cluster0/apps/kube-system/local-path-provisioner/ks.yaml
@@ -6,7 +6,18 @@ metadata:
   name: cluster-apps-local-path-provisioner
   namespace: flux-system
 spec:
-  path: ./kubernetes/cluster0/apps/kube-system/local-path-provisioner/app
+  # This path was historically `./app` (the Helm release for the upstream
+  # local-path-provisioner chart) but is intentionally disabled in the root
+  # kube-system kustomization — the actual local-path-provisioner running in
+  # the cluster is the k3s built-in addon reconciled by the k3s
+  # `objectset.rio.cattle.io` machinery, not Helm. See the comment in
+  # `apps/kube-system/kustomization.yaml`.
+  #
+  # Phase 4b (#2951) re-enables this Flux Kustomization but points it at a
+  # dedicated `policy/` directory that contains only the NetworkPolicy and
+  # CiliumNetworkPolicy that lock down the k3s-managed pod. Adding policies
+  # without re-introducing the Helm release.
+  path: ./kubernetes/cluster0/apps/kube-system/local-path-provisioner/policy
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/cluster0/apps/kube-system/local-path-provisioner/policy/cilium-network-policy.yaml
+++ b/kubernetes/cluster0/apps/kube-system/local-path-provisioner/policy/cilium-network-policy.yaml
@@ -1,0 +1,16 @@
+---
+# CiliumNetworkPolicy: local-path-provisioner egress to the K8s API server.
+# Companion to local-path-provisioner-allow-k8s-api (defence-in-depth ipBlock).
+# Authoritative under Cilium kubeProxyReplacement=true — see #2829 / #2947.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: local-path-provisioner-allow-kube-apiserver
+  namespace: kube-system
+spec:
+  endpointSelector:
+    matchLabels:
+      app: local-path-provisioner
+  egress:
+    - toEntities:
+        - kube-apiserver

--- a/kubernetes/cluster0/apps/kube-system/local-path-provisioner/policy/kustomization.yaml
+++ b/kubernetes/cluster0/apps/kube-system/local-path-provisioner/policy/kustomization.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: kube-system
 resources:
-  - ./helm-release.yaml
   - ./network-policy.yaml
   - ./cilium-network-policy.yaml

--- a/kubernetes/cluster0/apps/kube-system/local-path-provisioner/policy/network-policy.yaml
+++ b/kubernetes/cluster0/apps/kube-system/local-path-provisioner/policy/network-policy.yaml
@@ -1,0 +1,80 @@
+---
+# =============================================================================
+# local-path-provisioner — Phase 4b (#2951)
+# Pod label: app=local-path-provisioner (Deployment, k3s built-in addon —
+#            NOT managed by the sibling Helm release in ../app/, which is
+#            commented out in apps/kube-system/kustomization.yaml).
+# Listens on: nothing (no exposed containerPort — verified).
+# Ingress: none required.
+# Egress to: K8s API (watches PersistentVolumeClaims and Pods; creates/
+#            deletes helper Pods for volume setup/teardown), DNS.
+#
+# Note: this policy lives under a dedicated `policy/` subdirectory because
+# the Helm-based local-path-provisioner ks.yaml is intentionally disabled —
+# the running addon ships with k3s and is reconciled by the k3s
+# `objectset.rio.cattle.io` machinery. The dedicated Flux Kustomization in
+# `policy/ks.yaml` reconciles only this NetworkPolicy + sibling
+# CiliumNetworkPolicy without touching the k3s-managed Deployment.
+# =============================================================================
+---
+# Default deny-all for local-path-provisioner
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: local-path-provisioner-default-deny
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      app: local-path-provisioner
+  policyTypes: [Ingress, Egress]
+---
+# Allow DNS resolution to CoreDNS in kube-system
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: local-path-provisioner-allow-dns
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      app: local-path-provisioner
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+---
+# Allow egress to Kubernetes API server (PVC/Pod watch + helper Pod
+# create/delete).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: local-path-provisioner-allow-k8s-api
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      app: local-path-provisioner
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.43.0.0/16  # Service CIDR (kubernetes.default.svc)
+    - ports:
+        - port: 443
+          protocol: TCP
+        - port: 6443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.87.42.2/32  # control plane node (defence-in-depth)

--- a/kubernetes/cluster0/apps/kube-system/metrics-server/app/cilium-network-policy.yaml
+++ b/kubernetes/cluster0/apps/kube-system/metrics-server/app/cilium-network-policy.yaml
@@ -1,0 +1,43 @@
+---
+# CiliumNetworkPolicy: metrics-server bi-directional K8s API allow + kubelet
+# egress on the host-network entity.
+#
+# Egress block 1: kube-apiserver entity allow (resource lookups for nodes,
+# APIService reconciliation). Standard ipBlock rules are bypassed by Cilium
+# under kubeProxyReplacement=true because the API server runs in the host
+# network namespace — see #2829 / #2947.
+#
+# Egress block 2: kubelet :10250 on every node. Kubelets run with
+# hostNetwork=true and Cilium assigns them `reserved:host` /
+# `reserved:remote-node` entity identity, so the egress on :10250 must use
+# `toEntities: [host, remote-node]`. Same pattern as #2965 (Prometheus host-
+# network scrape targets).
+#
+# Ingress: kube-apiserver calls back to the pod on :10250 (the aggregated
+# v1beta1.metrics.k8s.io APIService routes through the metrics-server Service).
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: metrics-server-allow-kube-apiserver
+  namespace: kube-system
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: metrics-server
+  egress:
+    - toEntities:
+        - kube-apiserver
+    - toEntities:
+        - host
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "10250"
+              protocol: TCP
+  ingress:
+    - fromEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "10250"
+              protocol: TCP

--- a/kubernetes/cluster0/apps/kube-system/metrics-server/app/kustomization.yaml
+++ b/kubernetes/cluster0/apps/kube-system/metrics-server/app/kustomization.yaml
@@ -4,3 +4,5 @@ kind: Kustomization
 namespace: kube-system
 resources:
   - ./helm-release.yaml
+  - ./network-policy.yaml
+  - ./cilium-network-policy.yaml

--- a/kubernetes/cluster0/apps/kube-system/metrics-server/app/network-policy.yaml
+++ b/kubernetes/cluster0/apps/kube-system/metrics-server/app/network-policy.yaml
@@ -1,0 +1,150 @@
+---
+# =============================================================================
+# metrics-server — Phase 4b (#2951)
+# Pod label: app.kubernetes.io/name=metrics-server (Deployment, 1 replica)
+# Listens on: :10250 (https — the apiservice + metrics endpoint)
+# Ingress from:
+#   - kube-apiserver on :10250 (the v1beta1.metrics.k8s.io APIService points
+#     at the metrics-server Service; HPA / `kubectl top` calls the aggregated
+#     API which kube-apiserver proxies to this pod). Authoritative allow is
+#     the sibling CiliumNetworkPolicy.
+#   - monitoring scrape on :10250 (ServiceMonitor metrics-server, scheme:
+#     https, insecureSkipVerify: true).
+# Egress to:
+#   - All node kubelets on :10250 (host-networked — node CIDR ipBlock +
+#     toEntities: [host, remote-node]).
+#   - K8s API for NodeMetrics / PodMetrics ApiService reconciliation.
+#   - DNS.
+# =============================================================================
+---
+# Default deny-all for metrics-server
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: metrics-server-default-deny
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: metrics-server
+  policyTypes: [Ingress, Egress]
+---
+# Allow DNS resolution to CoreDNS in kube-system
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: metrics-server-allow-dns
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: metrics-server
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+---
+# Allow ingress from kube-apiserver on :10250 (aggregated APIService callback
+# — pod containerPort 10250, Service maps :443 → :10250). Defence-in-depth
+# ipBlock; authoritative rule is the CiliumNetworkPolicy.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: metrics-server-allow-kube-apiserver-ingress
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: metrics-server
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - ipBlock:
+            cidr: 10.43.0.0/16  # Service CIDR (kubernetes.default.svc)
+        - ipBlock:
+            cidr: 10.87.42.2/32  # control plane node
+      ports:
+        - port: 10250
+          protocol: TCP
+---
+# Allow Prometheus to scrape metrics-server on :10250 (https).
+# ServiceMonitor metrics-server, scheme=https, insecureSkipVerify=true,
+# targetPort name=https → containerPort 10250.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: metrics-server-allow-prometheus-scrape
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: metrics-server
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+      ports:
+        - port: 10250
+          protocol: TCP
+---
+# Allow egress to all node kubelets on :10250 (host-networked — pod-selector
+# rules don't match `reserved:host` identity). The authoritative allow is the
+# CiliumNetworkPolicy `metrics-server-allow-kubelet` (toEntities: [host,
+# remote-node]); this ipBlock is defence-in-depth, mirroring the prometheus
+# kubelet-scrape pattern in #2965.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: metrics-server-allow-kubelet-egress
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: metrics-server
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 10250
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.87.42.0/24  # node CIDR — kubelet on host network
+---
+# Allow egress to Kubernetes API server (APIService and node listing).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: metrics-server-allow-k8s-api
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: metrics-server
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.43.0.0/16  # Service CIDR (kubernetes.default.svc)
+    - ports:
+        - port: 443
+          protocol: TCP
+        - port: 6443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.87.42.2/32  # control plane node (defence-in-depth)

--- a/kubernetes/cluster0/apps/kube-system/node-feature-discovery/app/cilium-network-policy.yaml
+++ b/kubernetes/cluster0/apps/kube-system/node-feature-discovery/app/cilium-network-policy.yaml
@@ -1,0 +1,18 @@
+---
+# CiliumNetworkPolicy: NFD egress to the K8s API server.
+# Companion to node-feature-discovery-allow-k8s-api (defence-in-depth ipBlock).
+# Authoritative under Cilium kubeProxyReplacement=true — see #2829 / #2947.
+# Selects all three NFD roles (master, gc, worker).
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: node-feature-discovery-allow-kube-apiserver
+  namespace: kube-system
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: node-feature-discovery
+      app.kubernetes.io/instance: node-feature-discovery
+  egress:
+    - toEntities:
+        - kube-apiserver

--- a/kubernetes/cluster0/apps/kube-system/node-feature-discovery/app/kustomization.yaml
+++ b/kubernetes/cluster0/apps/kube-system/node-feature-discovery/app/kustomization.yaml
@@ -5,6 +5,8 @@ kind: Kustomization
 namespace: kube-system
 resources:
   - ./helm-release.yaml
+  - ./network-policy.yaml
+  - ./cilium-network-policy.yaml
 labels:
   - pairs:
       app.kubernetes.io/name: node-feature-discovery

--- a/kubernetes/cluster0/apps/kube-system/node-feature-discovery/app/network-policy.yaml
+++ b/kubernetes/cluster0/apps/kube-system/node-feature-discovery/app/network-policy.yaml
@@ -1,0 +1,93 @@
+---
+# =============================================================================
+# node-feature-discovery — Phase 4b (#2951)
+# Pod label: app.kubernetes.io/name=node-feature-discovery
+# Three roles share the selector — distinguished by `role`:
+#   - master (Deployment, 1 replica): containerPort :8080 (http — health
+#     probe endpoint only; no in-cluster ingress consumers).
+#   - gc (Deployment, 1 replica): containerPort :8080 (http — health probe).
+#   - worker (DaemonSet, 4 pods): containerPort :8080 (http — health probe).
+#
+# Modern NFD (≥v0.10) communicates worker → master via NodeFeature CRDs in
+# the K8s API; there is no direct worker→master gRPC. So no intra-ns NFD
+# rule is required.
+#
+# No ServiceMonitor / PodMonitor selects NFD pods today — no Prometheus-scrape
+# ingress added (per the AC: don't add a scrape allow speculatively).
+#
+# Egress: K8s API (master reads NodeFeature CRDs and labels nodes; worker
+#         writes NodeFeature CRDs; gc reaps stale NodeFeature CRDs), DNS.
+# Ingress: kubelet :8080 health probes — same as every other pod in the
+#          cluster, not explicitly allowed (Cilium handles host→pod probes
+#          per the standard pattern; no other policy in this repo adds an
+#          explicit kubelet-probe allow either).
+#
+# Targeting all three roles via the shared name/instance pair keeps the
+# policy count minimal while still being unambiguous (no other pods in
+# kube-system have these labels).
+# =============================================================================
+---
+# Default deny-all for all NFD pods (master, gc, worker)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: node-feature-discovery-default-deny
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: node-feature-discovery
+      app.kubernetes.io/instance: node-feature-discovery
+  policyTypes: [Ingress, Egress]
+---
+# Allow DNS resolution to CoreDNS in kube-system
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: node-feature-discovery-allow-dns
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: node-feature-discovery
+      app.kubernetes.io/instance: node-feature-discovery
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+---
+# Allow egress to Kubernetes API server (NodeFeature CRD reconciliation +
+# node label patching).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: node-feature-discovery-allow-k8s-api
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: node-feature-discovery
+      app.kubernetes.io/instance: node-feature-discovery
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.43.0.0/16  # Service CIDR (kubernetes.default.svc)
+    - ports:
+        - port: 443
+          protocol: TCP
+        - port: 6443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.87.42.2/32  # control plane node (defence-in-depth)

--- a/kubernetes/cluster0/apps/kube-system/reloader/app/cilium-network-policy.yaml
+++ b/kubernetes/cluster0/apps/kube-system/reloader/app/cilium-network-policy.yaml
@@ -1,0 +1,16 @@
+---
+# CiliumNetworkPolicy: reloader egress to the K8s API server.
+# Companion to reloader-allow-k8s-api (defence-in-depth ipBlock). Authoritative
+# under Cilium kubeProxyReplacement=true — see #2829 / #2947.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: reloader-allow-kube-apiserver
+  namespace: kube-system
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: reloader
+  egress:
+    - toEntities:
+        - kube-apiserver

--- a/kubernetes/cluster0/apps/kube-system/reloader/app/network-policy.yaml
+++ b/kubernetes/cluster0/apps/kube-system/reloader/app/network-policy.yaml
@@ -1,0 +1,96 @@
+---
+# =============================================================================
+# reloader — Phase 4b (#2951)
+# Pod label: app.kubernetes.io/name=reloader (Deployment, 1 replica)
+# Listens on: :9090 (http — metrics endpoint)
+# Ingress from: monitoring scrape on :9090 (PodMonitor reloader, port=http).
+# Egress to: K8s API (watches ConfigMaps/Secrets cluster-wide for changes,
+#            triggers rollouts on owning Deployments/StatefulSets/DaemonSets),
+#            DNS.
+# =============================================================================
+---
+# Default deny-all for reloader
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: reloader-default-deny
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: reloader
+  policyTypes: [Ingress, Egress]
+---
+# Allow DNS resolution to CoreDNS in kube-system
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: reloader-allow-dns
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: reloader
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+---
+# Allow Prometheus to scrape reloader metrics on :9090 (PodMonitor "reloader"
+# selects port=http → containerPort 9090).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: reloader-allow-prometheus-scrape
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: reloader
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+      ports:
+        - port: 9090
+          protocol: TCP
+---
+# Allow egress to Kubernetes API server (watches ConfigMaps/Secrets
+# cluster-wide and triggers rolling updates).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: reloader-allow-k8s-api
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: reloader
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.43.0.0/16  # Service CIDR (kubernetes.default.svc)
+    - ports:
+        - port: 443
+          protocol: TCP
+        - port: 6443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.87.42.2/32  # control plane node (defence-in-depth)


### PR DESCRIPTION
## Summary

Phase 4b of the cluster NetworkPolicy rollout (#2812): default-deny + targeted NetworkPolicy / CiliumNetworkPolicy on **11 pods across two namespaces** — the entire `cert-manager` namespace plus the "minor services" in `kube-system` (everything except CoreDNS and host-networked Cilium / kube-vip).

CoreDNS lockdown is deliberately deferred to Phase 4c (#2952). Cilium agents, Cilium operator, Cilium envoy, and kube-vip pods are host-networked and exempt by design.

## What this PR contains

### `cert-manager` namespace (4 pods)

| Pod | Selector | Policies added |
|---|---|---|
| `cert-manager` controller | `name=cert-manager` + `component=controller` | default-deny, DNS, K8s API (NetworkPolicy + CiliumNetworkPolicy), external :80/:443 ACME egress, monitoring scrape on :9402 |
| `cert-manager-cainjector` | `name=cainjector` + `component=cainjector` | default-deny, DNS, K8s API (dual-policy), monitoring scrape on :9402 |
| `cert-manager-webhook` | `name=webhook` + `component=webhook` | default-deny, DNS, K8s API egress (dual-policy), **kube-apiserver ingress on :10250 (dual-policy — see risk note)**, monitoring scrape on :9402 |
| `trust-manager` | `name=trust-manager` | default-deny, DNS, K8s API (dual-policy), kube-apiserver ingress on :6443 (dual-policy for the Bundle webhook) |

### `kube-system` namespace (7 pod groups; host-networked exempt)

| Pod | Selector | Policies added |
|---|---|---|
| `hubble-relay` | `k8s-app=hubble-relay` | default-deny, DNS, intra-ns ingress from `hubble-ui` on :4245, egress to `host`/`remote-node` :4244 (CiliumNetworkPolicy) + node CIDR ipBlock |
| `hubble-ui` | `k8s-app=hubble-ui` | default-deny, DNS, ingress from `networking/traefik` on :8081, egress to intra-ns `hubble-relay` :4245 |
| `metrics-server` | `name=metrics-server` | default-deny, DNS, kube-apiserver ingress on :10250 (dual-policy), monitoring scrape on :10250, kubelet egress on :10250 (dual-policy with toEntities `host`/`remote-node` + node CIDR ipBlock), K8s API egress (dual-policy) |
| `reloader` | `name=reloader` | default-deny, DNS, monitoring scrape on :9090 (PodMonitor), K8s API egress (dual-policy) |
| `intel-gpu-plugin` (DaemonSet) | `app=intel-gpu-plugin` | default-deny, DNS only (no network egress required — plugin uses local unix socket to kubelet) |
| `inteldeviceplugins-controller-manager` | `control-plane=controller-manager` | default-deny, DNS, kube-apiserver ingress on :9443 (dual-policy), K8s API egress (dual-policy) |
| `node-feature-discovery` (master + gc + worker — single selector) | `name=node-feature-discovery` + `instance=node-feature-discovery` | default-deny, DNS, K8s API egress (dual-policy). Modern NFD uses NodeFeature CRDs — no intra-ns gRPC. |
| `local-path-provisioner` | `app=local-path-provisioner` | default-deny, DNS, K8s API egress (dual-policy). Targets the **k3s built-in addon** (the sibling Helm release's `ks.yaml` was previously commented out and is left disabled; policies live under a new `policy/` subdirectory). |

### Files added / modified

- `apps/cert-manager/cert-manager/app/{network-policy,cilium-network-policy}.yaml` (+ `kustomization.yaml`)
- `apps/cert-manager/trust-manager/app/{network-policy,cilium-network-policy}.yaml` (+ `kustomization.yaml`)
- `apps/kube-system/cilium/app/{network-policy,cilium-network-policy}.yaml` (+ `kustomization.yaml`) — hubble-relay + hubble-ui only (cilium-agent/operator/envoy are host-networked and exempt)
- `apps/kube-system/intel-device-plugin/app/{network-policy,cilium-network-policy}.yaml` (+ `kustomization.yaml`) — controller-manager
- `apps/kube-system/intel-device-plugin/gpu/network-policy.yaml` (+ `kustomization.yaml`) — DaemonSet
- `apps/kube-system/metrics-server/app/{network-policy,cilium-network-policy}.yaml` (+ `kustomization.yaml`)
- `apps/kube-system/node-feature-discovery/app/{network-policy,cilium-network-policy}.yaml` (+ `kustomization.yaml`)
- `apps/kube-system/reloader/app/{network-policy,cilium-network-policy}.yaml` (+ `kustomization.yaml`)
- `apps/kube-system/local-path-provisioner/policy/{network-policy,cilium-network-policy,kustomization}.yaml` (new directory) + re-enabled `local-path-provisioner/ks.yaml` (pointing at the new `policy/` path, not the unused `app/` path)
- `apps/kube-system/kustomization.yaml` — uncomment `./local-path-provisioner/ks.yaml`

## Verification done before authoring

| Check | Result |
|---|---|
| All 11 pod label selectors verified via `kubectl get pod ... --show-labels` | ✅ confirmed (cert-manager-cainjector is `name=cainjector`, not `name=cert-manager`; webhook is `name=webhook`; intel daemonset uses bare `app=intel-gpu-plugin`; local-path-provisioner uses bare `app=local-path-provisioner` from the k3s built-in addon, not Helm) |
| cert-manager-webhook containerPort | `:10250` (name: https) — verified on the running pod |
| trust-manager containerPort | `:6443` (name: webhook), `:9402` (metrics) |
| hubble-ui containerPorts | frontend `:8081`, backend `:8090` (intra-pod) |
| hubble-relay containerPort | `:4245` (grpc) |
| metrics-server containerPort | `:10250` (https) — Service `:443` → pod `:10250` |
| reloader containerPort | `:9090` (http) |
| inteldeviceplugins-controller-manager containerPort | `:9443` (webhook-server) |
| NFD containerPorts (master/gc/worker) | `:8080` (http; health probe only — no intra-cluster RPC) |
| intel-gpu-plugin / local-path-provisioner ports | none — DaemonSet and k3s addon expose nothing on the network |
| ServiceMonitor / PodMonitor inventory | `cert-manager` (all 3 components on :9402), `metrics-server` (:10250 https), `reloader` PodMonitor (:9090 http). **No SM/PM** for trust-manager, hubble-relay, hubble-ui, NFD, intel-gpu-plugin, controller-manager, or local-path-provisioner → no speculative scrape allows added. |
| trust-manager webhook callback | `ValidatingWebhookConfiguration/trust-manager` exists → ingress allow added on :6443 |
| inteldeviceplugins controller webhook callback | Service `inteldeviceplugins-webhook-service` (:443→:9443) exists → ingress allow added on :9443 |
| kube-apiserver ingress entity | CiliumNetworkPolicy `fromEntities: [kube-apiserver]` on cert-manager-webhook :10250, trust-manager :6443, metrics-server :10250, inteldeviceplugins-controller-manager :9443 |
| K8s API ipBlock pattern | `10.43.0.0/16` (Service CIDR) + `10.87.42.2/32` (control plane) — matches cnpg / kube-prometheus-stack / external-dns / traefik |
| Node CIDR for metrics-server kubelet egress | `10.87.42.0/24` ipBlock (NetworkPolicy) + `toEntities: [host, remote-node]` (CiliumNetworkPolicy) — matches #2965 host-network scrape pattern |
| hubble-relay → cilium-agents hubble-peer | `:4244` to `toEntities: [host, remote-node]` (cilium agents are host-networked) + node CIDR ipBlock companion |
| `kubectl kustomize` build | clean for `apps/cert-manager`, `apps/kube-system`, and every leaf `*/app/` and `*/policy/` directory in scope |
| Server-side schema dry-run | all NetworkPolicy + CiliumNetworkPolicy manifests pass server-side validation (errors observed are RBAC-only) |

## Critical risk

**The cert-manager-webhook ingress is the most fragile rule in this PR.** kube-apiserver calls this webhook whenever **any** Certificate, Issuer, ClusterIssuer, or CertificateRequest resource changes anywhere in the cluster. If the rule is wrong, cert-manager operations silently halt cluster-wide.

The rule is implemented with **both** a CiliumNetworkPolicy `fromEntities: [kube-apiserver]` (authoritative under `kubeProxyReplacement=true`) and a defence-in-depth ipBlock NetworkPolicy — same dual-policy pattern as cnpg-operator's webhook (#2947).

Webhook containerPort verified as `:10250` (name: https) on the running pod — NetworkPolicy enforces on pod containerPorts, **not** the Service `:443`. If Cilium drops the connection because the API server's `kube-apiserver` entity doesn't match a `toEntities` allow, the CiliumNetworkPolicy is what catches it; the ipBlock alone would be silently bypassed.

The same pattern is applied to trust-manager (webhook on :6443) and the Intel device-plugin controller-manager (webhook on :9443).

## Post-merge verification (for coordinator)

```bash
# Reconcile
flux reconcile source git home-ops-cluster0
# (Flux will reconcile every affected Kustomization — cert-manager,
#  trust-manager, cilium, intel-device-plugin-{operator,gpu},
#  node-feature-discovery, metrics-server, reloader, and the newly-re-enabled
#  local-path-provisioner)

# Confirm policies created
kubectl -n cert-manager get networkpolicy
kubectl -n cert-manager get ciliumnetworkpolicy
kubectl -n kube-system  get networkpolicy
kubectl -n kube-system  get ciliumnetworkpolicy

# *** Critical smoke — cert-manager webhook still callable ***
kubectl describe validatingwebhookconfiguration cert-manager-webhook   # no recent errors
kubectl get certificates -A                                            # all Ready=True
# Force a renewal to exercise the path end-to-end:
kubectl -n <ns> annotate certificate <name> cert-manager.io/issue-temporary-certificate-

# Functional smoke
kubectl top nodes                                                       # metrics-server
# Hubble UI reachable via Traefik (https://hubble.<domain>)
# Reloader still triggers rollouts on ConfigMap edit
kubectl describe node | grep 'gpu.intel.com/i915'                       # intel-gpu-plugin
kubectl get nodes -L feature.node.kubernetes.io/cpu-cpuid.AVX2          # NFD labels

# Drop watch
hubble observe --namespace cert-manager --verdict DROPPED --since 10m
hubble observe --namespace kube-system  --verdict DROPPED --since 10m
```

## Out of scope (per #2951)

- **CoreDNS** — Phase 4c (#2952).
- **Cilium agent / operator / envoy, kube-vip** — host-networked, NetworkPolicy doesn't apply.
- **Restricting cert-manager external :443 egress to specific ACME endpoints** — Let's Encrypt etc. use Cloudflare CDN IPs that rotate; rule is intentionally wide with RFC1918 excluded.

## Notes

- A parallel worker is editing `apps/seaweedfs/seaweedfs/app/network-policy.yaml` (#2969). Disjoint from this work.
- Phase 4a (#2950) is already merged — the `kube-system` namespace already carries `netpol.home-ops/traefik-backend: "true"`.
- Phase 4c (#2952) will modify `apps/longhorn-system/` and `apps/kube-system/coredns/`. This PR does not touch CoreDNS.
- Merge queue is currently unavailable — coordinator will squash-merge manually.

Refs #2812
Closes #2951
