### PR TITLE
fix(plex): revert to root (Path C) — s6 setuid requirement, fix-forward for #2982

### DIFF
--- a/kubernetes/cluster0/apps/media/plex/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/plex/app/helm-release.yaml
@@ -27,20 +27,27 @@ spec:
     defaultPodOptions:
       nodeSelector:
         intel.feature.node.kubernetes.io/gpu: "true"
+      # Plex runs as root by design. The plexinc/pms-docker image uses s6-overlay
+      # and its init script calls `s6-setuidgid` (a setuid binary) to drop from
+      # root to PLEX_UID. Setting `runAsUser: 1000` at the pod level breaks this:
+      # init starts as 1000, cannot execute the setuid helper, and Plex Media
+      # Server never starts (tight crash-loop inside the s6 supervisor). See #2980
+      # / PR #2982 investigation and fix-forward for this PR.
+      #
+      # `runAsNonRoot: false` makes the exception explicit per the AC in #2980.
+      #
+      # supplementalGroups documents the GPU-group intent for the historical record
+      # and would be useful if Plex ever ships a non-root capable image:
+      #   44  = video (Debian/Ubuntu)
+      #   105 = render (Debian)
+      #   107 = render (Ubuntu)
+      #   109 = render (some k3s/Alpine-derivative nodes)
       securityContext:
-        runAsUser: 1000
-        runAsGroup: 1000
-        fsGroup: 1000
+        runAsNonRoot: false
+        runAsUser: 0
+        runAsGroup: 0
+        fsGroup: 0
         fsGroupChangePolicy: OnRootMismatch
-        # supplementalGroups covers `video` and `render` GIDs across common
-        # node distros so the Plex transcoder can access /dev/dri/*:
-        #   44  = video (Debian/Ubuntu)
-        #   105 = render (Debian)
-        #   107 = render (Ubuntu)
-        #   109 = render (some k3s/Alpine-derivative nodes)
-        # Intentionally a defensive superset — the actual node-side render GID
-        # is what matters; the extras are harmless. If transcode breaks, narrow
-        # to the GID observed via `ls -l /dev/dri` inside the pod.
         supplementalGroups: [44, 105, 107, 109]
     controllers:
       main:
@@ -53,8 +60,8 @@ spec:
               TZ: "${TIMEZONE}"
               # PLEX_UID/PLEX_GID are read by the plexinc/pms-docker entrypoint
               # and must match the pod securityContext runAsUser/runAsGroup.
-              PLEX_UID: 1000
-              PLEX_GID: 1000
+              PLEX_UID: 0
+              PLEX_GID: 0
             resources:
               requests:
                 gpu.intel.com/i915: 1


### PR DESCRIPTION
## URGENT fix-forward for #2982 — Plex crash loop

Plex has been crash-looping since #2982 merged. This PR reverts Plex (and **only** Plex) back to running as root, with the exception now explicitly documented per the Path C plan anticipated in #2980.

## Why Plex requires root

The `plexinc/pms-docker` image uses **s6-overlay**. Its init script calls **`s6-setuidgid`** — a setuid binary — to drop from root to `PLEX_UID` before launching Plex Media Server.

Setting `runAsUser: 1000` at the pod level breaks this:

1. Init starts as UID 1000 instead of UID 0.
2. UID 1000 cannot execute the setuid `s6-setuidgid` helper (`Permission denied`).
3. Plex Media Server never starts; the s6 supervisor restarts the child ~1/sec forever.
4. The pod reports `Running 1/1` because the s6 supervisor itself is alive, masking the inner crash loop.

The #2982 investigation incorrectly concluded `plexinc/pms-docker` doesn't use s6 — it does. This case is exactly the **"Path C / per-app documented exception"** outcome that #2980 anticipated.

**Do not retry non-root for this image.** It will not work for the reason above. A future non-root option would require switching to a different image (e.g. `lscr.io/linuxserver/plex`), which is intentionally **out of scope** here — separate PR with its own investigation.

## Changes (only `kubernetes/cluster0/apps/media/plex/app/helm-release.yaml`)

- `runAsUser: 1000` → `0`
- `runAsGroup: 1000` → `0`
- `fsGroup: 1000` → `0`
- `PLEX_UID: 1000` → `0`
- `PLEX_GID: 1000` → `0`
- Added `runAsNonRoot: false` to make the exception explicit (#2980 AC).
- Kept `fsGroupChangePolicy: OnRootMismatch` (harmless, matches pattern).
- Kept `supplementalGroups: [44, 105, 107, 109]` (harmless, documents GPU-group intent for any future non-root attempt).
- Replaced the old supplementalGroups comment with an updated block explaining s6 setuid requirement, the AC linkage, and the future-non-root rationale.

## Out of scope

- Switching to `lscr.io/linuxserver/plex`.
- The other five media apps (sonarr, radarr, prowlarr, lidarr, sabnzbd) — **not touched**, they're running clean as UID 1000.

## Verification

- `kubectl kustomize kubernetes/cluster0/apps/media/plex/app` builds cleanly.
- Only one file modified (`git diff --stat` shows 1 file, 21 insertions, 14 deletions).

## Audit-goal status

The #2980 "drop root in media" goal is met for **5 of 6** media apps. Plex remains the documented exception per Path C.

Refs #2980
Refs #2982
