### PR TITLE
feat(changedetection): migrate browser pod from abandoned browserless/chrome to browserless/chromium v2

### DIFF
--- a/kubernetes/cluster0/apps/monitoring/changedetection-io/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/monitoring/changedetection-io/app/helm-release.yaml
@@ -34,11 +34,16 @@ spec:
             env:
               TZ: "${TIMEZONE}"
               USE_X_SETTINGS: 1
-              PLAYWRIGHT_DRIVER_URL: ws://changedetection-browser:3000/?stealth=1&--disable-web-security=true
+              # PLAYWRIGHT_DRIVER_URL is injected via envFrom below from
+              # changedetection-io-secret because it embeds the browserless v2
+              # auth TOKEN in the query string.
               # Socket.io configuration for reverse proxy / Cloudflare
               FLASK_SERVER_NAME: "changedetection-io.${SECRET_PUBLIC_DOMAIN}"
               BASE_URL: "https://changedetection-io.${SECRET_PUBLIC_DOMAIN}"
               SOCKETIO_CORS_ORIGINS: "https://changedetection-io.${SECRET_PUBLIC_DOMAIN}"
+            envFrom:
+              - secretRef:
+                  name: changedetection-io-secret
     service:
       app:
         controller: main

--- a/kubernetes/cluster0/apps/monitoring/changedetection-io/app/kustomization.yaml
+++ b/kubernetes/cluster0/apps/monitoring/changedetection-io/app/kustomization.yaml
@@ -3,6 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helm-release.yaml
+  - ./secret.sops.yaml
 labels:
   - pairs:
       app.kubernetes.io/name: changedetection-io

--- a/kubernetes/cluster0/apps/monitoring/changedetection-io/app/secret.sops.yaml
+++ b/kubernetes/cluster0/apps/monitoring/changedetection-io/app/secret.sops.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: changedetection-io-secret
+    namespace: monitoring
+type: Opaque
+stringData:
+    #ENC[AES256_GCM,data:LojpJAMjsdjG1G8t3l2TYRliHIJqG1PQeb9PRAYw3imECFkFwOvNCDDLuWzfT5remWT1/VUfPf8vrq9Z7LEs/A1MTXlDbTpZ,iv:FtJN2txsSZi+dOHVUKoPLeYksd8GP5ckD/GtOiWnb9U=,tag:msQ2GXmEfIN75zvybzuxOw==,type:comment]
+    #ENC[AES256_GCM,data:VmJl7HPvmL/jEZTp6r/2Q66myugyvFGYSON0qtPrlJ37H23rnySDLVZv7z0i+u9T4n5+KgrJa2D4fBdjvaMqktRtOD6ik6hzfoN5OIqRqQM=,iv:m0yCSyEqoHHvkW8CadoclWNbFGv5Fptzbl6xUYX4pNw=,tag:5fAbK9mcTS6jwGLJqfmYXw==,type:comment]
+    #ENC[AES256_GCM,data:Z6HcSjkVQimQs814k5D6HO3x87SK+s+O/Gur6RKasyViMyaDnfDTACBakqaPm5qoqO+/DqOoqouPdcthv34nUAa4WzI=,iv:9AngTGC/Jd9S23j6rAuh/jdB76KdgZlYjHqBPCParc4=,tag:U0uQpzL5ww+bpr8a8DT9dA==,type:comment]
+    #ENC[AES256_GCM,data:+pTKxSWaeGKzijItwAe29ZWXgd0QfDzILPLww3E5HhTyd6WN9wBbOgGwMvmokPrwwafjvkIMrn8YHY/70o7AJ6+/a32gqRk=,iv:5cupgqj/18WIotzgAze2nr+GFwedjCd5bzr1YvU13No=,tag:CBorK82jL+mO0930LH234A==,type:comment]
+    PLAYWRIGHT_DRIVER_URL: ENC[AES256_GCM,data:iQcokdKh/IuB4WOsKJ6DlKr9PRZAy1CZ6RI+wKE8RmBF2wnfEjNtcTfF8oBb4FT7E8NBdO004iSgpgwFI3jt3PIHb1ZynvJpBStzoLf27a1QNDpkvUvFwHh4jeFgOhoVHLp0cuAVX/E9k6ZI/TMk0Xc7ehhJ5kCy8yZIur8n4yiEubhL96renfDvEmTUZ8w=,iv:dB5kv0KWAduEYSgngr1iWvtzLqWcdascjLDZJRKJSYU=,tag:UhabD/TtNCmi7+VyWjzHyg==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBqalA3VTlpOGsxZWkyMkNS
+            NElYbFROK1VoVmRYaVBzZnlrdVoweFVNelhZClRyOENXbmFtbVpqUEZGa1BQSmxo
+            ZmIyTlJrZVVwcVk3RUVLV1pzMDlVUTAKLS0tIFVLMFRkWFM0UW9odGpRa3c3Qmxn
+            VnF0bTl2UnI0WTd3dmpWbWVBSEJ0S3MKPxBYrK/0qeYBSxH3qFqQZe07hD5xgfxQ
+            PTSLP3wLYMcUZYpRipXrX/6Vz44VNHKrmbF/Nw8oPzMh598yRmlaiA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1582vh25trj6w7klwt38d44n5nr8njr8rrxxx5kcfu3y2ezx9ss3s6j24ex
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAzNUtjV2JlRnhxWWk4bjlM
+            czZJSFN5cVlrRkFEaHNVUTB5WjRaT1VCdHlzCjRqT3pnanJROTZPZC9QdGdZZkVB
+            Wll5OUVZdFBrcDJHZFdvcXl4K2pyS3MKLS0tIGttVENYMVdhUUlONFlISEdFVjNC
+            aTdNTTRNZVZPaVM4U2xoMkxPNEJjeVkKlUNJ99lOJ1Bns2qB8PUT6DSRguabZTmC
+            eFwGrsTbsZrIyX4Ks38ETgy+arQNZ8hUf5883Ihi4vh8hZTQi9+qow==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age185kanaq3uw2gjx5enu2v69nk9ner3lamdevrfgx3wqucsl9ewa2qlt2gf7
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-05-16T23:37:21Z"
+    mac: ENC[AES256_GCM,data:NORx8F16L+sTr7hEVtgQyuoUCiaVthfr9OTspl4ayjNU6AiaHQ1CdpWSXvI97CsugIy0TS1Urhg1VBt9ZXoix5OBnfNv8Od6Guue4VnpcCmBQm7lsoJGjZUsRJ8p0OBJFGMvj3Kj9WGON/KTxjVFZ0RIPu1dkrXo3fOAxjC+uOs=,iv:TC3IFBFUU9hXeAxBrHwXq2Muli5wlSNASiNl9zeNk1w=,tag:e5kLAgNf2QXimA3Fl5th6g==,type:str]
+    version: 3.13.0

--- a/kubernetes/cluster0/apps/monitoring/changedetection-io/browser/helm-release.yaml
+++ b/kubernetes/cluster0/apps/monitoring/changedetection-io/browser/helm-release.yaml
@@ -26,27 +26,39 @@ spec:
         containers:
           app:
             image:
-              repository: docker.io/browserless/chrome
-              tag: latest@sha256:57d19e414d9fe4ae9d2ab12ba768c97f38d51246c5b31af55a009205c136012f
+              # Migrated 2026-05 from abandoned docker.io/browserless/chrome (v1, last published 2024-02)
+              # to ghcr.io/browserless/chromium (v2). See issue #2998.
+              repository: ghcr.io/browserless/chromium
+              tag: v2.38.1@sha256:78afaada9f7b049783bfed624e6b5e9a2d3438fc04bb46801ed777e82ae1501f
             env:
-              SCREEN_WIDTH: 1920
-              SCREEN_HEIGHT: 1024
-              SCREEN_DEPTH: 16
+              # v2 defaults HOST to "localhost" — must bind 0.0.0.0 for in-cluster traffic.
+              HOST: 0.0.0.0
+              # v2 renamed CONNECTION_TIMEOUT -> TIMEOUT (ms).
+              TIMEOUT: 300000
+              # v2 renamed MAX_CONCURRENT_SESSIONS -> CONCURRENT.
+              CONCURRENT: 5
+              # Retained from v1; still honoured by v2's Config.
               ENABLE_DEBUGGER: false
-              PREBOOT_CHROME: true
-              CONNECTION_TIMEOUT: 300000
-              MAX_CONCURRENT_SESSIONS: 5
-              CHROME_REFRESH_TIME: 600000
-              DEFAULT_BLOCK_ADS: true
-              DEFAULT_STEALTH: true
-              DEFAULT_LAUNCH_ARGS: "[\"--no-sandbox\",\"--disable-dev-shm-usage\"]"
+              # v1 env vars dropped in v2:
+              #   PREBOOT_CHROME, CHROME_REFRESH_TIME — deprecated, ignored in v2.
+              #   DEFAULT_BLOCK_ADS, DEFAULT_STEALTH, DEFAULT_LAUNCH_ARGS — now per-session
+              #     query-string flags on PLAYWRIGHT_DRIVER_URL (see app helm-release).
+              #   SCREEN_WIDTH/HEIGHT/DEPTH — v1 Xvfb-only, not used by v2.
+            envFrom:
+              # TOKEN — v2 requires auth by default. Stored SOPS-encrypted.
+              - secretRef:
+                  name: changedetection-browser-secret
             probes:
               liveness:
                 enabled: true
                 custom: true
                 spec:
                   httpGet:
-                    path: /pressure
+                    # v1 used /pressure (unauthenticated). In v2 /pressure requires
+                    # the auth token, which a k8s httpGet probe cannot supply, so we
+                    # probe the unauthenticated static root instead — it returns 200
+                    # once the HTTP server is listening.
+                    path: /
                     port: 3000
                   initialDelaySeconds: 30
                   periodSeconds: 60

--- a/kubernetes/cluster0/apps/monitoring/changedetection-io/browser/kustomization.yaml
+++ b/kubernetes/cluster0/apps/monitoring/changedetection-io/browser/kustomization.yaml
@@ -3,6 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helm-release.yaml
+  - ./secret.sops.yaml
 labels:
   - pairs:
       app.kubernetes.io/name: changedetection-io

--- a/kubernetes/cluster0/apps/monitoring/changedetection-io/browser/secret.sops.yaml
+++ b/kubernetes/cluster0/apps/monitoring/changedetection-io/browser/secret.sops.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: changedetection-browser-secret
+    namespace: monitoring
+type: Opaque
+stringData:
+    TOKEN: ENC[AES256_GCM,data:qsUZBXrp4SRY/rF1mCgspzr1JYJm3ioOxlBfqk/CPakeRrS+88Hf7rp4SPV22jEoB0XNaWNralL+bV31nMZp4A==,iv:PalJWGOBIiq6PMwvtqhnvSpncQQmZ+t32Fa8ouCgoCA=,tag:enwAbw5YFCY8H51MnQ4lkQ==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA0UVgwdEhxclNmWTZKcHA2
+            SXRGYW5Qd3h2b0sxTDZoUENPa2FmNTJHQkRRCmhncjRHeWVPa29rWVI2eUpsbGwv
+            WFh1aFhvREdvZkphaTFOakVORXdCa00KLS0tIGlxcXJyZG1UdGlqa1hNQ245aTEw
+            SDJzc0ZRSGxMUUVUMktHMlRkR0QxdmcKHS/ZjRl4cSERlcWecuo1Ix5Y0tzYkXXG
+            lworkVOkBc+S5jF7AEC9TOo7Poyhw05gAJk7U3+efFKpSTvdA3RqCA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1582vh25trj6w7klwt38d44n5nr8njr8rrxxx5kcfu3y2ezx9ss3s6j24ex
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB4NHYvYm5SS0xCZzUrRmZr
+            ZWl4SGNZUFVFWjBrMmgzWGVmSUxMU2ZpM0dJCkJJSW5IVnFBV0tLbWNEaGoyNTBp
+            QXh6ZGhNRS9idTFqaHpyVi81OWh0WFkKLS0tIE03VE1wZ0JsdVhlNE9aVlJPZlpz
+            M2trdHVud2lycWNnc3NUZkdUcm9UUmcKVnQQ6IryekI5lGJGEifJOfC+4EXy6HC/
+            A9tQIlHJX1cxt6w8l8cyiyGzQ2wyt16FiNySfANvjrM62IxSX31tNw==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age185kanaq3uw2gjx5enu2v69nk9ner3lamdevrfgx3wqucsl9ewa2qlt2gf7
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-05-16T23:15:13Z"
+    mac: ENC[AES256_GCM,data:PgZKMrolcRqF0BusACg2K2OnkRDjmi89qmEuFi8WblsVJgKw26JJXV+xgm06IX26TTiGi8/ZnV5jpMbhlrYuDlkuqEgLGlN6SxRXZ92wWteufBIUsmw/hGfpv4bxmy1avbWk7tBsAD/oJtkUwIJYuZbGqUJUDmuMJDRhtpaOh+I=,iv:71oLO7jkCRrOMZhJdTyjjXHfDBobU1vNsom1XGl74Dk=,tag:7/I4kXE3b/26DaYpld5cKg==,type:str]
+    version: 3.13.0


### PR DESCRIPTION
Closes #2998

## Why

`kubernetes/cluster0/apps/monitoring/changedetection-io/browser/helm-release.yaml` was running `docker.io/browserless/chrome:latest@sha256:57d19e41…`. That image was last published **2024-02-16** — upstream rewrote the project as v2 under `ghcr.io/browserless/chromium` and the v1 chrome line is abandoned (no security patches, no Chromium engine updates; the image we shipped bundles Chromium ~120). Renovate cannot help because there are no newer `chrome:latest` digests to detect.

This PR migrates the browser pod to `ghcr.io/browserless/chromium:v2.38.1` (current latest at time of writing) pinned to a sha256 digest, and adapts the changedetection-io app pod to the v2 auth model.

## Env-var migration (v1 → v2)

Verified against the v2 source ([`src/config.ts`](https://github.com/browserless/browserless/blob/main/src/config.ts)) — `oldConfig` / `newConfigMap` / `deprecatedConfig` enums.

| v1 env var | v2 status | Action taken |
|---|---|---|
| `CONNECTION_TIMEOUT` | renamed → `TIMEOUT` | renamed (value unchanged: 300000 ms) |
| `MAX_CONCURRENT_SESSIONS` | renamed → `CONCURRENT` | renamed (value unchanged: 5) |
| `PREBOOT_CHROME` | deprecated, ignored | **dropped** |
| `CHROME_REFRESH_TIME` | deprecated, ignored | **dropped** |
| `DEFAULT_BLOCK_ADS` | per-session query param (`?blockAds=true`) | **dropped from env**; not currently re-added as a query flag (we never had a reason to block ads on the watched targets — easy to add later if needed) |
| `DEFAULT_STEALTH` | per-session query param (`?stealth=1`) | **dropped from env**; already present as `?stealth=1` in the existing `PLAYWRIGHT_DRIVER_URL` (handled by the v2 legacy shim, [`src/shim.ts`](https://github.com/browserless/browserless/blob/main/src/shim.ts)) |
| `DEFAULT_LAUNCH_ARGS` (`--no-sandbox`, `--disable-dev-shm-usage`) | per-session query params (e.g. `?--no-sandbox=true`) | **dropped from env**; the existing URL already carries `&--disable-web-security=true`. The chromium v2 image runs unsandboxed by default (it's the only mode the container supports), and `/dev/shm` is already mounted as a `tmpfs`, so the other two v1 launch args are redundant. |
| `SCREEN_WIDTH` / `SCREEN_HEIGHT` / `SCREEN_DEPTH` | v1 Xvfb-only, not referenced anywhere in v2 source | **dropped** |
| `ENABLE_DEBUGGER` | still honoured by v2 `Config` | retained (`false`) |
| — | new in v2: `HOST` | **added** `HOST=0.0.0.0` (v2 default is `localhost`, which would refuse in-cluster traffic) |
| — | new in v2: `TOKEN` (required by default) | **added**, sourced from new SOPS secret `changedetection-browser-secret` via `envFrom` |

## Liveness probe

v1's `/pressure` route still exists in v2 ([`src/routes/management/http/pressure.get.ts`](https://github.com/browserless/browserless/blob/main/src/routes/management/http/pressure.get.ts)) **but is now `auth = true`** — a k8s `httpGet` probe cannot supply the token. Switched to `/` (the unauthenticated static-files route, [`src/routes/management/http/static.get.ts`](https://github.com/browserless/browserless/blob/main/src/routes/management/http/static.get.ts), `auth = false`). It returns 200 as soon as the HTTP server is listening, which is the right semantics for a liveness probe.

## Token wiring

The token is a single 32-byte hex value (`openssl rand -hex 32`) used in two places:

1. **Browser pod** — `TOKEN` env var, sourced from `changedetection-browser-secret` (new file, SOPS-encrypted, in `monitoring`).
2. **App pod** — embedded in the `PLAYWRIGHT_DRIVER_URL` query string (`?token=…`). Because k8s does not substitute secret values into other env values, the entire URL is stored in a second SOPS secret, `changedetection-io-secret` (new file, in `monitoring`), and injected via `envFrom`. This keeps the token out of the helm-release YAML in both places.

Both secrets round-trip cleanly with `sops -d`.

## Acceptance Criteria

- [x] [functional] `monitoring/changedetection-io/browser/helm-release.yaml` `repository:` changed from `docker.io/browserless/chrome` to `ghcr.io/browserless/chromium`, with a current explicit version tag + `@sha256:` digest. → `ghcr.io/browserless/chromium:v2.38.1@sha256:78afaada9f7b049783bfed624e6b5e9a2d3438fc04bb46801ed777e82ae1501f`
- [x] [functional] v1-only env vars are removed or renamed for v2 compatibility: `PREBOOT_CHROME`, `CHROME_REFRESH_TIME`, `DEFAULT_BLOCK_ADS`, `DEFAULT_STEALTH`, `DEFAULT_LAUNCH_ARGS`, `MAX_CONCURRENT_SESSIONS`, `CONNECTION_TIMEOUT` audited against v2 docs; replaced or dropped as required. → see table above.
- [x] [functional] `TOKEN` env var added (v2 requires authentication by default) and wired into changedetection-io's `PLAYWRIGHT_DRIVER_URL` query string in `monitoring/changedetection-io/app/helm-release.yaml`. → via SOPS secret + `envFrom` on both pods.
- [x] [functional] Liveness probe path (`/pressure` in v1) updated to v2 equivalent or replaced with `/`. → switched to `/` (unauthenticated; `/pressure` now requires the auth token in v2).
- [x] [functional] Service port still exposes 3000 to match the changedetection-io `PLAYWRIGHT_DRIVER_URL`. → unchanged.
- [ ] [edge-case] Post-deploy: trigger a changedetection-io watch on a JS-heavy site and confirm the diff renders correctly (browser pod logs show successful playwright sessions). → **maintainer post-merge**, see "Post-deploy check" below.
- [x] [security] The new browser pod's NetworkPolicy (`allow-changedetection-ingress`, `allow-external-egress`, `allow-dns`) is preserved unchanged. → byte-for-byte identical to the v1 file (plus `default-deny`, also preserved).
- [x] [security] The v2 `TOKEN` is stored in a SOPS-encrypted secret, not as plaintext in the helm-release.

## Post-deploy check (for maintainer)

After Flux reconciles:

```bash
# 1. Pods rolled cleanly
kubectl -n monitoring rollout status deployment/changedetection-browser
kubectl -n monitoring rollout status deployment/changedetection-io

# 2. Browser pod is listening and answering the auth-free root
kubectl -n monitoring port-forward svc/changedetection-browser 3001:3000 &
curl -sf -o /dev/null -w '%{http_code}\n' http://localhost:3001/   # expect 200
kill %1

# 3. Trigger a JS-heavy watch in the changedetection-io UI (or 'Recheck All')
# 4. Confirm browser pod logs show a successful playwright session
kubectl -n monitoring logs -l app.kubernetes.io/name=changedetection-browser --tail=200 | grep -iE 'playwright|connect|disconnect|error'
#    Expect: connect/disconnect lines, no "Forbidden" / "401" / "Unauthorized".
# 5. Confirm the watch's diff page renders the rendered DOM as expected.
```

## Validation done locally

- `flux-local test --all-namespaces --enable-helm --path kubernetes/cluster0/flux` → **101 passed** in 92s.
- `sops -d` on both new `secret.sops.yaml` files → round-trips to the expected plaintext.
- `helm template` of both HRs against `bjw-s/app-template:5.0.1` → confirms `TOKEN` / `envFrom` are wired through to the rendered Deployment, image tag + digest are present, liveness `path: /` is set, and all four NetworkPolicies are emitted.
