### PR TITLE
feat(traefik): bump chart v39.0.9 -> v40.2.0 and migrate service block

### DIFF
--- a/kubernetes/cluster0/apps/networking/traefik/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/networking/traefik/app/helm-release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: traefik
-      version: 39.0.9
+      version: 40.2.0
       sourceRef:
         kind: HelmRepository
         name: traefik-charts
@@ -29,9 +29,10 @@ spec:
       replicas: 3
     service:
       enabled: true
-      type: LoadBalancer
       annotations:
         io.cilium/lb-ipam-ips: ${TRAEFIK_IP}
+      spec:
+        type: LoadBalancer
     tlsStore:
       default:
         defaultCertificate:


### PR DESCRIPTION
## Summary

Bumps the Traefik Helm chart from **v39.0.9** to **v40.2.0** (latest 40.x patch at the time of writing) and applies the only required values change: migrating `service.type` under `service.spec.type` per the v40 breaking change in [helm-chart#1686](https://github.com/traefik/traefik-helm-chart/pull/1686).

This is a second attempt — the first attempt (#2899 → #2900 → revert #2901) caused a fleet-wide TLS outage on 2026-05-07. The pre-requisite that was missing then (Gateway API CRD schema skew between in-cluster v1.4.0 and chart-expected v1.5.x) was addressed by #2990 and has now baked ≥24h cleanly.

> [!IMPORTANT]
> **The maintainer is driving the merge personally for this PR.** Worker/coordinator will NOT merge. After review-complete (PASS), the PR will be left ready for the maintainer to review and merge at a screen with cluster access. Per the rule established after #2900: if 525s appear post-merge, **revert — do not fix-forward.**

Closes #2986
Refs #2812
Refs #2990

## Changes

`kubernetes/cluster0/apps/networking/traefik/app/helm-release.yaml`:

```diff
@@ chart.spec @@
-      version: 39.0.9
+      version: 40.2.0
@@ values.service @@
   service:
     enabled: true
-    type: LoadBalancer
     annotations:
       io.cilium/lb-ipam-ips: ${TRAEFIK_IP}
+    spec:
+      type: LoadBalancer
```

No other file is modified. The `ports.websecure.http.tls.{enabled: true, options: default}` block is **preserved unchanged** — see the `helm template` excerpt below confirming this is the correct v40 config when paired with the v1.5.1 CRDs landed by #2990.

## Pre-condition: CRD prep (#2990) is in place

| Check | Result |
|---|---|
| `gateways.gateway.networking.k8s.io` bundle-version | `v1.5.1` ✓ |
| HelmRelease `spec.install.crds` | `CreateReplace` ✓ |
| HelmRelease `spec.upgrade.crds` | `CreateReplace` ✓ |
| ≥24h bake on #2990 | held cleanly (per coordinator brief) ✓ |
| `tlsOptions.default.sniStrict: true` | preserved unchanged ✓ |

`tlsOptions.default { minVersion: VersionTLS12, maxVersion: VersionTLS13, sniStrict: true }` is left as-is — the v40 template renders it identically to v39.

## `helm template` diff: Deployment args are byte-identical except image tag

Rendered against the proposed v40 values:

```bash
helm template traefik traefik/traefik --version 40.2.0 -n networking -f values-v40.yaml
```

vs the v39 baseline:

```bash
helm template traefik traefik/traefik --version 39.0.9 -n networking -f values-v39.yaml
```

Container args on the `traefik` Deployment (identical between v39.0.9 and v40.2.0):

```
- --entryPoints.metrics.address=:9100/tcp
- --entryPoints.traefik.address=:8080/tcp
- --entryPoints.web.address=:80/tcp
- --entryPoints.websecure.address=:443/tcp
- --api.dashboard=true
- --ping=true
- --metrics.prometheus=true
- --metrics.prometheus.entrypoint=metrics
- --providers.kubernetescrd
- --providers.kubernetescrd.allowCrossNamespace=true
- --providers.kubernetescrd.allowExternalNameServices=true
- --providers.kubernetescrd.allowEmptyServices=true
- --providers.kubernetesingress
- --providers.kubernetesingress.allowExternalNameServices=true
- --providers.kubernetesingress.allowEmptyServices=true
- --providers.kubernetesingress.ingressendpoint.publishedservice=networking/traefik
- --providers.kubernetesgateway
- --providers.kubernetesgateway.statusaddress.service.name=traefik
- --providers.kubernetesgateway.statusaddress.service.namespace=networking
- --entryPoints.web.http.redirections.entryPoint.to=:443
- --entryPoints.web.http.redirections.entryPoint.scheme=https
- --entryPoints.web.http.redirections.entryPoint.permanent=true
- --entryPoints.websecure.http.tls=true            # ← preserved
- --entryPoints.websecure.http.tls.options=default # ← preserved
- --log.level=INFO
- --accesslog=true
- --accesslog.fields.defaultmode=keep
- --accesslog.fields.headers.defaultmode=drop
- --api.insecure=true
- --providers.kubernetesingress.ingressclass=traefik
- --providers.kubernetesingress.ingressendpoint.ip=10.87.42.10
- --providers.kubernetescrd.allowexternalnameservices=true
```

Image tag is the only delta:

```
v39.0.9 → image: docker.io/traefik:v3.6.15
v40.2.0 → image: docker.io/traefik:v3.7.1
```

This addresses the root concern from the #2899/#2900 post-mortem: under v39 the entrypoint was launched with `--entryPoints.websecure.http.tls=true --entryPoints.websecure.http.tls.options=default`, and v40.2.0 against the same values block renders **exactly the same flags**. The TLS wiring path that was working under v39 will continue under v40.

## v40.x release notes review

Scanned all v40 stable releases for TLS / Gateway-API related items:

- **v40.0.0** — `service:` syntax aligned with upstream Kubernetes Service spec (the `.spec.type` migration we do here); `providers.kubernetesIngressNginx` → `kubernetesIngressNGINX` (we don't set this); CRDs updated to v3.7; default proxy image v3.7.0. No TLS-handling change called out.
- **v40.0.1** — Traefik Hub bump only. No relevant changes.
- **v40.1.0** — Adds `disableDashboardAd`, `forwardedHeaders.notAppendXForwardedFor`, NGINX provider polish. Default proxy v3.7.1. No TLS-handling change.
- **v40.2.0** — **First release without Gateway API v1.5.1 CRDs bundled** ([#1850](https://github.com/traefik/traefik-helm-chart/pull/1850), tracking [#1669](https://github.com/traefik/traefik-helm-chart/issues/1669)). This is **good** for our setup: per #2990 the Gateway API CRDs are now Flux-managed (`apps/networking/gateway-api/app`), so the chart no longer trying to ship its own copy aligns with our ownership model. The chart-bundled `traefik.io_*` CRDs are unaffected and continue to be upgraded via `CreateReplace`.

Nothing alarming. The Gateway-API-CRD removal in v40.2.0 in particular is **better** than v40.0.0/v40.0.1 for our setup.

## Validation

- `git diff` shows exactly the two changes spec'd (chart version + `service.spec.type` migration). No other file touched.
- `kubectl kustomize kubernetes/cluster0/apps/networking/traefik/app` — builds cleanly (400 lines, exits 0). Rendered HelmRelease shows `version: 40.2.0`.
- `helm template` diff of full rendered manifests (excluding image tag / chart label / appVersion label) shows the only other delta is a **reduction** in ClusterRole verbs (upstream chart no longer grants `get` on `secrets`/`configmaps` in one rule; `list/watch` remain). This is upstream RBAC tightening, not new RBAC introduced by us.

## Post-merge verification (maintainer to run)

```bash
flux reconcile source git home-ops-cluster0
flux reconcile helmrelease -n networking traefik
kubectl -n networking rollout status deploy/traefik --timeout=180s

# Chart version
kubectl get hr -n networking traefik -o jsonpath='{.spec.chart.spec.version}'; echo
# Expected: 40.2.0

# Smoke 3 representative routes (must be non-525)
for host in home-assistant.tinfoilforest.nz auth.tinfoilforest.nz grafana.tinfoilforest.nz; do
  echo -n "$host: "
  curl -sS -o /dev/null -w "%{http_code}\n" "https://$host/"
done

# Cert chain — must be Let's Encrypt, NOT TRAEFIK DEFAULT CERT
for host in home-assistant.tinfoilforest.nz auth.tinfoilforest.nz; do
  echo "=== $host ==="
  echo | openssl s_client -connect 10.87.42.10:443 -servername "$host" 2>&1 \
    | grep -E 'subject=|issuer='
done

# Gateway + HTTPRoute health
kubectl -n networking get gateway traefik-gateway \
  -o jsonpath='{.status.conditions[?(@.type=="Programmed")].status}'; echo
# Expected: True
kubectl get httproute -A -o json \
  | jq -r '.items[] | select(.status.parents[].conditions[]? | select(.type=="Accepted").status=="True") | .metadata.namespace+"/"+.metadata.name' \
  | sort -u | wc -l
# Expected: 25 (the 1 False is pre-existing networking/httpsredirect; not in scope)
```

## Rollback procedure

If anything goes wrong post-merge — **revert, do not fix-forward** (lesson from #2900):

```bash
# Open a revert PR within 60 seconds of seeing 525s
gh pr create --base main --title "revert: Traefik v40.2.0 chart bump"
# Reverting this PR restores helm-release.yaml to its 39.0.9 + flat service block
# shape. Flux will roll the chart back on the next reconcile (~90s). The CRD
# prep landed by #2990 stays in place — v1.5.1 CRDs are forward-compatible
# with v39, and the `crds: CreateReplace` knob will simply not have any new
# CRDs to roll on the next reconcile.

flux reconcile source git home-ops-cluster0
flux reconcile helmrelease -n networking traefik
```

The `safe-upgrades` ValidatingAdmissionPolicy installed by #2990 does **not** block this revert — it only blocks Gateway API CRD downgrades below v1.5.0, which this PR does not touch.

## Risk profile vs the #2899 attempt

| Risk | #2899 attempt | This attempt |
|---|---|---|
| Chart values correctness | medium (migration was right, root cause was elsewhere) | high — `helm template` diff verified byte-identical Deployment args |
| Gateway API CRD schema skew | unaddressed → caused outage | fully addressed via #2990 (v1.5.1 in cluster, baked ≥24h) |
| Proxy v3.7.x against in-cluster CRDs | guaranteed mismatch | matched |
| Rollback path | clean revert | clean revert (CRD prep stays in place) |
| Maintainer at screen during merge | mixed | **yes — maintainer is driving the merge personally** |

## Out of scope

- Any change to CRDs (handled by #2990).
- Any change outside `helm-release.yaml`.
- Fixing the pre-existing `networking/httpsredirect` HTTPRoute (separate cleanup).
- Upgrading any other chart.
- Adjusting `tlsOptions.default { sniStrict: true }` — no change required under v40 per the template diff.
