### PR TITLE
renovate: opt grafana/grafana out of pinDigests

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -73,6 +73,16 @@
       pinDigests: false,
     },
     {
+      // Disable digest pinning on grafana/grafana. Renovate's docker datasource
+      // cannot reliably resolve new digests when the image is pinned via the
+      // helm chart's `image.tag` value (see closed #2832 and the unpin in #2985).
+      // Maintainer position from #2804 audit follow-up: image digest pinning
+      // is intentionally not used in this cluster ("up to date is important").
+      matchDatasources: ['docker'],
+      matchPackageNames: ['grafana/grafana'],
+      pinDigests: false,
+    },
+    {
       // Disable digest pinning on the reloader OCIRepository specifically.
       // The flux-manifests OCIRepository keeps digest pinning because it is
       // consumed by a Kustomization (not templated by helm) and is unaffected.


### PR DESCRIPTION
Closes #2994

## Summary

Adds a per-package opt-out for `grafana/grafana` from Renovate's repo-wide `pinDigests: true` default. Without this rule, Renovate keeps re-proposing a digest pin (#2992) that it then cannot resolve on subsequent tag bumps (see closed #2832, the unpin in #2985, and the retracted-tag fallout in #2987).

Mirrors the existing `rancher/k3s-upgrade` (#2819, #2876, #2895, #2898) and `reloader` (#2831) precedents — same unresolvable-digest shape, same fix. Maintainer policy from the #2804 audit follow-up was explicit that digest pinning is intentionally not used in this cluster.

## Change

Single edit to `.github/renovate.json5`: new \`packageRules\` entry placed adjacent to the `rancher/k3s-upgrade` opt-out so the three exceptions cluster together.

\`\`\`jsonc
{
  matchDatasources: ['docker'],
  matchPackageNames: ['grafana/grafana'],
  pinDigests: false,
},
\`\`\`

(with an inline comment referencing #2832, #2985, and #2804.)

## Post-merge (coordinator)

1. Renovate re-evaluates on its next run.
2. Close #2992 with `gh pr close 2992 --comment "superseded by the renovate config exception"`.
3. Confirm the dashboard (#2603) no longer shows a `pinDigest` proposal for grafana/grafana.