### PR TITLE
fix(changedetection-browser): probe /docs/ instead of / to stop ~3min restart loop

### DIFF
--- a/kubernetes/cluster0/apps/monitoring/changedetection-io/browser/helm-release.yaml
+++ b/kubernetes/cluster0/apps/monitoring/changedetection-io/browser/helm-release.yaml
@@ -54,11 +54,22 @@ spec:
                 custom: true
                 spec:
                   httpGet:
-                    # v1 used /pressure (unauthenticated). In v2 /pressure requires
-                    # the auth token, which a k8s httpGet probe cannot supply, so we
-                    # probe the unauthenticated static root instead — it returns 200
-                    # once the HTTP server is listening.
-                    path: /
+                    # v1 used /pressure (unauthenticated). In v2 most useful health
+                    # endpoints (/pressure, /metrics, /json/version) require the TOKEN
+                    # auth header, which a k8s httpGet probe cannot supply — and we
+                    # will not bake the token into a probe Exec because that risks
+                    # leaking it into kubelet event logs.
+                    #
+                    # GET / returns 404 on v2 ("No route or file found for resource
+                    # GET: /") — see issue #3037 for the restart-loop this caused.
+                    #
+                    # /docs/ is served by the built-in Swagger UI, requires no auth,
+                    # and returns 200 as soon as the HTTP server is listening (it is
+                    # static and does not depend on browser-subsystem warm-up, so it
+                    # stays 200 on an idle pod). Verified against v2.49.0 via
+                    # apiserver pods/proxy — see PR #3037 description for evidence.
+                    # Trailing slash matters: /docs returns 301 to /docs/.
+                    path: /docs/
                     port: 3000
                   initialDelaySeconds: 30
                   periodSeconds: 60


### PR DESCRIPTION
## Summary

Fixes the `changedetection-browser` ~3-minute restart loop in the `monitoring` namespace by switching the liveness probe from `httpGet /` (returns 404 on `ghcr.io/browserless/chromium:v2.49.0`) to `httpGet /docs/` (returns 200, no auth required).

Closes #3037

## Root cause recap

The v2 image's root handler returns `404 No route or file found for resource GET: /`. After 3 consecutive 404s, kubelet sent SIGTERM, the container exited cleanly (`Exit Code: 0, Reason: Completed`), and we got a "Completed-style" restart loop — `Running 1/1` between kills, so it slipped past the migration's validation.

The previous comment in the YAML claimed `/` "returns 200 once the HTTP server is listening" — that assumption is exactly what introduced the bug. The comment is now rewritten to document the actual constraint (auth-token requirement on the useful health endpoints) and the rationale for `/docs/`.

## Why `/docs/`

`/pressure`, `/metrics`, and `/json/version` all require the `TOKEN` header in v2, and a k8s `httpGet` probe cannot supply auth headers. `/docs/` is the built-in Swagger UI: unauthenticated, static, and returns 200 the moment the HTTP server is listening — it does not depend on browser-subsystem warm-up, so an idle pod still answers 200.

We deliberately do not implement this as an `exec` probe that echoes the token (would risk leaking it into kubelet event logs) or as a disable-auth env var (would weaken the v2 default).

The trailing slash matters: `/docs` returns 301 to `/docs/`.

## Verification — live evidence against `ghcr.io/browserless/chromium:v2.49.0`

Captured against a `Running` pod (`changedetection-browser-649687dcd5-9c8zt`) in the `monitoring` namespace via the apiserver `pods/proxy` endpoint, which routes through the same in-cluster network path the kubelet probe uses:

```
$ kubectl get --raw "/api/v1/namespaces/monitoring/pods/changedetection-browser-649687dcd5-9c8zt:3000/proxy/<path>"
```

| Path             | Status | Note |
| ---------------- | ------ | ---- |
| `/`              | **404 Not Found** | reproduces the bug |
| `/docs`          | 301 Moved Permanently | redirect to `/docs/` |
| `/docs/`         | **200 OK** (x3 consecutive on a Running pod) | chosen probe target |
| `/json/version`  | 401 Unauthorized | needs TOKEN |
| `/metrics`       | 401 Unauthorized | needs TOKEN |

The other two pods in the deployment returned 503 during the same window — that is the bug in progress (kubelet had just sent SIGTERM and the server was mid-shutdown), not a property of `/docs/`. Once this PR merges and the restart loop ends, all three pods will be steady-state Running and `/docs/` will return 200 on all of them.

## Probe tolerances (preserved)

```yaml
initialDelaySeconds: 30
periodSeconds: 60
timeoutSeconds: 10
failureThreshold: 3
```

`failureThreshold: 3` and `periodSeconds: 60` are unchanged — existing tolerances for transient slow responses are preserved, not tightened.

## Post-merge validation plan

After merge + Flux reconcile:

1. `kubectl get pods -n monitoring | grep changedetection-browser` — confirm restart count stops advancing.
2. Wait 15 minutes, re-check restart counts on all 3 pods.
3. `kubectl logs --previous` on a pod — confirm no `No route or file found for resource GET: /` from kubelet probes and no `SIGTERM received` clean-shutdown sequence.

## AC checklist

- [x] **functional** — probe target changed to a 200-returning endpoint against v2.49.0 (`/docs/`).
- [ ] **functional** — 15-min no-restart verification (post-merge, post-reconcile).
- [ ] **functional** — `--previous` logs clean of probe-induced 404s and SIGTERM (post-merge).
- [x] **functional** — PR description records the live HTTP status codes (table above).
- [x] **functional** — inline YAML comment rewritten to document auth-token constraint and rationale; misleading "it returns 200" claim removed.
- [x] **edge-case** — `/docs/` is static, served by Swagger UI, returns 200 on idle pods (no warm-up dependency).
- [x] **edge-case** — `failureThreshold: 3` and `periodSeconds: 60` preserved.
- [x] **security** — no token mounting into Exec, no auth disable; `/docs/` is unauthenticated by design.
- [ ] **functional** — `flux-local` PR checks pass (will verify on PR).
