### PR TITLE
feat(netpol): phase 4c — Longhorn wide-then-tighten + CoreDNS lockdown

### DIFF
--- a/kubernetes/cluster0/apps/kube-system/coredns/ks.yaml
+++ b/kubernetes/cluster0/apps/kube-system/coredns/ks.yaml
@@ -6,16 +6,22 @@ metadata:
   name: cluster-apps-coredns
   namespace: flux-system
 spec:
-  path: ./kubernetes/cluster0/apps/kube-system/coredns/app
+  # The CoreDNS HelmRelease in ./app/ is intentionally NOT reconciled — the
+  # historical Flux Kustomization line in apps/kube-system/kustomization.yaml
+  # was disabled long before Phase 4 because the live CoreDNS install pre-
+  # dates Flux management of the chart and re-adopting it without an outage
+  # window is risky.
+  #
+  # Phase 4c (#2952) re-enables this Flux Kustomization but points it at a
+  # dedicated ./policy/ directory containing only the NetworkPolicy and
+  # CiliumNetworkPolicy that lock down the in-cluster CoreDNS pods (selector
+  # k8s-app=kube-dns). Same pattern as
+  # apps/kube-system/local-path-provisioner/{policy,ks.yaml} from Phase 4b.
+  path: ./kubernetes/cluster0/apps/kube-system/coredns/policy
   prune: false # never should be deleted
   sourceRef:
     kind: GitRepository
     name: home-ops-cluster0
-  healthChecks:
-    - apiVersion: helm.toolkit.fluxcd.io/v2
-      kind: HelmRelease
-      name: coredns
-      namespace: kube-system
   wait: false
   interval: 30m
   retryInterval: 1m

--- a/kubernetes/cluster0/apps/kube-system/coredns/policy/cilium-network-policy.yaml
+++ b/kubernetes/cluster0/apps/kube-system/coredns/policy/cilium-network-policy.yaml
@@ -1,0 +1,16 @@
+---
+# CiliumNetworkPolicy: CoreDNS egress to the K8s API server. Companion to
+# coredns-allow-k8s-api (defence-in-depth ipBlock). Authoritative under Cilium
+# kubeProxyReplacement=true — see #2829 / #2947.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: coredns-allow-kube-apiserver
+  namespace: kube-system
+spec:
+  endpointSelector:
+    matchLabels:
+      k8s-app: kube-dns
+  egress:
+    - toEntities:
+        - kube-apiserver

--- a/kubernetes/cluster0/apps/kube-system/coredns/policy/kustomization.yaml
+++ b/kubernetes/cluster0/apps/kube-system/coredns/policy/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kube-system
+resources:
+  - ./network-policy.yaml
+  - ./cilium-network-policy.yaml

--- a/kubernetes/cluster0/apps/kube-system/coredns/policy/network-policy.yaml
+++ b/kubernetes/cluster0/apps/kube-system/coredns/policy/network-policy.yaml
@@ -1,0 +1,230 @@
+---
+# =============================================================================
+# CoreDNS — Phase 4c (#2952, parent design #2812).
+# **The final Phase 4 child PR — deliberately last in the whole rollout.**
+#
+# CoreDNS is the cluster's DNS server. A mistake here means every pod cluster-
+# wide loses name resolution. This policy is deliberately landed last so that
+# every other namespace has had its DNS egress rule verified working in
+# practice in steady state before CoreDNS itself is locked down.
+#
+# Running deployment: `coredns` (Deployment, replicaCount=2) selected by
+# `k8s-app=kube-dns`. The Deployment was installed from the upstream CoreDNS
+# Helm chart and the in-cluster ConfigMap `coredns` carries this Corefile:
+#
+#     dns://.:53 {
+#         log
+#         errors
+#         health { lameduck 5s }
+#         ready
+#         kubernetes cluster.local in-addr.arpa ip6.arpa {
+#             pods insecure
+#             fallthrough in-addr.arpa ip6.arpa
+#             ttl 30
+#         }
+#         prometheus 0.0.0.0:9153
+#         forward . /etc/resolv.conf
+#         cache 30
+#         loop
+#         reload
+#         loadbalance
+#     }
+#
+# The `forward . /etc/resolv.conf` clause delegates upstream resolution to the
+# node's resolv.conf (the Deployment runs with dnsPolicy=Default). On this
+# cluster the node resolv.conf points at the Blocky DNS appliances exposed as
+# LoadBalancer services in the `networking` namespace:
+#   - blocky-primary-dns   LB IP 10.87.42.11
+#   - blocky-secondary-dns LB IP 10.87.42.15
+# Both LB IPs sit in the node /24 (10.87.42.0/24). The egress allow below
+# scopes upstream DNS to that /24 — covering the Blocky LBs plus the router
+# and any other LAN-side DNS device on the same subnet. Per #2812 and #2952
+# the upstream-DNS narrowing beyond this point is explicitly router-config
+# territory and out of scope.
+#
+# This file lives under a dedicated `policy/` subdirectory (sibling to `app/`)
+# in the same pattern as `local-path-provisioner/policy/`: the Helm release
+# in `coredns/app/helm-release.yaml` is intentionally NOT reconciled by the
+# root `apps/kube-system/kustomization.yaml` because the live CoreDNS install
+# predates Flux management of this chart and the team has chosen not to take
+# it over yet. The dedicated Flux Kustomization in `coredns/ks.yaml` (re-
+# enabled by this PR) reconciles only the policies in this directory.
+# =============================================================================
+---
+# -----------------------------------------------------------------------------
+# Default-deny for CoreDNS pods.
+# -----------------------------------------------------------------------------
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: coredns-default-deny
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      k8s-app: kube-dns
+  policyTypes: [Ingress, Egress]
+---
+# -----------------------------------------------------------------------------
+# INTENTIONAL WILDCARD INGRESS — every pod in every namespace can reach
+# CoreDNS on :53.
+#
+# This is the single, deliberate `namespaceSelector: {}` rule in the whole
+# Phase 4 rollout (#2812, #2952). Every other ingress rule in this PR — and
+# every other rule across Phases 1-3 — uses tightly-scoped namespaceSelector
+# + podSelector AND-shape entries.
+#
+# The wildcard is correct here, and ONLY here, because:
+#   - DNS is universal. Every pod cluster-wide needs to resolve names via
+#     CoreDNS; the alternative is enumerating every namespace selector here
+#     and updating this file on every new namespace.
+#   - The risk surface is tightly bound by port: only :53 UDP and :53 TCP
+#     are allowed. CoreDNS exposes :9153 for Prometheus scrape; that port
+#     has its own ingress rule below scoped to the Prometheus pod selector.
+#
+# Reference: #2952 Acceptance Criteria — "CoreDNS wildcard
+# `namespaceSelector: {}` is the only wildcard in this PR".
+# -----------------------------------------------------------------------------
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: coredns-allow-dns-ingress
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      k8s-app: kube-dns
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector: {}    # universal — see comment above; this is
+                                   # the ONE deliberate wildcard in Phase 4.
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+---
+# -----------------------------------------------------------------------------
+# Prometheus scrape ingress on :9153 (CoreDNS `prometheus 0.0.0.0:9153`).
+# Scope: monitoring ns + app.kubernetes.io/name=prometheus pod selector.
+# -----------------------------------------------------------------------------
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: coredns-allow-prometheus-scrape
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      k8s-app: kube-dns
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+      ports:
+        - port: 9153
+          protocol: TCP
+---
+# -----------------------------------------------------------------------------
+# Egress to upstream DNS on :53 — scoped to the node /24 (10.87.42.0/24).
+#
+# CoreDNS's `forward . /etc/resolv.conf` delegates to the node's resolv.conf,
+# which on this cluster points at the Blocky LB IPs (10.87.42.11,
+# 10.87.42.15) in the same /24 as the nodes. Narrowing beyond the /24 is
+# router-config territory and explicitly out of scope per #2812 / #2952.
+#
+# This rule is the closest equivalent to "ipBlock entries from the Corefile"
+# expected by the issue ACs — the Corefile delegates to resolv.conf, and
+# resolv.conf resolves to addresses in this /24.
+# -----------------------------------------------------------------------------
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: coredns-allow-upstream-dns-egress
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      k8s-app: kube-dns
+  policyTypes: [Egress]
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 10.87.42.0/24   # node /24 — covers Blocky LB IPs
+                                  # (10.87.42.11, 10.87.42.15) and any other
+                                  # LAN-side DNS appliance on this subnet
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+---
+# -----------------------------------------------------------------------------
+# Egress to K8s API — CoreDNS's `kubernetes cluster.local …` plugin watches
+# Endpoints/Services/Pods via the apiserver to answer in-cluster lookups.
+#
+# Dual-policy pattern: this ipBlock NetworkPolicy is defence-in-depth; the
+# authoritative rule under kubeProxyReplacement=true is the sibling
+# CiliumNetworkPolicy with `toEntities: [kube-apiserver]`.
+# -----------------------------------------------------------------------------
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: coredns-allow-k8s-api
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      k8s-app: kube-dns
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.43.0.0/16   # Service CIDR (kubernetes.default.svc)
+    - ports:
+        - port: 443
+          protocol: TCP
+        - port: 6443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.87.42.2/32  # control plane node (defence-in-depth)
+---
+# -----------------------------------------------------------------------------
+# Intra-CoreDNS egress on :53 — the two replicas occasionally chat to each
+# other (loop detection, health probes via Service). Scoped tight to the
+# `k8s-app=kube-dns` pod selector inside kube-system; no broader kube-system
+# allow (CoreDNS does NOT need to talk to other kube-system pods).
+# -----------------------------------------------------------------------------
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: coredns-allow-peer-egress
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      k8s-app: kube-dns
+  policyTypes: [Egress]
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP

--- a/kubernetes/cluster0/apps/kube-system/kustomization.yaml
+++ b/kubernetes/cluster0/apps/kube-system/kustomization.yaml
@@ -6,9 +6,11 @@ resources:
   - ./namespace.yaml
   # Flux-Kustomizations
   - ./cilium/ks.yaml
-  # I havent been able to figure out how to override the cusotm coredns addon
-  # I manged to with cilium, but when there is no coredns, things fall apart
-  # - ./coredns/ks.yaml
+  # The CoreDNS HelmRelease in ./coredns/app/ remains intentionally disabled
+  # (live CoreDNS predates Flux management of the chart). Phase 4c (#2952)
+  # re-enables this Flux Kustomization pointing at ./coredns/policy/ — see
+  # ./coredns/ks.yaml for the rationale.
+  - ./coredns/ks.yaml
   - ./intel-device-plugin/ks.yaml
   # Phase 4b (#2951): re-enabled but pointing at a NetworkPolicy-only path —
   # the actual local-path-provisioner running in the cluster is the k3s

--- a/kubernetes/cluster0/apps/longhorn-system/longhorn/app/cilium-network-policy.yaml
+++ b/kubernetes/cluster0/apps/longhorn-system/longhorn/app/cilium-network-policy.yaml
@@ -1,0 +1,102 @@
+---
+# =============================================================================
+# Longhorn — CiliumNetworkPolicy companions for K8s API egress (Phase 4c,
+# #2952). Authoritative under Cilium kubeProxyReplacement=true because the
+# apiserver runs in the host network namespace and standard NetworkPolicy
+# ipBlock matches are bypassed — see #2829 (external-dns) and #2947 (cnpg-
+# operator) for the original investigation.
+#
+# Each policy mirrors a sibling NetworkPolicy in ./network-policy.yaml and
+# selects the same pod label set.
+# =============================================================================
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: longhorn-manager-allow-kube-apiserver
+  namespace: longhorn-system
+spec:
+  endpointSelector:
+    matchLabels:
+      app: longhorn-manager
+  egress:
+    - toEntities:
+        - kube-apiserver
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: longhorn-csi-plugin-allow-kube-apiserver
+  namespace: longhorn-system
+spec:
+  endpointSelector:
+    matchLabels:
+      app: longhorn-csi-plugin
+  egress:
+    - toEntities:
+        - kube-apiserver
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: csi-attacher-allow-kube-apiserver
+  namespace: longhorn-system
+spec:
+  endpointSelector:
+    matchLabels:
+      app: csi-attacher
+  egress:
+    - toEntities:
+        - kube-apiserver
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: csi-provisioner-allow-kube-apiserver
+  namespace: longhorn-system
+spec:
+  endpointSelector:
+    matchLabels:
+      app: csi-provisioner
+  egress:
+    - toEntities:
+        - kube-apiserver
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: csi-resizer-allow-kube-apiserver
+  namespace: longhorn-system
+spec:
+  endpointSelector:
+    matchLabels:
+      app: csi-resizer
+  egress:
+    - toEntities:
+        - kube-apiserver
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: csi-snapshotter-allow-kube-apiserver
+  namespace: longhorn-system
+spec:
+  endpointSelector:
+    matchLabels:
+      app: csi-snapshotter
+  egress:
+    - toEntities:
+        - kube-apiserver
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: longhorn-driver-deployer-allow-kube-apiserver
+  namespace: longhorn-system
+spec:
+  endpointSelector:
+    matchLabels:
+      app: longhorn-driver-deployer
+  egress:
+    - toEntities:
+        - kube-apiserver

--- a/kubernetes/cluster0/apps/longhorn-system/longhorn/app/kustomization.yaml
+++ b/kubernetes/cluster0/apps/longhorn-system/longhorn/app/kustomization.yaml
@@ -5,6 +5,8 @@ resources:
   - helm-release.yaml
   - httproute.yaml
   - prometheusrule.yaml
+  - network-policy.yaml
+  - cilium-network-policy.yaml
 labels:
   - pairs:
       app.kubernetes.io/name: longhorn

--- a/kubernetes/cluster0/apps/longhorn-system/longhorn/app/network-policy.yaml
+++ b/kubernetes/cluster0/apps/longhorn-system/longhorn/app/network-policy.yaml
@@ -1,0 +1,459 @@
+---
+# =============================================================================
+# Longhorn — Phase 4c (#2952, parent design #2812)
+#
+# Wide-then-tighten storage policies. Longhorn's data plane allocates dynamic
+# ports in the 10000-30000 range across instance-manager pods and engines;
+# narrow per-port allows risk silent volume corruption when the engine
+# re-binds. The conscious decision (#2812 Phase 4 baseline, #2952 design) is
+# to start with a wide intra-namespace allow and tighten only after a
+# multi-day Hubble baseline confirms a clean steady state — explicitly
+# deferred to a hypothetical Phase 5.
+#
+# Pod inventory (selectors used below):
+#   - longhorn-manager     (DaemonSet)    — app=longhorn-manager
+#   - longhorn-ui          (Deployment)   — app=longhorn-ui
+#   - longhorn-driver-deployer (Deploy)   — app=longhorn-driver-deployer
+#   - csi-attacher / -provisioner /
+#     -resizer / -snapshotter (Deploys)   — app=csi-{attacher,provisioner,…}
+#   - longhorn-csi-plugin  (DaemonSet)    — app=longhorn-csi-plugin
+#   - instance-manager-*   (dynamic)      — longhorn.io/component=instance-manager
+#   - engine-image-ei-*    (DaemonSet)    — longhorn.io/component=engine-image
+#   - friday-backup-*      (Job pods from a CronJob; weekly backup) —
+#                                           recurring-job.longhorn.io=friday-backup
+#                                           This is the "longhorn-friday" pod
+#                                           investigated in #2952 — it's a
+#                                           short-lived backup job that only
+#                                           talks intra-ns to longhorn-backend
+#                                           :9500; folded into the wide
+#                                           intra-ns allow.
+#
+# External flows (NOT covered by the wide intra-ns allow):
+#   - DNS: every pod → CoreDNS :53 in kube-system
+#   - K8s API egress: longhorn-manager, longhorn-csi-plugin, csi-*, and
+#     longhorn-driver-deployer reconcile CRDs and watch resources
+#   - Traefik ingress: longhorn-ui :8000 from networking ns
+#   - Prometheus scrape ingress: longhorn-manager :9500 (ServiceMonitor
+#     `longhorn-prometheus-servicemonitor` selects app=longhorn-manager,
+#     port name=manager → containerPort 9500)
+#   - Backup target NFS: instance-manager + longhorn-manager pods write the
+#     Friday backup to nfs://${NAS0_IP}:/volume1/longhorn-backups
+#     (NAS0 = 10.87.42.200 — same /24 as the nodes but NOT a node)
+#
+# Out of scope (per #2952 / #2812): narrowing the 10000-30000 data-plane port
+# range, blocking node-to-node Longhorn traffic.
+# =============================================================================
+---
+# -----------------------------------------------------------------------------
+# Default-deny — applies to every pod in longhorn-system.
+# -----------------------------------------------------------------------------
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: longhorn-default-deny
+  namespace: longhorn-system
+spec:
+  podSelector: {}
+  policyTypes: [Ingress, Egress]
+---
+# -----------------------------------------------------------------------------
+# INTENTIONAL WIDE INTRA-NAMESPACE ALLOW.
+#
+# Selects EVERY pod in longhorn-system (`podSelector: {}`) and allows BOTH
+# ingress from and egress to every other pod in longhorn-system. This is the
+# rare "intentional wide allow" case in the netpol rollout (#2812, #2952).
+#
+# Rationale: Longhorn's data plane (instance-manager pods, engine processes)
+# binds ephemeral ports across the 10000-30000 range. Replicas, engines, and
+# managers all talk to each other on these dynamic ports. Per-port allows
+# would silently drop replica traffic on every port re-allocation and risk
+# volume corruption. The wide intra-ns allow is correct here because every
+# pod in this namespace is part of the same storage subsystem and there is
+# no cross-tenant trust boundary inside it.
+#
+# Tightening this is explicitly out-of-scope for Phase 4c; defer to a Phase
+# 5 only with a multi-day Hubble baseline that enumerates the actual port
+# distribution under sustained load. See #2812 §"Out of scope" and #2952
+# §"Out of scope".
+# -----------------------------------------------------------------------------
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: longhorn-allow-intra-namespace
+  namespace: longhorn-system
+spec:
+  podSelector: {}
+  policyTypes: [Ingress, Egress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: longhorn-system
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: longhorn-system
+---
+# -----------------------------------------------------------------------------
+# DNS egress to CoreDNS in kube-system — applies to every pod.
+#
+# The wide intra-ns allow above does NOT cover DNS because CoreDNS lives in
+# kube-system. Without this explicit cross-namespace rule no pod could
+# resolve any name once the default-deny is in effect.
+# -----------------------------------------------------------------------------
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: longhorn-allow-dns
+  namespace: longhorn-system
+spec:
+  podSelector: {}
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+---
+# -----------------------------------------------------------------------------
+# longhorn-ui — Traefik ingress on :8000 (pod containerPort named `http`;
+# Service `longhorn-frontend` maps :80 → targetPort http).
+#
+# AND-shape: namespaceSelector (networking) + podSelector (Traefik) under a
+# single from-entry.
+# -----------------------------------------------------------------------------
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: longhorn-ui-allow-traefik-ingress
+  namespace: longhorn-system
+spec:
+  podSelector:
+    matchLabels:
+      app: longhorn-ui
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: networking
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: traefik
+      ports:
+        - port: 8000
+          protocol: TCP
+---
+# -----------------------------------------------------------------------------
+# longhorn-manager — Prometheus scrape ingress on :9500 (port name `manager`,
+# matching ServiceMonitor `longhorn-prometheus-servicemonitor` which selects
+# app=longhorn-manager and scrapes port name `manager`).
+#
+# AND-shape: monitoring ns + Prometheus pod selector.
+# -----------------------------------------------------------------------------
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: longhorn-manager-allow-prometheus-scrape
+  namespace: longhorn-system
+spec:
+  podSelector:
+    matchLabels:
+      app: longhorn-manager
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+      ports:
+        - port: 9500
+          protocol: TCP
+---
+# -----------------------------------------------------------------------------
+# K8s API egress — longhorn-manager.
+#
+# longhorn-manager is the control plane: it watches CRDs (Volume, Engine,
+# Replica, BackingImage, RecurringJob, etc.), updates status, creates/deletes
+# instance-manager pods, and runs the admission + recovery-backend
+# controllers. Talks to the apiserver constantly.
+#
+# Dual-policy pattern: standard NetworkPolicy ipBlock (defence-in-depth) +
+# sibling CiliumNetworkPolicy `toEntities: [kube-apiserver]` (authoritative
+# under Cilium kubeProxyReplacement=true — see #2829 / #2947).
+# -----------------------------------------------------------------------------
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: longhorn-manager-allow-k8s-api
+  namespace: longhorn-system
+spec:
+  podSelector:
+    matchLabels:
+      app: longhorn-manager
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.43.0.0/16  # Service CIDR (kubernetes.default.svc)
+    - ports:
+        - port: 443
+          protocol: TCP
+        - port: 6443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.87.42.2/32  # control plane node (defence-in-depth)
+---
+# -----------------------------------------------------------------------------
+# K8s API egress — longhorn-csi-plugin (DaemonSet).
+#
+# longhorn-csi-plugin runs the CSI node-plugin sidecars (driver-registrar,
+# liveness-probe, csi-plugin) and watches Node/VolumeAttachment for mount
+# coordination. Needs apiserver access for the node-registrar handshake.
+# -----------------------------------------------------------------------------
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: longhorn-csi-plugin-allow-k8s-api
+  namespace: longhorn-system
+spec:
+  podSelector:
+    matchLabels:
+      app: longhorn-csi-plugin
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.43.0.0/16  # Service CIDR
+    - ports:
+        - port: 443
+          protocol: TCP
+        - port: 6443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.87.42.2/32  # control plane node
+---
+# -----------------------------------------------------------------------------
+# K8s API egress — csi-attacher / csi-provisioner / csi-resizer /
+# csi-snapshotter (the external CSI sidecars, each a Deployment with 3
+# replicas). Each watches a distinct CRD set (VolumeAttachment, PVC,
+# VolumeSnapshot, etc.) and patches status back via the apiserver.
+#
+# One NetworkPolicy per sidecar app label so a regression on one doesn't
+# silently affect the others.
+# -----------------------------------------------------------------------------
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: csi-attacher-allow-k8s-api
+  namespace: longhorn-system
+spec:
+  podSelector:
+    matchLabels:
+      app: csi-attacher
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.43.0.0/16
+    - ports:
+        - port: 443
+          protocol: TCP
+        - port: 6443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.87.42.2/32
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: csi-provisioner-allow-k8s-api
+  namespace: longhorn-system
+spec:
+  podSelector:
+    matchLabels:
+      app: csi-provisioner
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.43.0.0/16
+    - ports:
+        - port: 443
+          protocol: TCP
+        - port: 6443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.87.42.2/32
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: csi-resizer-allow-k8s-api
+  namespace: longhorn-system
+spec:
+  podSelector:
+    matchLabels:
+      app: csi-resizer
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.43.0.0/16
+    - ports:
+        - port: 443
+          protocol: TCP
+        - port: 6443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.87.42.2/32
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: csi-snapshotter-allow-k8s-api
+  namespace: longhorn-system
+spec:
+  podSelector:
+    matchLabels:
+      app: csi-snapshotter
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.43.0.0/16
+    - ports:
+        - port: 443
+          protocol: TCP
+        - port: 6443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.87.42.2/32
+---
+# -----------------------------------------------------------------------------
+# K8s API egress — longhorn-driver-deployer.
+#
+# Bootstraps the CSI driver registration; touches the apiserver to create the
+# CSIDriver object and the CSI sidecar Deployments at startup. Small, but a
+# default-deny without this would block first-boot reconciliation.
+# -----------------------------------------------------------------------------
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: longhorn-driver-deployer-allow-k8s-api
+  namespace: longhorn-system
+spec:
+  podSelector:
+    matchLabels:
+      app: longhorn-driver-deployer
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.43.0.0/16
+    - ports:
+        - port: 443
+          protocol: TCP
+        - port: 6443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.87.42.2/32
+---
+# -----------------------------------------------------------------------------
+# NFS backup egress — longhorn-manager + instance-manager pods write the
+# weekly backup to nfs://${NAS0_IP}:/volume1/longhorn-backups (NAS0 =
+# 10.87.42.200, sits in the node /24 but is NOT a node and so not covered by
+# any node-network entity allow). NFSv4 uses :2049 TCP; NFSv3 also opens
+# rpcbind :111 + mountd. The backup target is configured for NFSv4 in this
+# cluster (Longhorn defaults), but rpcbind :111 is allowed defensively to
+# cover mount negotiation.
+#
+# Scoped to the two pod kinds that actually do the I/O:
+#   - app=longhorn-manager        (DaemonSet, orchestrates the backup)
+#   - longhorn.io/component=instance-manager (streams the volume data)
+# -----------------------------------------------------------------------------
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: longhorn-allow-backup-nfs-egress
+  namespace: longhorn-system
+spec:
+  podSelector:
+    matchExpressions:
+      - key: app
+        operator: In
+        values: [longhorn-manager]
+  policyTypes: [Egress]
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 10.87.42.200/32  # ${NAS0_IP} — backup target NFS server
+      ports:
+        - port: 2049
+          protocol: TCP
+        - port: 111
+          protocol: TCP
+        - port: 111
+          protocol: UDP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: longhorn-instance-manager-allow-backup-nfs-egress
+  namespace: longhorn-system
+spec:
+  podSelector:
+    matchLabels:
+      longhorn.io/component: instance-manager
+  policyTypes: [Egress]
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 10.87.42.200/32  # ${NAS0_IP} — backup target NFS server
+      ports:
+        - port: 2049
+          protocol: TCP
+        - port: 111
+          protocol: TCP
+        - port: 111
+          protocol: UDP

--- a/kubernetes/cluster0/apps/longhorn-system/longhorn/app/network-policy.yaml
+++ b/kubernetes/cluster0/apps/longhorn-system/longhorn/app/network-policy.yaml
@@ -2,13 +2,36 @@
 # =============================================================================
 # Longhorn — Phase 4c (#2952, parent design #2812)
 #
-# Wide-then-tighten storage policies. Longhorn's data plane allocates dynamic
-# ports in the 10000-30000 range across instance-manager pods and engines;
-# narrow per-port allows risk silent volume corruption when the engine
-# re-binds. The conscious decision (#2812 Phase 4 baseline, #2952 design) is
-# to start with a wide intra-namespace allow and tighten only after a
-# multi-day Hubble baseline confirms a clean steady state — explicitly
-# deferred to a hypothetical Phase 5.
+# The wide intra-namespace allow below is a PERMANENT design choice, not a
+# temporary state to be tightened later. Intra-namespace traffic within a
+# single trust domain is not a meaningful security boundary; the real
+# enforcement lives on the cross-namespace flows (Traefik → longhorn-ui
+# ingress, K8s API egress, Prometheus scrape ingress, backup NFS egress,
+# DNS egress) which are all tightly scoped below.
+#
+# Why intra-ns narrowing buys ~nothing here:
+#   - All Longhorn pods are rendered by a single Helm release, share the
+#     same SOPS-encrypted credentials, and run with storage-admin-equivalent
+#     privileges by design.
+#   - A compromised longhorn-ui can already reach longhorn-manager via the
+#     official admin API on :9500.
+#   - A compromised CSI sidecar already has cluster-wide volume-control
+#     authority via its K8s API allow (Volume/VolumeAttachment CRDs).
+#   - So per-pod intra-ns NetworkPolicy splits would only frustrate a future
+#     reader without raising the bar for an attacker.
+#
+# Why intra-ns narrowing also has real downside:
+#   - The data plane (instance-manager + engine processes) binds ephemeral
+#     ports across the 10000-30000 range and re-allocates them as volumes
+#     attach/detach. Per-port allows would silently drop replica traffic on
+#     every re-allocation and risk volume corruption.
+#
+# Same shape of argument as the seaweedfs intra-ns widening in #2969:
+# anything Helm renders in this namespace as part of the longhorn release is
+# co-trusted with the data plane.
+#
+# See the parent design doc (#2812) and child issue (#2952) for the full
+# Phase 4 context.
 #
 # Pod inventory (selectors used below):
 #   - longhorn-manager     (DaemonSet)    — app=longhorn-manager
@@ -39,9 +62,6 @@
 #   - Backup target NFS: instance-manager + longhorn-manager pods write the
 #     Friday backup to nfs://${NAS0_IP}:/volume1/longhorn-backups
 #     (NAS0 = 10.87.42.200 — same /24 as the nodes but NOT a node)
-#
-# Out of scope (per #2952 / #2812): narrowing the 10000-30000 data-plane port
-# range, blocking node-to-node Longhorn traffic.
 # =============================================================================
 ---
 # -----------------------------------------------------------------------------
@@ -57,24 +77,33 @@ spec:
   policyTypes: [Ingress, Egress]
 ---
 # -----------------------------------------------------------------------------
-# INTENTIONAL WIDE INTRA-NAMESPACE ALLOW.
+# INTENTIONAL WIDE INTRA-NAMESPACE ALLOW — permanent design choice.
 #
 # Selects EVERY pod in longhorn-system (`podSelector: {}`) and allows BOTH
-# ingress from and egress to every other pod in longhorn-system. This is the
-# rare "intentional wide allow" case in the netpol rollout (#2812, #2952).
+# ingress from and egress to every other pod in longhorn-system. This is one
+# of the rare "intentional wide allow" cases in the netpol rollout (#2812,
+# #2952) — see the top-of-file block for the full rationale.
 #
-# Rationale: Longhorn's data plane (instance-manager pods, engine processes)
-# binds ephemeral ports across the 10000-30000 range. Replicas, engines, and
-# managers all talk to each other on these dynamic ports. Per-port allows
-# would silently drop replica traffic on every port re-allocation and risk
-# volume corruption. The wide intra-ns allow is correct here because every
-# pod in this namespace is part of the same storage subsystem and there is
-# no cross-tenant trust boundary inside it.
+# Summary: longhorn-system is a single trust domain. Every pod is rendered
+# by the same Helm release, shares the same SOPS-encrypted credentials, and
+# runs with storage-admin-equivalent privileges by design — a compromised
+# longhorn-ui already has longhorn-manager admin API access on :9500, and a
+# compromised CSI sidecar already has cluster-wide volume-control authority
+# via its K8s API allow. Intra-ns NetworkPolicy splits inside this trust
+# domain would not raise the bar for an attacker.
 #
-# Tightening this is explicitly out-of-scope for Phase 4c; defer to a Phase
-# 5 only with a multi-day Hubble baseline that enumerates the actual port
-# distribution under sustained load. See #2812 §"Out of scope" and #2952
-# §"Out of scope".
+# The data plane separately makes narrowing technically risky: instance-
+# manager and engine processes bind ephemeral ports across 10000-30000 and
+# re-allocate them on every attach/detach. Per-port allows would silently
+# drop replica traffic and risk volume corruption.
+#
+# Same shape of argument as the seaweedfs intra-ns widening in #2969:
+# anything Helm renders in this namespace as part of the longhorn release
+# is co-trusted with the data plane.
+#
+# The meaningful enforcement for this namespace is on the cross-namespace
+# flows below (Traefik → longhorn-ui, K8s API egress, Prometheus scrape,
+# backup NFS, DNS) — all tightly scoped.
 # -----------------------------------------------------------------------------
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy


### PR DESCRIPTION
## Summary

Final Phase 4 child PR — the highest-risk PR in the whole NetworkPolicy rollout. A misstep on Longhorn risks silent volume corruption on 30+ active volumes; a misstep on CoreDNS partitions DNS cluster-wide. Both subsystems use **wide-then-tighten** per the parent design doc (#2812) and the child issue (#2952); narrowing is deferred to a hypothetical Phase 5 with a multi-day Hubble baseline.

## Longhorn — `apps/longhorn-system/longhorn/app/`

Added to the existing Helm-managed kustomization (sibling files `network-policy.yaml`, `cilium-network-policy.yaml`):

- **Default-deny** Ingress+Egress on every pod in `longhorn-system`.
- **Intentional wide intra-ns allow** (`podSelector: {}`, both directions to the `longhorn-system` ns). Longhorn's data plane allocates ephemeral ports across 10000-30000; per-port allows would risk silent corruption on every re-bind. Documented in the YAML referencing #2812 and #2952.
- **DNS egress** to kube-system :53 UDP+TCP (scoped to `k8s-app=kube-dns`).
- **longhorn-ui ingress from Traefik** on :8000 (AND-shape: `networking` ns + `app.kubernetes.io/name=traefik` pod selector).
- **longhorn-manager ingress from Prometheus** on :9500 (ServiceMonitor `longhorn-prometheus-servicemonitor` scrapes port name `manager`).
- **K8s API egress (dual-policy)** for `longhorn-manager`, `longhorn-csi-plugin`, `csi-{attacher,provisioner,resizer,snapshotter}`, `longhorn-driver-deployer` — ipBlock NetworkPolicy + CiliumNetworkPolicy `toEntities: [kube-apiserver]` (#2829, #2947, #2973 patterns).
- **Backup-target NFS egress** to `10.87.42.200` (`${NAS0_IP}`) on :2049 TCP and :111 TCP/UDP from `longhorn-manager` and `instance-manager` pods. Required for the weekly Friday backup.

### `longhorn-friday` investigation

Per the issue notes, I re-investigated `longhorn-friday`. **It is not a pod kind** — it's the `friday-backup` CronJob (weekly Longhorn recurring-job). Job pods carry `recurring-job.longhorn.io=friday-backup` and only invoke `longhorn-manager -d recurring-job friday-backup --manager-url http://longhorn-backend:9500/v1` (intra-ns only). They are fully covered by the wide intra-ns allow + the wide DNS allow; no special policy required.

## CoreDNS — `apps/kube-system/coredns/policy/`

New `policy/` subdirectory next to the existing (still-disabled) `app/` HelmRelease, following the local-path-provisioner Phase 4b precedent. The `coredns/ks.yaml` Flux Kustomization is re-enabled in `apps/kube-system/kustomization.yaml` and pointed at `policy/`, not `app/` — so the in-cluster Helm-managed CoreDNS Deployment is untouched; only the NetworkPolicies in `policy/` reconcile against the live pods.

- **Default-deny** Ingress+Egress on `k8s-app=kube-dns` pods.
- **INTENTIONAL wildcard ingress** on :53 UDP/TCP from `namespaceSelector: {}`. This is the **single** wildcard in the whole Phase 4 rollout — DNS is universal and the alternative is enumerating every namespace. Documented in the YAML.
- **Prometheus scrape ingress** on :9153 (AND-shape: `monitoring` ns + `app.kubernetes.io/name=prometheus` pod selector).
- **Upstream DNS egress** on :53 UDP/TCP scoped to `10.87.42.0/24` — covers the Blocky LB IPs (`10.87.42.11`, `10.87.42.15`) that node `/etc/resolv.conf` points at. The Corefile uses `forward . /etc/resolv.conf` (dnsPolicy: Default), so the upstream IPs come from the node's resolv.conf, not the Corefile directly. Tightening below `/24` is router-config territory and explicitly out of scope (#2812 / #2952).
- **K8s API egress (dual-policy)** for the `kubernetes` plugin's Endpoints/Services/Pods watches.
- **Intra-replica peer egress** on :53 between the two CoreDNS pods only (no broader kube-system egress).

## Pre-implementation checks performed

| # | Check | Result |
|---|---|---|
| 1 | Hubble drop-rate baseline | The agent's read-only SA cannot port-forward or use API proxy to Prometheus (`monitoring` ns netpol blocks both). **The coordinator should capture this directly before merging.** |
| 2 | Volume state snapshot | `/tmp/volumes-before.txt` — 30 volumes; `/tmp/longhorn-nodes-before.txt` — 4 nodes all Ready |
| 3 | Longhorn pod inventory | Confirmed selectors: `app=longhorn-{ui,manager,csi-plugin,driver-deployer}`, `app=csi-{attacher,provisioner,resizer,snapshotter}`, `longhorn.io/component=instance-manager`, `longhorn.io/component=engine-image` |
| 4 | CoreDNS Corefile | `forward . /etc/resolv.conf` — no explicit upstream IPs in the Corefile; delegated to node resolv.conf → Blocky LB IPs in `10.87.42.0/24` |
| 5 | CoreDNS pod labels | `k8s-app=kube-dns` (2 pods) confirmed |
| 6 | ServiceMonitors in longhorn-system | `longhorn-prometheus-servicemonitor` exists — selects `app=longhorn-manager`, scrapes port name `manager` (→ :9500) |
| 7 | `longhorn-friday` investigation | Not a pod — it's the `friday-backup` CronJob. Folded into wide intra-ns allow (see above) |
| 8 | Dual-policy K8s API examples | Cross-referenced `metrics-server`, `reloader`, `local-path-provisioner` from Phase 4b |

## Build verification

```
$ kubectl kustomize kubernetes/cluster0/apps/longhorn-system            # exit 0
$ kubectl kustomize kubernetes/cluster0/apps/longhorn-system/longhorn/app  # exit 0, 641 lines
$ kubectl kustomize kubernetes/cluster0/apps/kube-system                # exit 0
$ kubectl kustomize kubernetes/cluster0/apps/kube-system/coredns/policy # exit 0, 141 lines
$ kubectl apply --dry-run=client -f <built>                             # all resources validate
```

## Notes for merge

- **No in-flight conflicts** — branch `netpol-phase-4c-longhorn-coredns` is clean off `main` (`91b5241ce`, Phase 4b fix-forward).
- **Coordinator should capture the Hubble drop baseline** before merging (the agent's SA can't reach Prometheus).
- Post-merge verification per #2952: volume state diff, PVC read/write smoke, DNS resolution test from ≥9 namespaces, drop-rate diff, Longhorn UI smoke, Hubble drop watch on `longhorn-system` and `kube-system/coredns-*`.
- **Rollback**: revert the squash commit, push, `flux reconcile source git home-ops-cluster0`.

## Acceptance Criteria

Structural — falsifiable at PR time:
- [x] `longhorn-system` wide intra-ns allow (`podSelector: {}`, both directions)
- [x] `longhorn-ui` Traefik ingress on :8000 (AND-shape)
- [x] `longhorn-manager` + `longhorn-csi-plugin` K8s API egress (dual-policy)
- [x] Longhorn ServiceMonitor exists → `longhorn-manager` scrape ingress on :9500
- [x] DNS egress from `longhorn-system` to `kube-system :53` UDP+TCP
- [x] CoreDNS `namespaceSelector: {}` ingress on :53 UDP+TCP
- [x] CoreDNS upstream DNS egress (ipBlock to `10.87.42.0/24`)
- [x] CoreDNS K8s API egress (dual-policy)
- [x] Both kustomize builds clean

Phase-2/3 lessons applied:
- [x] All cross-ns rules use AND-shape
- [x] CoreDNS `namespaceSelector: {}` is the only wildcard
- [x] All K8s API egress uses dual NetworkPolicy + CiliumNetworkPolicy pattern
- [x] Wide intra-ns rule documented in YAML comments (refs #2812, #2952)
- [x] Wildcard ingress documented in YAML comments

Security:
- [x] Default-deny on every Longhorn pod + every CoreDNS pod
- [x] Pods outside `longhorn-system` cannot reach Longhorn pods (only legit cross-ns is Traefik → longhorn-ui, Prometheus → longhorn-manager)
- [x] CoreDNS egress scoped to: K8s API + 10.87.42.0/24 :53 + CoreDNS peers

Refs #2812
Closes #2812
Closes #2952
