### PR TITLE
fix(renovate): pin alpine/git and busybox init images to explicit versions

### DIFF
--- a/kubernetes/cluster0/apps/home/home-assistant/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/home/home-assistant/app/helm-release.yaml
@@ -27,7 +27,7 @@ spec:
           git-sync:
             image:
               repository: alpine/git
-              tag: latest@sha256:d453f54c83320412aa89c391b076930bd8569bc1012285e8c68ce2d4435826a3
+              tag: v2.52.0@sha256:d453f54c83320412aa89c391b076930bd8569bc1012285e8c68ce2d4435826a3
             command:
               - sh
               - -c

--- a/kubernetes/cluster0/apps/kube-system/local-path-provisioner/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/kube-system/local-path-provisioner/app/helm-release.yaml
@@ -28,7 +28,7 @@ spec:
     replicaCount: 2
     helperImage:
       repository: public.ecr.aws/docker/library/busybox
-      tag: latest@sha256:1487d0af5f52b4ba31c7e465126ee2123fe3f2305d638e7827681e7cf6c83d5e
+      tag: 1.37.0@sha256:1487d0af5f52b4ba31c7e465126ee2123fe3f2305d638e7827681e7cf6c83d5e
     storageClass:
       defaultClass: false
     nodePathMap:


### PR DESCRIPTION
Closes #3002

## Summary

Two init-container images were pinned as `latest@sha256:<digest>`, which caused Renovate to silently re-pin the digest with no PR visibility (PR-history search for `alpine/git` and `busybox` returns zero results). Switch to explicit version tags so Renovate's docker datasource produces normal version-bump PRs that flow through the existing auto-merge rules — same handling as every other image in the cluster.

## Changes

| File | Image | Before | After |
|---|---|---|---|
| `kubernetes/cluster0/apps/home/home-assistant/app/helm-release.yaml` | `alpine/git` | `latest@sha256:d453f54c…26a3` | `v2.52.0@sha256:d453f54c…26a3` |
| `kubernetes/cluster0/apps/kube-system/local-path-provisioner/app/helm-release.yaml` | `public.ecr.aws/docker/library/busybox` | `latest@sha256:1487d0af…3d5e` | `1.37.0@sha256:1487d0af…3d5e` |

**Both pins are zero-image-change** — only the tag string changes; the sha256 digest (and therefore the actual image layers pulled) is identical to what was previously deployed. Verified with `crane digest`:

```
$ crane digest alpine/git:v2.52.0
sha256:d453f54c83320412aa89c391b076930bd8569bc1012285e8c68ce2d4435826a3

$ crane digest public.ecr.aws/docker/library/busybox:1.37.0
sha256:1487d0af5f52b4ba31c7e465126ee2123fe3f2305d638e7827681e7cf6c83d5e
```

For busybox, `1.37.0` was preferred over the moving `stable` tag so Renovate can track patch/minor bumps (`stable` would never produce a version-bump PR).

## Validation

- `flux-local test --all-namespaces --enable-helm` → 101 passed.
- `flux-local diff helmrelease` against `main` shows only the expected one-line image-string change on the `home-assistant` `git-sync` init container. The local-path-provisioner `app/helm-release.yaml` does not appear in the diff because its `ks.yaml` points at `./policy` (not `./app`) — see escalation note below.

## Note for the coordinator

While working on this I noticed that `kubernetes/cluster0/apps/kube-system/local-path-provisioner/app/helm-release.yaml` is not actually applied to the cluster — the `ks.yaml` points at the sibling `policy/` directory only, since the real local-path-provisioner is the k3s built-in addon. The busybox pin in this PR is therefore Renovate-visibility-only and has no cluster effect. Escalated separately for possible follow-up cleanup; out of scope for this PR.
