### PR TITLE
fix(seaweedfs): disable Flux wait gate to unstick chart 4.28.0 upgrade

### DIFF
--- a/kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/helm-release.yaml
@@ -17,10 +17,12 @@ spec:
         namespace: seaweedfs
       interval: 5m
   install:
+    disableWait: true
     timeout: 15m
     remediation:
       retries: 3
   upgrade:
+    disableWait: true
     timeout: 15m
     cleanupOnFail: true
     remediation:
@@ -61,6 +63,7 @@ spec:
       s3:
         enabled: true
         enableAuth: true
+        existingConfigSecret: seaweedfs-s3-config
 
     s3:
       enabled: true


### PR DESCRIPTION
## Summary

Fix the `seaweedfs` HelmRelease upgrade so it can successfully roll from chart `4.25.1` → `4.28.0`. The chart version in git has been `4.28.0` for some time, but the cluster has been stuck on `4.25.1` after Flux auto-rolled back four times.

## Root cause

The `helm.sh/chart` label is on the pod template, so **every chart bump rolls all four workloads** (master/filer/volume StatefulSets + s3 Deployment). The same failure pattern has hit on every chart bump since `4.26.0` — verified by ReplicaSet image-tag history showing `4.26`, `4.27`, and `4.28` all rolled and reverted.

The s3 Deployment carries the chart's hardcoded `progressDeadlineSeconds: 600` (there is no chart values knob to override it). While master/filer/volume StatefulSets are still rolling on Longhorn-backed PVCs (>10 min), s3 cannot reach a healthy filer; kstatus flips the s3 Deployment to `Failed` via `ProgressDeadlineExceeded`; Flux's "fail early on stalled resources" gate aborts the upgrade and rolls back.

The **10-minute cadence in helm history** (`02:15 → 02:27 → 02:39 → 02:49`) is the smoking gun. StatefulSets don't have a `progressDeadlineSeconds` field so they can't trigger this — only the s3 Deployment can.

The chart diff `4.25.1 → 4.28.0` is otherwise a structural no-op for our values: the leftover `seaweedfs-s3-5d567b5cf5` ReplicaSet in the cluster is byte-for-byte identical to the running `4.25.1` ReplicaSet apart from the image tag (`chrislusf/seaweedfs:4.25` → `:4.28`) and the chart label.

## Changes

Two edits to `kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/helm-release.yaml`:

1. **The upgrade fix (Option A — coordinator-approved).** Add `disableWait: true` to `spec.install` and `spec.upgrade`. This tells Flux to skip the kstatus health-gate during install/upgrade. The chart's own readiness probes (s3 `/status:8333` with `failureThreshold: 100 × periodSeconds: 15`, etc.) continue to gate runtime health, and the Kustomization-level HelmRelease healthCheck still detects a permanently-broken release.

2. **Suppress the stale `seaweedfs-s3-secret` regeneration.** Set `filer.s3.existingConfigSecret: seaweedfs-s3-config`. The chart auto-generates `seaweedfs-s3-secret` (random `anvAdmin`/`anvReadOnly` identities) when `filer.s3.enableAuth=true` and no existing secret is named. Nothing mounts it (the s3 Deployment uses the `s3.existingConfigSecret: seaweedfs-s3-config` override). Setting `filer.s3.existingConfigSecret` to the same secret stops the chart re-creating the dead Secret on every upgrade.

## Out of scope

- Chart version remains `4.28.0` (no bump).
- No postRenderer patch (Option B was considered and rejected).
- The existing stale `seaweedfs-s3-secret` in the cluster is harmless and will not be regenerated after this PR — can be deleted manually post-merge if desired.

## Verification (post-merge)

```bash
flux reconcile helmrelease seaweedfs -n seaweedfs --force
kubectl -n seaweedfs get helmrelease seaweedfs -w
kubectl -n seaweedfs get pods -w
```

Expected:
- HelmRelease transitions `Stalled` → reconciling → `Ready=True` (no failure latch this time).
- s3 Deployment rolls; the new ReplicaSet pod (`chrislusf/seaweedfs:4.28` image) reaches Ready within ~5 min.
- master/filer/volume StatefulSets roll one at a time on their own readiness probes.
- `kubectl -n seaweedfs get helmrelease seaweedfs -o jsonpath='{.spec.chart.spec.version}'` returns `4.28.0`.
- Filer sanity: `kubectl -n seaweedfs exec seaweedfs-filer-0 -- /bin/sh -c 'wget -qO- http://localhost:8888/?stat=1 | head'` returns filer status without error.
