### PR TITLE
fix(netpol): hubble-ui backend K8s API egress allow (Phase 4b gap)

### DIFF
--- a/kubernetes/cluster0/apps/kube-system/cilium/app/cilium-network-policy.yaml
+++ b/kubernetes/cluster0/apps/kube-system/cilium/app/cilium-network-policy.yaml
@@ -26,3 +26,22 @@ spec:
         - ports:
             - port: "4244"
               protocol: TCP
+---
+# CiliumNetworkPolicy companion for hubble-ui-allow-k8s-api. Required because
+# Cilium kubeProxyReplacement=true rewrites Service routing to the host-
+# networked API server in a way that bypasses ipBlock NetworkPolicy matches.
+# Pattern parallels every other dual-policy K8s API egress in this cluster
+# (#2829 external-dns, #2947 cnpg, #2965 prometheus, plus the cert-manager/
+# metrics-server/reloader/NFD policies in this same Phase 4b PR).
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: hubble-ui-allow-kube-apiserver
+  namespace: kube-system
+spec:
+  endpointSelector:
+    matchLabels:
+      k8s-app: hubble-ui
+  egress:
+    - toEntities:
+        - kube-apiserver

--- a/kubernetes/cluster0/apps/kube-system/cilium/app/network-policy.yaml
+++ b/kubernetes/cluster0/apps/kube-system/cilium/app/network-policy.yaml
@@ -199,3 +199,36 @@ spec:
           podSelector:
             matchLabels:
               k8s-app: hubble-relay
+---
+# Allow egress from hubble-ui backend container to the K8s API server.
+# The backend image (hubble-ui-backend) is a K8s client that watches
+# Namespaces/Pods/Services to enrich Hubble flow records. Dual-policy pattern
+# per #2829 / #2947 / #2965: ipBlock here, toEntities in the sibling
+# CiliumNetworkPolicy (hubble-ui-allow-kube-apiserver). Cilium kubeProxyReplacement
+# can bypass ipBlock matches against the host-networked API server — both
+# policies are required.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: hubble-ui-allow-k8s-api
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      k8s-app: hubble-ui
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.43.0.0/16  # Service CIDR (kubernetes.default.svc)
+    - ports:
+        - port: 443
+          protocol: TCP
+        - port: 6443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.87.42.2/32  # control plane node (defence-in-depth)


### PR DESCRIPTION
## Summary

Phase 4b (PR #2973) attached default-deny NetworkPolicies to hubble-ui but missed K8s API egress. The hubble-ui **backend** container (`quay.io/cilium/hubble-ui-backend`) is a Kubernetes API client that watches Namespaces/Pods/Services to enrich Hubble flow records with workload metadata for the UI. After Phase 4b landed, every backend API request was POLICY_DENIED — 48 drops in 5 minutes confirmed via Hubble, and the backend log showed `first tick failed / context canceled`.

## Fix

Apply the same dual-policy pattern used by every other K8s-API-client pod in the cluster (cert-manager, metrics-server, reloader, NFD, external-dns, cnpg, prometheus, …):

1. `kubernetes/cluster0/apps/kube-system/cilium/app/network-policy.yaml` — add `hubble-ui-allow-k8s-api` standard NetworkPolicy with ipBlock egress to `10.43.0.0/16:443` (service CIDR) and `10.87.42.2/32:{443,6443}` (control plane node). Shape mirrors `metrics-server-allow-k8s-api` verbatim.
2. `kubernetes/cluster0/apps/kube-system/cilium/app/cilium-network-policy.yaml` — add `hubble-ui-allow-kube-apiserver` CiliumNetworkPolicy with `toEntities: [kube-apiserver]`. Required because Cilium `kubeProxyReplacement=true` rewrites Service routing in a way that bypasses ipBlock matches against the host-networked API server.

No other field in either file is modified. No files outside `kubernetes/cluster0/apps/kube-system/cilium/app/` are touched.

## Verification

- `kubectl kustomize kubernetes/cluster0/apps/kube-system` builds cleanly.
- `kubectl kustomize kubernetes/cluster0/apps/kube-system/cilium/app` builds cleanly and both new policies appear in the output.

Post-merge verification steps (Hubble drop watch, backend log check, UI smoke) are detailed in the issue body.

Closes #2974
Refs #2951