### PR TITLE
fix(searxng): align settings.yml with v2026.5.16 schema ahead of image bump

### DIFF
--- a/kubernetes/cluster0/apps/home/searxng/app/settings.yml
+++ b/kubernetes/cluster0/apps/home/searxng/app/settings.yml
@@ -26,16 +26,28 @@ valkey:
 
 ui:
   default_theme: simple
-  infinite_scroll: false
   query_in_title: true
 
-enabled_plugins:
-  - Basic Calculator
-  - Hash plugin
-  - Open Access DOI rewrite
-  - Self Informations
-  - Tracker URL remover
-  - Unit converter plugin
+# As of SearXNG 2025.10+, plugins are configured via a top-level `plugins:`
+# map keyed by the plugin's fully-qualified class path. The previous
+# `enabled_plugins:` list of friendly names is no longer parsed. Listing a
+# plugin here with `active: true` enables it by default; unlisted plugins are
+# not loaded (matching the old `enabled_plugins` opt-in semantics).
+# Note: `infinite_scroll` is now controlled solely by its plugin (omitted
+# below = not loaded, equivalent to the previous `ui.infinite_scroll: false`).
+plugins:
+  searx.plugins.calculator.SXNGPlugin:
+    active: true
+  searx.plugins.hash_plugin.SXNGPlugin:
+    active: true
+  searx.plugins.oa_doi_rewrite.SXNGPlugin:
+    active: true
+  searx.plugins.self_info.SXNGPlugin:
+    active: true
+  searx.plugins.tracker_url_remover.SXNGPlugin:
+    active: true
+  searx.plugins.unit_converter.SXNGPlugin:
+    active: true
 
 categories_as_tabs:
   general:


### PR DESCRIPTION
## Summary

Aligns `kubernetes/cluster0/apps/home/searxng/app/settings.yml` with the schema used by SearXNG `2026.5.16-de49d2784` (the target of PR #3006). Two breaking schema changes landed upstream between `2025.8.3` and `2026.5.16` that affect our overrides; without this PR our plugin configuration would be silently dropped and the SearXNG container would log an unknown-key warning for `ui.infinite_scroll`.

**This PR must merge before #3006.**

## Drifted keys

### 1. `enabled_plugins:` (top-level list) → `plugins:` (top-level map)

Upstream removed the legacy `enabled_plugins:` list of friendly plugin names. Plugins are now declared via a top-level `plugins:` map keyed by each plugin's fully-qualified class path, with a per-plugin `active` flag. Unlisted plugins are not loaded, which preserves the old "opt-in only" semantics of `enabled_plugins`.

Verified via `searx/settings_loader.py` at `de49d2784`: when the user provides `plugins:`, the defaults are fully replaced (no merge), and `PluginStorage.load_settings` only loads what's in the dict.

Translated name → module path (each verified by inspecting `searx/plugins/<name>.py` at `de49d2784`):

| Old friendly name | New fully-qualified class |
|---|---|
| Basic Calculator | `searx.plugins.calculator.SXNGPlugin` |
| Hash plugin | `searx.plugins.hash_plugin.SXNGPlugin` |
| Open Access DOI rewrite | `searx.plugins.oa_doi_rewrite.SXNGPlugin` |
| Self Informations | `searx.plugins.self_info.SXNGPlugin` |
| Tracker URL remover | `searx.plugins.tracker_url_remover.SXNGPlugin` |
| Unit converter plugin | `searx.plugins.unit_converter.SXNGPlugin` |

### 2. `ui.infinite_scroll: false` removed

The `infinite_scroll` key has been removed from the `ui:` section schema in `searx/settings_defaults.py`. Infinite scroll is now controlled solely by the `searx.plugins.infinite_scroll.SXNGPlugin` plugin. By omitting that plugin from our `plugins:` map, it isn't loaded — matching the previous `ui.infinite_scroll: false` behaviour.

## Keys verified unchanged

All other overrides were cross-referenced against `searx/settings.yml` and `searx/settings_defaults.py` at commit `de49d2784` and confirmed to have the same name and value shape:

- `general.{debug, enable_metrics}`
- `search.{safe_search, autocomplete, autocomplete_min, default_lang, formats}`
- `server.{secret_key, image_proxy, method, limiter}`
- **`valkey.url`** — explicitly confirmed: still under a top-level `valkey:` key (not renamed back to `redis:`, not moved elsewhere). The deprecated `redis:` key still exists in defaults for back-compat but `valkey:` is current canonical.
- `ui.{default_theme, query_in_title}`
- `categories_as_tabs` (map shape unchanged)

## Validation

```
$ flux-local test --all-namespaces --enable-helm --path kubernetes/cluster0/flux
============================= test session starts ==============================
collected 101 items
...
======================== 101 passed in 69.45s (0:01:09) ========================
```

Same invocation used by `.github/workflows/flux-local.yaml`.

Refs #3006
