### PR TITLE
security(media): drop root in plex, sabnzbd, sonarr, radarr, prowlarr, lidarr

### DIFF
--- a/kubernetes/cluster0/apps/media/lidarr/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/lidarr/app/helm-release.yaml
@@ -24,6 +24,12 @@ spec:
     remediation:
       retries: 5
   values:
+    defaultPodOptions:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
     controllers:
       main:
         containers:
@@ -33,13 +39,10 @@ spec:
               tag: 2.12.4.4658-ls49@sha256:286af1e270d2829efd0b6a33d26dbadc614d61d8e9bb1a07b8396ad6231921a2
             env:
               TZ: "${TIMEZONE}"
+              # PUID/PGID are read by the linuxserver s6-overlay entrypoint;
+              # they must match the pod securityContext runAsUser/runAsGroup.
               PUID: 1000
               PGID: 1000
-            # to avoid permissions issues on volume
-            securityContext:
-              runAsUser: 0
-              runAsGroup: 0
-              fsGroup: 0
             resources:
               requests:
                 cpu: 50m

--- a/kubernetes/cluster0/apps/media/plex/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/plex/app/helm-release.yaml
@@ -27,6 +27,21 @@ spec:
     defaultPodOptions:
       nodeSelector:
         intel.feature.node.kubernetes.io/gpu: "true"
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        # supplementalGroups covers `video` and `render` GIDs across common
+        # node distros so the Plex transcoder can access /dev/dri/*:
+        #   44  = video (Debian/Ubuntu)
+        #   105 = render (Debian)
+        #   107 = render (Ubuntu)
+        #   109 = render (some k3s/Alpine-derivative nodes)
+        # Intentionally a defensive superset — the actual node-side render GID
+        # is what matters; the extras are harmless. If transcode breaks, narrow
+        # to the GID observed via `ls -l /dev/dri` inside the pod.
+        supplementalGroups: [44, 105, 107, 109]
     controllers:
       main:
         containers:
@@ -36,13 +51,10 @@ spec:
               tag: "1.43.1.10611-1e34174b1@sha256:8b5bcdf7b506fe051aa1a0a0d464efdb3ad8c0fb1f8a4dfb27a8c489b609920c"
             env:
               TZ: "${TIMEZONE}"
-              PLEX_UID: 0
-              PLEX_GID: 0
-            # to avoid permissions issues on volume
-            securityContext:
-              runAsUser: 0
-              runAsGroup: 0
-              fsGroup: 0
+              # PLEX_UID/PLEX_GID are read by the plexinc/pms-docker entrypoint
+              # and must match the pod securityContext runAsUser/runAsGroup.
+              PLEX_UID: 1000
+              PLEX_GID: 1000
             resources:
               requests:
                 gpu.intel.com/i915: 1

--- a/kubernetes/cluster0/apps/media/prowlarr/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/prowlarr/app/helm-release.yaml
@@ -24,6 +24,12 @@ spec:
     remediation:
       retries: 5
   values:
+    defaultPodOptions:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
     controllers:
       main:
         containers:
@@ -33,13 +39,10 @@ spec:
               tag: "2.0.5.5160-ls125@sha256:4f2a6d597845b2f3e19284b1d982b3e0b4bd7c22472c2979c956aa198b83f472"
             env:
               TZ: "${TIMEZONE}"
+              # PUID/PGID are read by the linuxserver s6-overlay entrypoint;
+              # they must match the pod securityContext runAsUser/runAsGroup.
               PUID: 1000
               PGID: 1000
-            # to avoid permissions issues on volume
-            securityContext:
-              runAsUser: 0
-              runAsGroup: 0
-              fsGroup: 0
             resources:
               requests:
                 cpu: 50m

--- a/kubernetes/cluster0/apps/media/radarr/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/radarr/app/helm-release.yaml
@@ -24,6 +24,12 @@ spec:
     remediation:
       retries: 5
   values:
+    defaultPodOptions:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
     controllers:
       main:
         containers:
@@ -33,13 +39,10 @@ spec:
               tag: "6.1.1@sha256:15417a594ebda4c660a9fa9748e7199d33e2d17b31bbc5ad7ba2e86f0b414763"
             env:
               TZ: "${TIMEZONE}"
+              # PUID/PGID are read by the linuxserver s6-overlay entrypoint;
+              # they must match the pod securityContext runAsUser/runAsGroup.
               PUID: 1000
               PGID: 1000
-            # to avoid permissions issues on volume
-            securityContext:
-              runAsUser: 0
-              runAsGroup: 0
-              fsGroup: 0
             resources:
               requests:
                 cpu: 50m

--- a/kubernetes/cluster0/apps/media/sabnzbd/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/sabnzbd/app/helm-release.yaml
@@ -25,6 +25,12 @@ spec:
     remediation:
       retries: 5
   values:
+    defaultPodOptions:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
     controllers:
       main:
         containers:
@@ -34,11 +40,10 @@ spec:
               tag: "5.0.3@sha256:f567ed2e26b964690e93d708d9660db011fcd0a4057f927cae1b6ec23387efd5"
             env:
               TZ: "${TIMEZONE}"
-            # to avoid permissions issues on volume
-            securityContext:
-              runAsUser: 0
-              runAsGroup: 0
-              fsGroup: 0
+              # PUID/PGID are read by the linuxserver s6-overlay entrypoint;
+              # they must match the pod securityContext runAsUser/runAsGroup.
+              PUID: 1000
+              PGID: 1000
             resources:
               requests:
                 cpu: 50m

--- a/kubernetes/cluster0/apps/media/sonarr/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/sonarr/app/helm-release.yaml
@@ -24,6 +24,12 @@ spec:
     remediation:
       retries: 5
   values:
+    defaultPodOptions:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
     controllers:
       main:
         containers:
@@ -33,13 +39,10 @@ spec:
               tag: "4.0.17@sha256:60f3b6b5c7647ba2bafd81163acfe34b11117b9b834ebd7fbcc3e5f1b309c7ef"
             env:
               TZ: "${TIMEZONE}"
+              # PUID/PGID are read by the linuxserver s6-overlay entrypoint;
+              # they must match the pod securityContext runAsUser/runAsGroup.
               PUID: 1000
               PGID: 1000
-            # to avoid permissions issues on volume
-            securityContext:
-              runAsUser: 0
-              runAsGroup: 0
-              fsGroup: 0
             resources:
               requests:
                 cpu: 50m


### PR DESCRIPTION
## Summary

Drop root in all six media-namespace apps (plex, sabnzbd, sonarr, radarr,
prowlarr, lidarr). All six now run with `runAsUser: 1000`, `runAsGroup: 1000`,
`fsGroup: 1000`, `fsGroupChangePolicy: OnRootMismatch`. Plex additionally
declares `supplementalGroups: [44, 105, 107, 109]` to retain `/dev/dri/*`
access for Intel GPU transcoding across the common node-distro render-group
GIDs.

Closes #2980
Refs #2804

## Investigation findings

This started as an investigation-first issue because the *arr group was in a
"half-fixed" state (PUID=1000/PGID=1000 but pod `runAsUser: 0`), and the
prior PR #2922 had stopped there citing "linuxserver requires runAsUser:0
because of s6-overlay". Before changing any YAML I gathered facts:

### NFS exports already permit UID 1000 writes

Jellyfin (same namespace) has **no** `securityContext` at all, mounts the
same NFS shares (`/volume1/Films`, `/volume1/TV-Series`) from `nas0` that
plex/sonarr/radarr use, and works. The upstream jellyfin image defaults to
a non-root UID. If UID 1000 were blocked by the NAS exports, jellyfin would
not be able to read media. **No NAS-side change is required for this PR.**

### The *arr group is already running as UID 1000 at process level

Logs from sonarr/radarr/prowlarr/lidarr show `User UID: 1000 / User GID: 1000`
from the linuxserver s6-overlay entrypoint. No `chown` failures, no
permission-denied errors. They write to `/config` (Longhorn PVC) and
read+write NFS (`/downloads`, `/tv`, `/movies`, `/music`) successfully. The
pod-level flip from `runAsUser: 0` → `runAsUser: 1000` is therefore a
no-op at the process level — the binary already runs as 1000. Only the
~few-second s6 init window changes from root → 1000.

### SABnzbd's chown warning is harmless

SABnzbd was running as UID 911 (linuxserver default `abc` user — no
PUID/PGID was set in the helm-release). It logs

    chown: changing ownership of '/downloads': Operation not permitted
    **** Permissions could not be set. ****

at startup but the app then works fine — writing to `/downloads` (NFS)
and `/config` (PVC) succeeds. The "permissions could not be set" warning
is just s6-overlay's chown attempt failing (UID 911 can't chown an NFS
mount it doesn't own), which is harmless given UID 911 already has write
access on the NFS export.

This PR changes sabnzbd's runtime UID from 911 → 1000 by setting
`PUID=1000 / PGID=1000` to match the pod securityContext. The first
post-rollout mount of `pvc-sabnzbd` (Longhorn) will trigger a one-time
ownership flip — `fsGroupChangePolicy: OnRootMismatch` keeps that cheap.

### Plex: GPU transcoder is the only real risk

Plex uses `plexinc/pms-docker` (not linuxserver). Its entrypoint reads
`PLEX_UID` / `PLEX_GID` and switches to that UID. The pod requests
`gpu.intel.com/i915: 1` via the Intel GPU device plugin, which injects
`/dev/dri/*` devices owned by `root:render` (GID varies by node distro).
To keep transcode working as a non-root UID, Plex needs supplementary
group membership of the render group.

The render GID is not consistent across distros (Debian=105, Ubuntu=107,
Alpine/k3s-derivatives sometimes 109), and the maintainer doesn't know
the exact node OS render GID off-hand. Per the spawn-prompt decision, we
use a **defensive superset** `supplementalGroups: [44, 105, 107, 109]`
covering `video` (44) and the three likely `render` GIDs. The extras are
harmless. If transcode breaks post-rollout we narrow to the actual GID
observed via `ls -l /dev/dri` in a follow-up PR.

### Why the half-fix stalled

PR #2922 added `PUID/PGID=1000` to the *arr group but kept `runAsUser: 0`,
citing "LinuxServer images use s6-overlay which **requires** the
container to start as root". This is outdated — modern linuxserver
baseimages support rootless operation, and the live cluster proves it:
the *arr group is already running as 1000 with no permission problems,
even though the pod still starts as root. Setting `runAsUser=PUID`
directly works because s6 detects it's already non-root and skips the
privilege-drop step.

## Path chosen

Uniform **Path A** (clean non-root, UID/GID 1000) across all six apps.
No NAS-side changes. No per-app exceptions. No `runAsNonRoot: false`
escapes.

| App | Before | After | Notes |
|---|---|---|---|
| plex | runAsUser:0 / PLEX_UID:0 | runAsUser:1000 / PLEX_UID:1000 / supplementalGroups:[44,105,107,109] | GPU access via supplemental render-GID superset |
| sabnzbd | runAsUser:0 / (no PUID, default 911) | runAsUser:1000 / PUID:1000 | One-time fsGroup chown on pvc-sabnzbd at next mount |
| sonarr | runAsUser:0 / PUID:1000 | runAsUser:1000 / PUID:1000 | Already running as 1000 at process level |
| radarr | runAsUser:0 / PUID:1000 | runAsUser:1000 / PUID:1000 | Same |
| prowlarr | runAsUser:0 / PUID:1000 | runAsUser:1000 / PUID:1000 | Same; no NFS mounts |
| lidarr | runAsUser:0 / PUID:1000 | runAsUser:1000 / PUID:1000 | Same |

## Out of scope

Per the spawn prompt:

- `allowPrivilegeEscalation: false` and `capabilities.drop: [ALL]` — deferred
  to a follow-up. PSA `warn=restricted` (landed in #2981) will flag these
  as warnings, which is the right backlog signal.
- `readOnlyRootFilesystem` — separate hardening item.
- Network policies — already in place from Phase 2.
- Resource limits — already handled (requests landed in #2981).
- Privileged containers (gluetun, z2m) — accepted as-is per maintainer.

## Acceptance criteria

- [x] [functional] Investigation findings documented above.
- [x] [functional] All six media apps run with `runAsUser != 0` AND `runAsGroup != 0`. No documented exceptions needed.
- [x] [functional] Existing `PUID`/`PGID` env vars match pod `runAsUser`/`runAsGroup` (1000/1000 everywhere; plex uses `PLEX_UID`/`PLEX_GID`).
- [ ] [functional] After rollout, each app's pod is `Running 1/1`, no `CrashLoopBackOff` (coordinator to verify post-merge).
- [ ] [functional] Each app's primary function works end-to-end (human maintainer to verify post-merge).
- [x] [functional] `kubectl kustomize` of each app builds cleanly. Verified for all six.
- [x] [edge-case] Existing NFS volume references in `persistence:` blocks unchanged. No NAS-side change required (see investigation).
- [ ] [edge-case] Plex GPU access via `/dev/dri/*` still works post-rollout (human maintainer to verify with a transcoded playback).
- [x] [security] No app reverted from the half-fixed state back to pure root. PR strictly raises the bar.
- [x] [security] No Path-C exceptions used; all six are explicitly non-root.

## Verification

```
$ for app in plex sabnzbd sonarr radarr prowlarr lidarr; do
    kubectl kustomize kubernetes/cluster0/apps/media/$app/app >/dev/null 2>&1 \
      && echo "$app: OK" || echo "$app: FAIL"
  done
plex: OK
sabnzbd: OK
sonarr: OK
radarr: OK
prowlarr: OK
lidarr: OK
```

## Post-merge verification (coordinator + human maintainer)

Coordinator will verify:
- Each pod `Running 1/1`, no `CrashLoopBackOff`
- `kubectl get pod <pod> -o jsonpath='{.spec.securityContext.runAsUser}'` returns `1000` for all six
- No new `chown failed` or `permission denied` lines in logs
- No PSA-related warning events for the new pod specs
- Hubble flows for monitoring scrape / NFS / Traefik ingress still landing correctly

Human maintainer will verify:
- `kubectl exec <pod> -- id` returns UID 1000 in each app
- Plex transcoded playback (the one real risk)
- Sonarr/Radarr/Lidarr indexer search end-to-end
- Prowlarr indexer test
- SABnzbd `/downloads` write test
- Plex library playback
