### PR TITLE
monitoring: move Prometheus TSDB to local-path, harden HA (anti-affinity, PDB, node-exporter)

### DIFF
--- a/kubernetes/cluster0/apps/monitoring/kube-prometheus-stack/app/cilium-network-policy.yaml
+++ b/kubernetes/cluster0/apps/monitoring/kube-prometheus-stack/app/cilium-network-policy.yaml
@@ -20,11 +20,13 @@ spec:
   egress:
     - toEntities:
         - kube-apiserver
-    - toEntities:           # host-networked scrape targets (Cilium agent/envoy/Hubble/operator/kubelet)
+    - toEntities:           # host-networked scrape targets (Cilium agent/envoy/Hubble/operator/kubelet/node-exporter)
         - host
         - remote-node
       toPorts:
         - ports:
+            - port: "9100"
+              protocol: TCP
             - port: "9962"
               protocol: TCP
             - port: "9963"

--- a/kubernetes/cluster0/apps/monitoring/kube-prometheus-stack/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/monitoring/kube-prometheus-stack/app/helm-release.yaml
@@ -82,9 +82,8 @@ spec:
         # Node recording rules (no alerts)
         node: true
         # Node exporter alerts (disk, memory, CPU, filesystem) - requires node-exporter
-        # node-exporter is disabled below; re-enable both together if you want host-level alerts
-        nodeExporterAlerting: false
-        nodeExporterRecording: false
+        nodeExporterAlerting: true
+        nodeExporterRecording: true
         # Prometheus self-monitoring
         prometheus: true
         # Prometheus Operator health
@@ -228,13 +227,27 @@ spec:
           - new-service-discovery-manager
         retention: 2d
         retentionSize: 15GB
+        # Pin each replica to a distinct node. With local-path storage the soft
+        # default anti-affinity is not enough: two replicas on the same node
+        # would lose the HA property entirely on node failure. "hard" makes the
+        # chart render a requiredDuringSchedulingIgnoredDuringExecution rule
+        # keyed on kubernetes.io/hostname with a selector matching both replicas
+        # (app.kubernetes.io/name=prometheus AND
+        #  app.kubernetes.io/instance=prometheus-kube-prometheus).
+        podAntiAffinity: hard
         storageSpec:
           volumeClaimTemplate:
             spec:
-              storageClassName: longhorn
+              storageClassName: local-path
               resources:
                 requests:
                   storage: 20Gi
+      # PDB for the Prometheus StatefulSet - keep at least one replica up during
+      # voluntary disruptions (node drains, etc.).
+      podDisruptionBudget:
+        enabled: true
+        maxUnavailable: 1
+        minAvailable: null
     grafana:
       enabled: false
       forceDeployDashboards: true
@@ -248,7 +261,5 @@ spec:
     kubeStateMetrics:
       enabled: true
     # node-exporter: exposes host-level metrics (CPU, memory, disk, filesystem).
-    # Disabled for now - re-enable alongside nodeExporterAlerting/nodeExporterRecording
-    # above if you want host-level alerting.
     nodeExporter:
-      enabled: false
+      enabled: true

--- a/kubernetes/cluster0/apps/monitoring/kube-prometheus-stack/app/network-policy.yaml
+++ b/kubernetes/cluster0/apps/monitoring/kube-prometheus-stack/app/network-policy.yaml
@@ -522,8 +522,8 @@ spec:
 ---
 # Allow Prometheus egress to host-networked scrape targets on the node CIDR (defence-in-depth).
 # Cilium agent (:9962), Cilium operator (:9963), Cilium envoy (:9964), Hubble (:9965),
-# kubelet/metrics-server (:10250) all run with hostNetwork=true; Cilium assigns them the
-# 'host'/'remote-node' entity identity, so podSelector rules don't match.
+# kubelet/metrics-server (:10250), node-exporter (:9100) all run with hostNetwork=true;
+# Cilium assigns them the 'host'/'remote-node' entity identity, so podSelector rules don't match.
 # The CiliumNetworkPolicy prometheus-allow-kube-apiserver (egress block 2) is authoritative;
 # this ipBlock rule is the standard-NetworkPolicy companion for defence-in-depth. See #2962.
 apiVersion: networking.k8s.io/v1
@@ -538,6 +538,8 @@ spec:
   policyTypes: [Egress]
   egress:
     - ports:
+        - port: 9100
+          protocol: TCP
         - port: 9962
           protocol: TCP
         - port: 9963
@@ -550,7 +552,7 @@ spec:
           protocol: TCP
       to:
         - ipBlock:
-            cidr: 10.87.42.0/24  # node CIDR — host-networked targets (Cilium/Hubble/kubelet)
+            cidr: 10.87.42.0/24  # node CIDR — host-networked targets (Cilium/Hubble/kubelet/node-exporter)
 ---
 # Allow Prometheus egress to scrape longhorn-system on :9500
 # ServiceMonitor longhorn-prometheus-servicemonitor targets app=longhorn-manager pods


### PR DESCRIPTION
Closes #3045.

## Summary

Four logical changes to `kubernetes/cluster0/apps/monitoring/kube-prometheus-stack/app/helm-release.yaml`:

1. **Prometheus TSDB storage class: `longhorn` → `local-path`.** Prometheus's 2-replica HA already provides redundancy at the application layer; Longhorn's synchronous replication was adding a WAL-corruption failure mode (observed on 2026-05-23 on replica `-1`) without adding availability beyond what the HA pair already gives us. The upstream recommendation for Prometheus TSDB is local volumes.

2. **Pod anti-affinity promoted from soft to hard.** With local storage, two replicas could in principle land on the same node, eliminating the HA property entirely on node failure. Implemented via the chart-native `prometheus.prometheusSpec.podAntiAffinity: hard` knob, which renders exactly the rule called out in the issue:
   ```yaml
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
       - topologyKey: kubernetes.io/hostname
         labelSelector:
           matchExpressions:
           - {key: app.kubernetes.io/name, operator: In, values: [prometheus]}
           - {key: app.kubernetes.io/instance, operator: In, values: [prometheus-kube-prometheus]}
   ```
   (Setting `affinity:` directly produces duplicate `podAntiAffinity:` keys in the rendered manifest because the chart unconditionally appends its default; using the dedicated knob avoids that.)

3. **PodDisruptionBudget for the Prometheus StatefulSet** with `maxUnavailable: 1`, via the chart-native `prometheus.podDisruptionBudget` option. Selector matches `app.kubernetes.io/name=prometheus` AND `operator.prometheus.io/name=prometheus-kube-prometheus`, both of which are present on both replica pods. Protects against drain storms that could otherwise evict both replicas concurrently.

4. **node-exporter re-enabled.** `defaultRules.rules.nodeExporterAlerting`, `defaultRules.rules.nodeExporterRecording`, and `nodeExporter.enabled` all flipped from `false` to `true`. Stale "disabled for now" comment blocks removed. Restores host-level metrics for queries like "did node0 reboot?" that previously required inferring from `process_start_time_seconds{job="kubelet"}`.

## Out of scope (deliberately)

- **Recreating the existing Prometheus PVCs.** `storageClassName` on a bound PVC is immutable; the operator will see the new template but existing PVCs stay on Longhorn. PVC recreation is a manual ops sequence (delete pod + PVC for `-1` first, let it recreate against `local-path`, verify, then `-0`) the repo owner will drive after merge.
- **Today's broken replica-1.** Will be addressed by that same post-merge PVC recreation.
- **The duplicate-default-storageclass condition** (`local-path` and `longhorn` both default). Separate concern.
- **Remote long-term storage** (Thanos / remote-write). Explicitly deferred.

## Verification

- `flux-local test --all-namespaces --enable-helm`: 100/100 pass.
- `flux-local diff helmrelease prometheus -n monitoring` (against `main`) shows exactly:
  - The Prometheus CR `storageClassName` flipping from `longhorn` to `local-path`.
  - The Prometheus CR anti-affinity flipping from `preferredDuringSchedulingIgnoredDuringExecution` to `requiredDuringSchedulingIgnoredDuringExecution` (same selector / topology key).
  - A new `PodDisruptionBudget/prometheus-kube-prometheus-prometheus` with `maxUnavailable: 1`.
  - The expected fan-out of new node-exporter resources (DaemonSet, Service, ServiceAccount, ServiceMonitor, two PrometheusRule groups, dashboard ConfigMaps).
- No other `storageClassName: longhorn` references in the file are changed (Alertmanager storage at line 122 deliberately preserved).
- No PVC manifests touched.
