### PR TITLE
security: audit quick-wins (zxcvbn, prom admin API, PSA labels, media requests)

### DIFF
--- a/kubernetes/cluster0/apps/auth/authelia/app/config/configuration.yaml
+++ b/kubernetes/cluster0/apps/auth/authelia/app/config/configuration.yaml
@@ -42,8 +42,8 @@ password_policy:
     require_number: false
     require_special: false
   zxcvbn:
-    enabled: false
-    min_score: 0
+    enabled: true
+    min_score: 3
 session:
   same_site: lax
   name: "${SECRET_PUBLIC_DOMAIN}_auth_session"

--- a/kubernetes/cluster0/apps/auth/namespace.yaml
+++ b/kubernetes/cluster0/apps/auth/namespace.yaml
@@ -6,4 +6,6 @@ metadata:
   labels:
     kustomize.toolkit.fluxcd.io/prune: disabled
     netpol.home-ops/traefik-backend: "true"
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted
 

--- a/kubernetes/cluster0/apps/cert-manager/namespace.yaml
+++ b/kubernetes/cluster0/apps/cert-manager/namespace.yaml
@@ -5,3 +5,5 @@ metadata:
   name: cert-manager
   labels:
     kustomize.toolkit.fluxcd.io/prune: disabled
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/kubernetes/cluster0/apps/databases/namespace.yaml
+++ b/kubernetes/cluster0/apps/databases/namespace.yaml
@@ -5,4 +5,6 @@ metadata:
   name: databases
   labels:
     kustomize.toolkit.fluxcd.io/prune: disabled
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted
     trust.cert-manager.io/enabled: "true"

--- a/kubernetes/cluster0/apps/home/namespace.yaml
+++ b/kubernetes/cluster0/apps/home/namespace.yaml
@@ -6,4 +6,6 @@ metadata:
   labels:
     kustomize.toolkit.fluxcd.io/prune: disabled
     netpol.home-ops/traefik-backend: "true"
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted
 

--- a/kubernetes/cluster0/apps/media/lidarr/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/lidarr/app/helm-release.yaml
@@ -40,6 +40,10 @@ spec:
               runAsUser: 0
               runAsGroup: 0
               fsGroup: 0
+            resources:
+              requests:
+                cpu: 50m
+                memory: 256Mi
     service:
       app:
         controller: main

--- a/kubernetes/cluster0/apps/media/namespace.yaml
+++ b/kubernetes/cluster0/apps/media/namespace.yaml
@@ -6,4 +6,6 @@ metadata:
   labels:
     kustomize.toolkit.fluxcd.io/prune: disabled
     netpol.home-ops/traefik-backend: "true"
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted
 

--- a/kubernetes/cluster0/apps/media/prowlarr/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/prowlarr/app/helm-release.yaml
@@ -40,6 +40,10 @@ spec:
               runAsUser: 0
               runAsGroup: 0
               fsGroup: 0
+            resources:
+              requests:
+                cpu: 50m
+                memory: 256Mi
     service:
       app:
         controller: main

--- a/kubernetes/cluster0/apps/media/radarr/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/radarr/app/helm-release.yaml
@@ -40,6 +40,10 @@ spec:
               runAsUser: 0
               runAsGroup: 0
               fsGroup: 0
+            resources:
+              requests:
+                cpu: 50m
+                memory: 256Mi
     service:
       app:
         controller: main

--- a/kubernetes/cluster0/apps/media/sabnzbd/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/sabnzbd/app/helm-release.yaml
@@ -39,6 +39,10 @@ spec:
               runAsUser: 0
               runAsGroup: 0
               fsGroup: 0
+            resources:
+              requests:
+                cpu: 50m
+                memory: 512Mi
     service:
       app:
         controller: main

--- a/kubernetes/cluster0/apps/media/sonarr/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/sonarr/app/helm-release.yaml
@@ -40,6 +40,10 @@ spec:
               runAsUser: 0
               runAsGroup: 0
               fsGroup: 0
+            resources:
+              requests:
+                cpu: 50m
+                memory: 256Mi
     service:
       app:
         controller: main

--- a/kubernetes/cluster0/apps/monitoring/kube-prometheus-stack/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/monitoring/kube-prometheus-stack/app/helm-release.yaml
@@ -220,7 +220,7 @@ spec:
         podMonitorSelectorNilUsesHelmValues: false
         probeSelectorNilUsesHelmValues: false
         scrapeConfigSelectorNilUsesHelmValues: false
-        enableAdminAPI: true
+        enableAdminAPI: false
         walCompression: true
         enableFeatures:
           - auto-gomaxprocs

--- a/kubernetes/cluster0/apps/monitoring/namespace.yaml
+++ b/kubernetes/cluster0/apps/monitoring/namespace.yaml
@@ -6,4 +6,6 @@ metadata:
   labels:
     kustomize.toolkit.fluxcd.io/prune: disabled
     netpol.home-ops/traefik-backend: "true"
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted
 

--- a/kubernetes/cluster0/apps/networking/namespace.yaml
+++ b/kubernetes/cluster0/apps/networking/namespace.yaml
@@ -6,4 +6,6 @@ metadata:
   labels:
     kustomize.toolkit.fluxcd.io/prune: disabled
     netpol.home-ops/traefik-backend: "true"
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted
 

--- a/kubernetes/cluster0/apps/seaweedfs/namespace.yaml
+++ b/kubernetes/cluster0/apps/seaweedfs/namespace.yaml
@@ -6,4 +6,6 @@ metadata:
   labels:
     kustomize.toolkit.fluxcd.io/prune: disabled
     netpol.home-ops/traefik-backend: "true"
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted
     trust.cert-manager.io/enabled: "true"


### PR DESCRIPTION
Four small, independent security hardening tweaks from audit #2804,
batched into one PR for review efficiency. Each can be reverted alone.

## Changes

1. **Authelia `zxcvbn`** (`apps/auth/authelia/app/config/configuration.yaml`)
   `enabled: true`, `min_score: 3`. `standard` policy block stays disabled.

2. **Prometheus `enableAdminAPI: false`**
   (`apps/monitoring/kube-prometheus-stack/app/helm-release.yaml`)
   Disables tsdb deletion/snapshot endpoints. Defence-in-depth; not in use.

3. **PSA labels (warn + audit, no enforce)** on 8 app namespaces:
   `auth`, `cert-manager`, `databases`, `home`, `media`, `monitoring`,
   `networking`, `seaweedfs`.
   Both `pod-security.kubernetes.io/warn: restricted` and
   `pod-security.kubernetes.io/audit: restricted` added.
   System namespaces (`kube-system`, `longhorn-system`, `flux-system`)
   intentionally **not** modified.
   No `enforce` label — that would break z2m/gluetun and is out of scope.

4. **Resource requests (no limits)** on five media HRs: `lidarr`,
   `prowlarr`, `radarr`, `sonarr`, `sabnzbd`.
   `cpu: 50m`, `memory: 256Mi` (sabnzbd: `512Mi` for par2/extraction).
   Shifts pods from BestEffort → Burstable QoS. No `limits:` block —
   limits cause OOM cascades / CPU throttling and are explicitly OOS.

## Verification

- `kubectl kustomize` builds cleanly for all 8 modified namespace parent
  dirs and all 5 media HR `app/` dirs.
- Rendered output confirms `enableAdminAPI: false` and the
  `resources.requests` blocks land verbatim.
- No SOPS-encrypted material added, removed or modified.
- No `limits:` or `enforce:` strings added anywhere in the diff
  (grep-verified).

## Expected post-merge side effects

The PSA `audit` labels will start producing warning events in
`kubectl get events` for existing pods that don't meet the `restricted`
standard (root containers in media, privileged containers in home and
media). This is **the point of the change** — surfacing violations for
future awareness — and is not an indicator of a regression.

Refs #2804