### PR TITLE
monitoring: alert when Longhorn weekly + CNPG daily backups have not run recently

### DIFF
--- a/kubernetes/cluster0/apps/databases/cloudnative-pg/chart/kustomization.yaml
+++ b/kubernetes/cluster0/apps/databases/cloudnative-pg/chart/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./secret.yaml
   - ./network-policy.yaml
   - ./cilium-network-policy.yaml
+  - ./prometheusrule.yaml

--- a/kubernetes/cluster0/apps/databases/cloudnative-pg/chart/prometheusrule.yaml
+++ b/kubernetes/cluster0/apps/databases/cloudnative-pg/chart/prometheusrule.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: cloudnative-pg
+  namespace: databases
+spec:
+  groups:
+    - name: cnpg.backups
+      rules:
+        - alert: CNPGBackupMissed
+          expr: |
+            time() - min by (job) (cnpg_collector_last_available_backup_timestamp > 0) > (36 * 3600)
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "CNPG cluster {{ $labels.job }} has no recent successful backup"
+            description: "Most recent successful base backup for {{ $labels.job }} is {{ $value | humanizeDuration }} old. Daily scheduled backup may have failed."
+
+        - alert: CNPGBackupCritical
+          expr: |
+            time() - min by (job) (cnpg_collector_last_available_backup_timestamp > 0) > (72 * 3600)
+          for: 30m
+          labels:
+            severity: critical
+          annotations:
+            summary: "CNPG cluster {{ $labels.job }} has no successful backup in over 72 hours"
+            description: "Most recent successful base backup for {{ $labels.job }} is {{ $value | humanizeDuration }} old. At least three consecutive daily backups have been missed."

--- a/kubernetes/cluster0/apps/longhorn-system/longhorn/app/prometheusrule.yaml
+++ b/kubernetes/cluster0/apps/longhorn-system/longhorn/app/prometheusrule.yaml
@@ -77,3 +77,23 @@ spec:
           annotations:
             summary: "Longhorn backup {{ $labels.backup }} failed"
             description: "Backup {{ $labels.backup }} for volume {{ $labels.volume }} is in a failed state."
+
+        - alert: LonghornBackupMissed
+          expr: |
+            time() - max by (volume) (longhorn_volume_last_backup_at) > (9 * 24 * 3600)
+          for: 1h
+          labels:
+            severity: warning
+          annotations:
+            summary: "Longhorn volume {{ $labels.volume }} has not been backed up in over 9 days"
+            description: "Most recent successful backup for {{ $labels.volume }} is {{ $value | humanizeDuration }} old. The weekly Friday backup may have skipped."
+
+        - alert: LonghornBackupCritical
+          expr: |
+            time() - max by (volume) (longhorn_volume_last_backup_at) > (14 * 24 * 3600)
+          for: 1h
+          labels:
+            severity: critical
+          annotations:
+            summary: "Longhorn volume {{ $labels.volume }} has not been backed up in over 14 days"
+            description: "Most recent successful backup for {{ $labels.volume }} is {{ $value | humanizeDuration }} old. At least two consecutive weekly backups have been missed."


### PR DESCRIPTION
Closes #3049

## Summary

Adds absence-style PrometheusRule alerts that fire when a backup chain silently stops running. Triggered by the 2026-05-22 silent skip of the Longhorn weekly backup, which no existing alert caught.

### Longhorn weekly backups

Appended to the existing `longhorn.backups` group in `kubernetes/cluster0/apps/longhorn-system/longhorn/app/prometheusrule.yaml`:

- **`LonghornBackupMissed`** — `severity: warning`, `for: 1h`, fires when `time() - max by (volume) (longhorn_volume_last_backup_at) > 9d`.
- **`LonghornBackupCritical`** — `severity: critical`, `for: 1h`, threshold 14d.

### CNPG daily backups

New `PrometheusRule` `cloudnative-pg` (namespace `databases`) in `kubernetes/cluster0/apps/databases/cloudnative-pg/chart/prometheusrule.yaml`:

- **`CNPGBackupMissed`** — `severity: warning`, `for: 30m`, fires when `time() - min by (job) (cnpg_collector_last_available_backup_timestamp > 0) > 36h`.
- **`CNPGBackupCritical`** — `severity: critical`, `for: 30m`, threshold 72h.

The `> 0` series filter excludes standby pods (which report `0` for this metric); aggregating with `min by (job)` gives one alert series per cluster.

## File-layout choice

**Option A** from the issue (preferred). The Longhorn alerts are co-located with the existing Longhorn PrometheusRule, and the new CNPG PrometheusRule lives alongside the operator's chart kustomization at `kubernetes/cluster0/apps/databases/cloudnative-pg/chart/`. Option A keeps each alert next to the system it monitors and matches the existing repo pattern (sibling: blackbox-exporter has its own PrometheusRule co-located with its app).

The CNPG operator's chart kustomization is the natural home because the per-cluster Cluster/ScheduledBackup specs live scattered across `apps/auth`, `apps/home`, `apps/media` — there is no single per-cluster directory that would own a cross-cluster alert. The `cluster/` sibling directory is commented out and unused.

Neither rule carries explicit selector labels — the cluster's Prometheus runs with `ruleSelectorNilUsesHelmValues: false`, which means any `PrometheusRule` is picked up regardless of labels (the existing Longhorn rule and blackbox-exporter rule both rely on this).

## Query validation against live Prometheus

Port-forwarded `prometheus-kube-prometheus-prometheus` and ran the three checks from the issue:

**1. Longhorn missed-backup query returns results today (the silent-skip the alert is designed to catch):**

```
$ curl -sG --data-urlencode 'query=time() - max by (volume) (longhorn_volume_last_backup_at) > (9 * 24 * 3600)' http://localhost:9090/api/v1/query | jq '.data.result | length'
28
```

28 volumes, each returning ~802000s (~9.3 days). Every backed-up volume crosses the 9-day threshold today, so `LonghornBackupMissed` would have fired on the silent skip. ✓

**2. CNPG `> 0` filter returns only primaries (no standbys):**

```
$ curl -sG --data-urlencode 'query=cnpg_collector_last_available_backup_timestamp > 0' http://localhost:9090/api/v1/query | jq '.data.result | length'
3
```

Exactly 3 series — one primary per cluster (`databases/home-assistant-postgres-v18`, `databases/authelia-postgres-v17`, `databases/miniflux-postgres-v17`). ✓

**3. Aggregated CNPG query produces 3 cluster-scoped values, all well under 36h:**

```
$ curl -sG --data-urlencode 'query=time() - min by (job) (cnpg_collector_last_available_backup_timestamp > 0)' http://localhost:9090/api/v1/query | jq '.data.result'
[
  { "metric": {"job": "databases/home-assistant-postgres-v18"}, "value": [..., "79005"] },
  { "metric": {"job": "databases/authelia-postgres-v17"},        "value": [..., "79165"] },
  { "metric": {"job": "databases/miniflux-postgres-v17"},        "value": [..., "79172"] }
]
```

~79000s ≈ 22h. CNPG alerts correctly silent under healthy conditions. ✓

## flux-local

`flux-local test --all-namespaces --enable-helm`: **99 pass, 1 fail**. The single failure is `cluster-apps-cilium` — a pre-existing helm-template error (`The cluster name is invalid: must consist of lower case alphanumeric characters and '-' ...`) that **reproduces on `main` without these changes**. Likely root cause: flux-local does not resolve the postBuild substitution for `flux-system/cluster: cluster-settings` (it logs `Unable to find SubstituteReference` for that var), leaving an unsubstituted placeholder that the cilium chart's validator rejects. Out of scope for this PR; the coordinator is tracking it separately.

The two kustomizations touched by this change (`cluster-apps-longhorn` and `cluster-apps-cloudnative-pg`) are among the 99 passing — i.e. these changes do not introduce a new failure.

## Scope guardrails honoured

- No existing alert rules modified — pure appends to the existing Longhorn group and a brand-new CNPG resource.
- No changes to backup configuration (recurring jobs, scheduled-backups, retention, targets, barman config).
- No change to `cnpg_collector_last_available_backup_timestamp` scraping or the CNPG PodMonitor setting.

`git diff origin/main --stat`:

```
 .../cloudnative-pg/chart/kustomization.yaml        |  1 +
 .../cloudnative-pg/chart/prometheusrule.yaml       | 30 ++++++++++++++++++++++
 .../longhorn/app/prometheusrule.yaml               | 20 +++++++++++++++
 3 files changed, 51 insertions(+)
```
