### PR TITLE
chore(deps): bump dnsdist 1.8.4 -> 2.0.5 (manual major, repo rename)

### DIFF
--- a/kubernetes/cluster0/apps/media/qbittorrent/app/config/dnsdist.conf
+++ b/kubernetes/cluster0/apps/media/qbittorrent/app/config/dnsdist.conf
@@ -28,4 +28,6 @@ newServer({
 })
 
 -- Routing rules
-addAction('cluster.local', PoolAction('k8s'))
+-- QNameSuffixRule is required since dnsdist 1.9; passing a bare string to
+-- addAction() was deprecated in 1.9 and is being phased out.
+addAction(QNameSuffixRule('cluster.local'), PoolAction('k8s'))

--- a/kubernetes/cluster0/apps/media/qbittorrent/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/qbittorrent/app/helm-release.yaml
@@ -45,8 +45,8 @@ spec:
           # doh to avoid dns leaks
           dnsdist:
             image:
-              repository: docker.io/powerdns/dnsdist-18
-              tag: 1.8.4@sha256:28217d070c861a9c0b394346cd644df077d1ee1fb019a7d69d6683ea1258d4c0
+              repository: docker.io/powerdns/dnsdist-20
+              tag: 2.0.5@sha256:40d9d75ea92260ffee52f52a9b156219a0701c811c3e827bb52ebbd95cd6f637
           # do the vpn thing
           gluetun:
             image:


### PR DESCRIPTION
## Summary

Manual major bump of the dnsdist sidecar in the qbittorrent stack from
`docker.io/powerdns/dnsdist-18:1.8.4` (Sept 2024) to
`docker.io/powerdns/dnsdist-20:2.0.5` (current stable, Apr 2026).
PowerDNS publishes each minor under a separate Docker repo name, so
Renovate cannot follow the rename across majors — this needs to be done
by hand.

Closes #2997

## What dnsdist-18 is doing in this stack (investigation)

The qbittorrent pod (`media/qbittorrent`) has three containers sharing a
network namespace:

| Container | Image | Role |
|-----------|-------|------|
| `app`     | `ghcr.io/home-operations/qbittorrent` | the torrent client |
| `gluetun` | `ghcr.io/qdm12/gluetun` | the VPN (shadowsocks, `NET_ADMIN`, privileged) |
| `dnsdist` | `docker.io/powerdns/dnsdist-18:1.8.4` | local DNS forwarder |

Relevant gluetun env:

```yaml
- name: DOT
  value: "off"                 # gluetun's built-in DoT proxy disabled
- name: DNS_PLAINTEXT_ADDRESS
  value: "127.0.0.2"           # all DNS in the pod is sent to 127.0.0.2:53
```

dnsdist listens on `127.0.0.2:53` and split-routes by suffix
(`config/dnsdist.conf`):

```lua
setLocal("127.0.0.2:53", {})

newServer({ address = "10.43.0.10", pool = "k8s", ... })            -- coredns
newServer({ address = "1.1.1.1:853", tls = "openssl", ... })        -- CF DoT
newServer({ address = "1.0.0.1:853", tls = "openssl", ... })        -- CF DoT

addAction('cluster.local', PoolAction('k8s'))                       -- split horizon
```

Traffic flow for any DNS lookup made by qbittorrent (or gluetun
itself):

```
qbittorrent -> 127.0.0.2:53 (dnsdist)
                |
                +-- *.cluster.local  -> 10.43.0.10 (k8s coredns, in-cluster)
                +-- everything else  -> 1.1.1.1:853 / 1.0.0.1:853 DoT (CloudFlare)
```

## Is dnsdist still required?

**Yes — retained.** gluetun's built-in DNS handling (`DOT=on`) would
encrypt outbound DNS to CloudFlare but has no notion of split-horizon
back to in-cluster `cluster.local` names. qbittorrent in this stack
needs to resolve sibling cluster services (the `*arr` apps have
ingress rules pointing at this pod on 8080, and the
`allow-arr-ingress` networkpolicy permits it). Without dnsdist,
`*.cluster.local` lookups would either be sent encrypted to CloudFlare
(which can't answer them) or leaked unencrypted, depending on gluetun
config. Removing dnsdist would break in-cluster name resolution.

Therefore: bump, not remove.

## Target choice

Current state of upstream PowerDNS Docker repos (checked
2026-05-17 via `hub.docker.com/v2/repositories/powerdns/`):

| Repo          | Latest tag    | Last push   | Notes                          |
|---------------|---------------|-------------|--------------------------------|
| `dnsdist-18`  | `1.8.4`       | 2024-09-19  | unmaintained, our current pin  |
| `dnsdist-19`  | `1.9.14`      | 2026-04-22  | maintained, LTS-ish            |
| `dnsdist-20`  | `2.0.5`       | 2026-04-22  | **current stable**             |
| `dnsdist-21`  | `2.1.0-beta2` | 2026-03-10  | pre-release only               |

The issue body assumed `dnsdist-21` was current stable; upstream
hasn't shipped a non-beta `2.1.0` yet, so the right pick today is
`dnsdist-20:2.0.5`.

Note: PowerDNS renumbered to `2.x` between `dnsdist-19` (1.9.x) and
`dnsdist-20` (2.0.x). The repo name convention now appears to encode
the year/sequence, not the upstream `MAJOR.MINOR`, so `dnsdist-20`
containing `2.0.x` is intentional upstream behaviour.

## Breaking config-syntax changes (1.8 → 2.0) that affect us

Walking the upstream upgrade guide (https://dnsdist.org/upgrade_guide.html)
section-by-section against our minimal config:

**1.8.x → 1.9.0** — relevant to us:
- `addAction()` called with a bare suffix string (e.g.
  `addAction('cluster.local', ...)`) is deprecated in favour of
  `addAction(QNameSuffixRule('cluster.local'), ...)`. Still works in
  1.9/2.0 with a deprecation warning. **Fixed in this PR.**
- `makeRule()` deprecation — we don't use it.
- SNMP build option — irrelevant, we use the upstream image.
- nghttp2 vs h2o for incoming DoH — we don't accept incoming DoH.

**1.9.x → 2.0.0** — none of these apply:
- `showTLSContexts()`/`getTLSContext()` removed — we don't call them.
- eBPF qtype semantics — we don't use eBPF filtering.
- XPF removal — we don't use XPF.
- `Server:setAuto` health-check semantic change — we use
  `healthCheckMode = "lazy"` directly on `newServer`, not `setAuto`.
- `HTTPStatusAction` options deprecation — we don't use it.
- Response cleanup on rcode actions — we don't use those actions.
- Python 3 + YAML / Rust build-time deps — irrelevant, image build.

**2.0.x → 2.1.0** (informational — not the target, but for the
record): YAML config default, custom Lua load-balancing policies must
return an index, h2o removal, structured-logging default, webserver
CORS default. None of these affect our config.

Net config delta in this PR: one line of `dnsdist.conf` updated from
`addAction('cluster.local', PoolAction('k8s'))` to
`addAction(QNameSuffixRule('cluster.local'), PoolAction('k8s'))`.

## Digest pin

`docker.io/powerdns/dnsdist-20:2.0.5` resolved via the Docker registry
manifest API on 2026-05-17:

```
sha256:40d9d75ea92260ffee52f52a9b156219a0701c811c3e827bb52ebbd95cd6f637
```

## Validation

```
$ flux-local test --all-namespaces --enable-helm --path kubernetes/cluster0/flux
============================= test session starts ==============================
collected 101 items
......................................................................  [100%]
======================== 101 passed in 65.59s (0:01:05) ========================
```

## Post-deploy verification (manual, for the maintainer)

After Flux reconciles, verify:

1. **Pod comes up healthy** — all three containers `Ready`:
   ```
   kubectl -n media get pod -l app.kubernetes.io/instance=qbittorrent
   kubectl -n media logs deploy/qbittorrent -c dnsdist | head -50
   ```
   dnsdist should not log syntax errors. A `addAction()` deprecation
   warning should no longer appear (we updated to `QNameSuffixRule`).

2. **In-cluster DNS still works** (cluster.local → coredns path):
   ```
   kubectl -n media exec deploy/qbittorrent -c app -- \
     nslookup kubernetes.default.svc.cluster.local 127.0.0.2
   ```
   Expect `10.43.0.1` (or whatever the kubernetes svc IP is) via the
   `k8s` pool.

3. **External DNS still works and goes via DoT** (no leak path):
   ```
   kubectl -n media exec deploy/qbittorrent -c app -- \
     nslookup cloudflare.com 127.0.0.2
   ```
   Expect a valid answer. Confirm via dnsdist's stats that the
   non-`k8s` pool was used:
   ```
   kubectl -n media exec deploy/qbittorrent -c dnsdist -- \
     dnsdist -c -e 'showServers()'
   ```

4. **Torrent traffic still flows behind the VPN** — open the
   qbittorrent web UI, confirm an active torrent's peer count > 0 and
   download is progressing. The
   "Tools → Run external program → IP-check" approach also works:
   confirm `curl ifconfig.me` from inside the `gluetun` container
   returns the VPN exit IP, not the home WAN IP.

5. **No DNS leak outside the tunnel** — confirm dnsdist's only
   upstreams are `10.43.0.10:53` (in-cluster, never leaves the node)
   and `1.1.1.1:853`/`1.0.0.1:853` over DoT (encrypted, goes via the
   gluetun tunnel since gluetun owns the network namespace and
   `FIREWALL_OUTBOUND_SUBNETS` only carves out the k8s subnets for
   plaintext). `dnsdist.conf` is unchanged in topology — the same
   upstreams are configured as before the bump.

## Acceptance Criteria

(Verbatim from #2997.)

- [x] [functional] Document what dnsdist-18 is doing in the
  qbittorrent/gluetun stack (which container it sits next to, what
  traffic flows through it, what config it loads) before changing
  anything. *(See "What dnsdist-18 is doing in this stack" above.)*
- [x] [functional] Confirm whether dnsdist is required at all
  post-gluetun, or whether it can be removed. *(See "Is dnsdist still
  required?" — retained because gluetun has no split-horizon for
  `cluster.local`.)*
- [x] [functional] If retained, summarise breaking changes between
  dnsdist 1.8 and the target minor (1.9 / 1.10 / 1.11) from upstream
  changelogs, focusing on config-file syntax. *(See "Breaking
  config-syntax changes" — only `addAction(string, ...)` →
  `addAction(QNameSuffixRule(...), ...)` affects us; fixed.)*
- [x] [functional] Update `repository:` from
  `docker.io/powerdns/dnsdist-18` to the chosen `dnsdist-NN` repo and
  pin to a current digest. *(Now `dnsdist-20:2.0.5@sha256:40d9d75e…`.)*
- [ ] [edge-case] Post-deploy verification: qbittorrent's DNS lookups
  (over the VPN) still resolve, and torrent traffic still flows.
  Document the exact check used. *(Documented above; manual check
  post-merge.)*
- [ ] [security] DNS resolution still goes via the intended upstream
  (no leaks outside the gluetun tunnel). *(Topology of upstreams in
  `dnsdist.conf` is unchanged — same `10.43.0.10` and CloudFlare DoT
  servers; the maintainer's post-deploy check above confirms this.)*
