### PR TITLE
monitoring: move Alertmanager storage to local-path + add PDB

### DIFF
--- a/kubernetes/cluster0/apps/monitoring/kube-prometheus-stack/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/monitoring/kube-prometheus-stack/app/helm-release.yaml
@@ -119,10 +119,19 @@ spec:
         storage:
           volumeClaimTemplate:
             spec:
-              storageClassName: longhorn
+              storageClassName: local-path
               resources:
                 requests:
                   storage: 1Gi
+      # PDB for the Alertmanager StatefulSet - keep at least one replica up
+      # during voluntary disruptions (node drains, etc.). Mirrors the
+      # Prometheus PDB added in #3046. Chart-native selector matches
+      # app.kubernetes.io/name=alertmanager AND alertmanager=prometheus-kube-prometheus,
+      # both of which are present on both replica pods.
+      podDisruptionBudget:
+        enabled: true
+        maxUnavailable: 1
+        minAvailable: null
       config:
         global:
           resolve_timeout: 5m


### PR DESCRIPTION
Closes #3047.

## Summary

Follow-up to #3046, which moved Prometheus TSDB to `local-path` and added a PDB + node-exporter. This PR applies the same shape to the Alertmanager pair, which #3046 deliberately left alone to keep that PR atomic.

Two logical changes to `kubernetes/cluster0/apps/monitoring/kube-prometheus-stack/app/helm-release.yaml`:

1. **Alertmanager storage class: `longhorn` → `local-path`.** The two AM replicas (`replicas: 2`) already exchange silences and notification-log entries via operator-managed gossip, so Longhorn's 3x volume replication was adding the same WAL-style "torn segment on ungraceful shutdown" failure mode that hit Prometheus on 2026-05-23 without adding availability beyond what the HA pair already gives us. The existing `podAntiAffinity: hard` makes the local-path move safe — the two replicas can never co-locate on the same node.

2. **PodDisruptionBudget for the Alertmanager StatefulSet** with `maxUnavailable: 1`, via the chart-native `alertmanager.podDisruptionBudget` knob (kube-prometheus-stack 85.2.2 exposes it, exactly analogous to `prometheus.podDisruptionBudget` used in #3046). The rendered selector matches `app.kubernetes.io/name=alertmanager` AND `alertmanager=prometheus-kube-prometheus`, both of which are present on both replica pods (verified with `kubectl -n monitoring get pods -l app.kubernetes.io/name=alertmanager --show-labels`). Protects against drain storms that could otherwise evict both replicas concurrently.

## Out of scope (deliberately)

- **Recreating the existing Alertmanager PVCs.** Same as #3046: `storageClassName` on a bound PVC is immutable; the operator will see the new template but existing PVCs stay on Longhorn. PVC recreation is a manual ops sequence the repo owner will drive after merge.
- **Other Longhorn-backed PVCs** (SeaweedFS, CNPG, etc.) — separate concerns.
- **Gossip / cluster peer wiring, replica count, anti-affinity, storage size** — all unchanged.

## Verification

- `flux-local test --all-namespaces --enable-helm`: 100/100 pass.
- `flux-local diff helmrelease prometheus -n monitoring` (against `main`) shows exactly:
  - The Alertmanager CR `storageClassName` flipping from `longhorn` to `local-path`.
  - A new `PodDisruptionBudget/prometheus-kube-prometheus-alertmanager` with `maxUnavailable: 1` and the chart's selector matching both replicas.
  - Nothing else.
- No other `storageClassName: longhorn` references in the file are changed.
- The Prometheus PDB added in #3046 is unchanged and not duplicated.
- No PVC manifests touched.
