### PR TITLE
fix(netpol): allow in-cluster pods to reach Traefik on :80/:443

### DIFF
--- a/kubernetes/cluster0/apps/networking/traefik/app/network-policy.yaml
+++ b/kubernetes/cluster0/apps/networking/traefik/app/network-policy.yaml
@@ -62,6 +62,50 @@ spec:
         - port: 443
           protocol: TCP
 ---
+# -----------------------------------------------------------------------------
+# INTENTIONAL WILDCARD INGRESS — every pod in every namespace can reach
+# Traefik on :80 and :443.
+#
+# Companion to `traefik-allow-external-ingress` above: that rule uses
+# `ipBlock: 0.0.0.0/0` which covers external / host-network sources, but
+# under Cilium `kubeProxyReplacement=true` in-cluster pod-to-pod flows are
+# matched by pod identity rather than source IP — so the ipBlock rule does
+# NOT cover an in-cluster pod (e.g. `monitoring/uptime-kuma`) connecting to
+# `https://<route>.tinfoilforest.nz/`. The two rules are complementary: the
+# ipBlock rule matches non-pod sources, this rule matches pod-identity
+# sources. See #2977 for the root cause and the Phase 4a origin (#2950 /
+# #2968).
+#
+# The `namespaceSelector: {}` wildcard is correct here, and follows the
+# precedent set by `coredns-allow-dns-ingress` in PR #2976: Traefik is THE
+# cluster-wide ingress point for every HTTPRoute, so enumerating namespaces
+# would create a maintenance burden every time a new monitor / health-check
+# / webhook pod is deployed in any namespace. The risk surface is tightly
+# bound by port — only :80 TCP and :443 TCP. The Traefik dashboard (:8080)
+# and all other ports remain governed by their own scoped ingress rules.
+# -----------------------------------------------------------------------------
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: traefik-allow-intracluster-ingress
+  namespace: networking
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: traefik
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector: {}    # universal — see comment above; complements
+                                   # the ipBlock 0.0.0.0/0 rule for in-cluster
+                                   # pod-identity sources under Cilium kpr.
+      ports:
+        - port: 80
+          protocol: TCP
+        - port: 443
+          protocol: TCP
+---
 # Allow intra-ns ingress from cloudflared — the Cloudflare tunnel terminates
 # at Traefik via the local cluster network on :443.
 apiVersion: networking.k8s.io/v1


### PR DESCRIPTION
## Summary

Phase 4a (#2950 / #2968) added `traefik-allow-external-ingress` with `ipBlock: 0.0.0.0/0` to permit external traffic to Traefik on :80/:443. Under Cilium `kubeProxyReplacement=true`, in-cluster pod-to-pod flows are matched by **pod identity** rather than source IP, so the ipBlock rule does **not** cover an in-cluster pod (e.g. `monitoring/uptime-kuma`) connecting to `https://<route>.tinfoilforest.nz/`. Hubble shows sustained POLICY_DENIED drops on that flow (10 drops / 5 min, consistent with uptime-kuma's check cadence).

## Change

Add a single companion NetworkPolicy `traefik-allow-intracluster-ingress` in `kubernetes/cluster0/apps/networking/traefik/app/network-policy.yaml`:

- `podSelector`: `app.kubernetes.io/name: traefik`
- `policyTypes: [Ingress]`
- One ingress rule `from: [{ namespaceSelector: {} }]` on ports **:80 TCP** and **:443 TCP only**

The existing `traefik-allow-external-ingress` (ipBlock 0.0.0.0/0) is preserved unchanged. The two rules are complementary: the ipBlock rule matches non-pod sources; the new rule matches pod-identity sources.

## Wildcard rationale (inline-documented)

The intentional `namespaceSelector: {}` wildcard follows the precedent established by `coredns-allow-dns-ingress` in PR #2976. Traefik is THE cluster-wide ingress point for every HTTPRoute, so enumerating namespaces would create a maintenance burden on every new monitor / health-check / webhook pod. The risk surface is tightly bound by port — the dashboard (:8080) and all other Traefik ports remain governed by their existing scoped rules.

## Scope

- Single-file change, pure addition (+44 lines, 0 removed).
- No other Traefik ingress / egress rule modified (cloudflared, dashboard, external, k8s-api, backend, authelia, external-services, dns, default-deny all preserved verbatim).
- No file outside `apps/networking/traefik/app/` modified.
- `kubectl kustomize kubernetes/cluster0/apps/networking` and `apps/networking/traefik/app` both build cleanly.

## Post-merge verification

See #2977 for the full verification recipe; the headline checks are:

```bash
flux reconcile source git home-ops-cluster0
flux reconcile kustomization cluster-apps-traefik
kubectl -n networking get netpol traefik-allow-intracluster-ingress -o jsonpath='{.spec.ingress}' | jq
hubble observe --verdict DROPPED --since 2m --from-pod monitoring/uptime-kuma -o compact   # expect empty for traefik:443
curl -I https://uptime.tinfoilforest.nz/                                                   # external still works
```

Closes #2977
Refs #2950, #2968, #2976