### PR TITLE
renovate: opt ghcr.io/searxng/searxng into loose versioning

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -53,6 +53,16 @@
       allowedVersions: '!/-(armhf|arm64|armv7|amd64|linux)$/',
     },
     {
+      matchDatasources: [
+        'docker',
+      ],
+      versioning: 'loose',
+      matchPackageNames: [
+        '/searxng\/searxng/',
+      ],
+      allowedVersions: '!/-(armhf|arm64|armv7|amd64|linux)$/',
+    },
+    {
       // Flux manager + OCIRepository hybrid digest shape is broken:
       // Renovate writes `tag: <semver>@sha256:<digest>` instead of populating
       // the separate `ref.digest` field (renovatebot/renovate#42082). flux-local


### PR DESCRIPTION
Closes #3000

`ghcr.io/searxng/searxng` is pinned to `2025.8.3-2e62eb5` in `kubernetes/cluster0/apps/home/searxng/app/helm-release.yaml`, but upstream tags daily as `YYYY.M.D-<short-sha>` (latest `2026.5.16-dce3bb69b`). Renovate's default `semver` versioning can't parse that shape, so it has never produced an update PR for this image. This adds a packageRule modelled directly on the existing `plexinc/pms-docker` rule (placed immediately after it for readability): `versioning: 'loose'` plus an `allowedVersions` regex filtering out per-arch tag suffixes (`-armhf|arm64|armv7|amd64|linux`). Validated locally with `renovate-config-validator` — reports "Config validated successfully".