### PR TITLE
fix(grafana): bump image tag 13.0.0 -> 13.0.1 (fix ImagePullBackOff)

### DIFF
--- a/kubernetes/cluster0/apps/monitoring/grafana/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/monitoring/grafana/app/helm-release.yaml
@@ -25,7 +25,7 @@ spec:
       type: Recreate
     image:
       repository: grafana/grafana
-      tag: 13.0.0
+      tag: 13.0.1
     route:
       main:
         enabled: true


### PR DESCRIPTION
## Fix-forward for #2985

Grafana pod went into `ImagePullBackOff` after #2985 removed the sha256 digest pin, leaving `tag: 13.0.0`. Upstream Grafana **retroactively deleted the `13.0.0` tag** from Docker Hub. The previously-running pod survived because it pulled by digest (content-addressed, still in the blob store), but the new pod resolves the tag and fails.

## Change

One-line bump:

```diff
     image:
       repository: grafana/grafana
-      tag: 13.0.0
+      tag: 13.0.1
```

No digest pin re-added (per #2984). No other fields touched.

## Verification

**Docker Hub tag presence** (registry API, with bearer token):

| Tag | HTTP | Note |
|---|---|---|
| `13.0.0` | `404` | confirmed deleted |
| `13.0.1` | `200` | manifest digest `sha256:0f86bada30d65ef9d0183b90c1e2682ac92d53d95da8bed322b984ea78a4a73a` |

Reproducer:

```bash
TOKEN=$(curl -s 'https://auth.docker.io/token?service=registry.docker.io&scope=repository:grafana/grafana:pull' | jq -r .token)
curl -sI -H "Authorization: Bearer $TOKEN" \
  -H 'Accept: application/vnd.docker.distribution.manifest.list.v2+json' \
  https://registry-1.docker.io/v2/grafana/grafana/manifests/13.0.1
# => HTTP/2 200
```

The Docker Hub tags listing also confirms `13.0.1` exists as a plain tag (not only as `13.0.1-security-01`), so we use the plain form per the spec.

**Kustomize build:**

```bash
kubectl kustomize kubernetes/cluster0/apps/monitoring/grafana/app
# builds cleanly
```

## Refs

Follow-up fix for #2985 (which is already merged). Keeps #2984's no-digest stance.
