### PR TITLE
fix(grafana): remove image digest pin to unblock Renovate

### DIFF
--- a/kubernetes/cluster0/apps/monitoring/grafana/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/monitoring/grafana/app/helm-release.yaml
@@ -25,7 +25,7 @@ spec:
       type: Recreate
     image:
       repository: grafana/grafana
-      tag: 13.0.0@sha256:a03d9e604e4dba58c5e64458a879701f46ef64af1f596058aacfad9aacdcab34
+      tag: 13.0.0
     route:
       main:
         enabled: true


### PR DESCRIPTION
## Summary

Removes the `@sha256:...` digest suffix from the Grafana image tag in
`kubernetes/cluster0/apps/monitoring/grafana/app/helm-release.yaml`. The
tag itself stays at `13.0.0` — Renovate will bump it on its next run.

## Why

Renovate's Docker datasource can't resolve a new digest through the helm
chart's `image.tag` path, so every Grafana patch release stalls (the
dependency dashboard #2603 has been carrying a warning, and PR #2832 for
13.0.1 failed CI and was closed). The audit follow-up in #2804 recorded
the maintainer's position: no digest pinning, "up to date is important".

## Change

```diff
     image:
       repository: grafana/grafana
-      tag: 13.0.0@sha256:a03d9e604e4dba58c5e64458a879701f46ef64af1f596058aacfad9aacdcab34
+      tag: 13.0.0
```

Nothing else in the file is modified. No file outside
`kubernetes/cluster0/apps/monitoring/grafana/app/helm-release.yaml` is touched.

## Verification

- `kubectl kustomize kubernetes/cluster0/apps/monitoring/grafana/app` builds cleanly (exit 0).
- Diff confined to the single tag line.

Post-merge verification steps (reconcile, rollout status, image string
check, UI check, Renovate dashboard) are listed in #2984.

Closes #2984