### PR TITLE
monitoring: add SeaweedFS scrape coverage + alerts

### DIFF
--- a/kubernetes/cluster0/apps/monitoring/kube-prometheus-stack/app/network-policy.yaml
+++ b/kubernetes/cluster0/apps/monitoring/kube-prometheus-stack/app/network-policy.yaml
@@ -578,6 +578,54 @@ spec:
             matchLabels:
               app: longhorn-manager
 ---
+# Allow Prometheus egress to scrape seaweedfs master/volume/filer/s3 on :9327
+# Chart-native ServiceMonitors (global.seaweedfs.monitoring.enabled=true) target
+# the "metrics" port on each component Service. Pod labels:
+# app.kubernetes.io/name=seaweedfs + app.kubernetes.io/component={master,volume,filer,s3}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: prometheus-allow-seaweedfs-scrape-egress
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 9327
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: seaweedfs
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: seaweedfs
+              app.kubernetes.io/component: master
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: seaweedfs
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: seaweedfs
+              app.kubernetes.io/component: volume
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: seaweedfs
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: seaweedfs
+              app.kubernetes.io/component: filer
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: seaweedfs
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: seaweedfs
+              app.kubernetes.io/component: s3
+---
 # Allow Prometheus egress to blackbox-exporter on :9115 (Probe CRD prober URL)
 # When Prometheus processes a Probe resource it makes an outbound HTTP request to
 # blackbox-exporter's prober endpoint (blackbox-exporter.monitoring.svc:9115).

--- a/kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/helm-release.yaml
@@ -31,6 +31,10 @@ spec:
     global:
       seaweedfs:
         enableSecurity: false
+        # Render chart-native ServiceMonitors for master/volume/filer/s3 so
+        # kube-prometheus-stack scrapes the :9327 /metrics endpoints. See #3051.
+        monitoring:
+          enabled: true
 
     master:
       replicas: 1

--- a/kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/kustomization.yaml
+++ b/kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - s3-config.sops.yaml
   - secret.sops.yaml
   - network-policy.yaml
+  - prometheusrule.yaml

--- a/kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/network-policy.yaml
+++ b/kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/network-policy.yaml
@@ -45,6 +45,31 @@ spec:
             matchLabels:
               kubernetes.io/metadata.name: kube-system
 ---
+# Allow Prometheus to scrape master metrics on :9327
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: seaweedfs-master-allow-prometheus-scrape
+  namespace: seaweedfs
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: seaweedfs
+      app.kubernetes.io/component: master
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+      ports:
+        - port: 9327
+          protocol: TCP
+---
 # Allow intra-ns ingress from volume/filer/s3/master on :9333/:19333
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -146,6 +171,31 @@ spec:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: kube-system
+---
+# Allow Prometheus to scrape volume metrics on :9327
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: seaweedfs-volume-allow-prometheus-scrape
+  namespace: seaweedfs
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: seaweedfs
+      app.kubernetes.io/component: volume
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+      ports:
+        - port: 9327
+          protocol: TCP
 ---
 # Allow intra-ns ingress from master/filer/s3/volume pods on :8080/:18080
 apiVersion: networking.k8s.io/v1
@@ -339,6 +389,31 @@ spec:
             matchLabels:
               kubernetes.io/metadata.name: kube-system
 ---
+# Allow Prometheus to scrape filer metrics on :9327
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: seaweedfs-filer-allow-prometheus-scrape
+  namespace: seaweedfs
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: seaweedfs
+      app.kubernetes.io/component: filer
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+      ports:
+        - port: 9327
+          protocol: TCP
+---
 # Allow intra-ns ingress from master/volume/s3/filer on :8888/:18888
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -521,6 +596,31 @@ spec:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: kube-system
+---
+# Allow Prometheus to scrape s3 metrics on :9327
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: seaweedfs-s3-allow-prometheus-scrape
+  namespace: seaweedfs
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: seaweedfs
+      app.kubernetes.io/component: s3
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+      ports:
+        - port: 9327
+          protocol: TCP
 ---
 # Allow ingress from databases CNPG cluster pods on :8333 (WAL archiving)
 apiVersion: networking.k8s.io/v1

--- a/kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/prometheusrule.yaml
+++ b/kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/prometheusrule.yaml
@@ -1,0 +1,56 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: seaweedfs
+  namespace: seaweedfs
+spec:
+  groups:
+    - name: seaweedfs.components
+      rules:
+        - alert: SeaweedFSComponentDown
+          expr: up{namespace="seaweedfs"} == 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "SeaweedFS component {{ $labels.job }} is down"
+            description: "SeaweedFS target {{ $labels.job }} ({{ $labels.pod }}) has been unreachable for more than 5 minutes. CNPG backups via SeaweedFS S3 may be affected."
+
+    - name: seaweedfs.volume
+      rules:
+        # Triggers when a volume server's currently-allocated volumes consume
+        # more than 90% of its configured max_volume_count.
+        - alert: SeaweedFSVolumeServerSpaceCritical
+          expr: |
+            (
+              SeaweedFS_volumeServer_volumes
+              /
+              SeaweedFS_volumeServer_max_volume_count
+            ) > 0.90
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: "SeaweedFS volume server {{ $labels.instance }} is over 90% full"
+            description: "Volume server {{ $labels.instance }} is using {{ $value | humanizePercentage }} of its max_volume_count. New writes will start failing once it reaches 1.0."
+
+    - name: seaweedfs.s3
+      rules:
+        # Triggers when more than 5% of S3 requests over a 15m window return a
+        # non-2xx status code (4xx/5xx). Metric is a counter of
+        # request_count partitioned by status code.
+        - alert: SeaweedFSS3RequestErrorsHigh
+          expr: |
+            (
+              sum(rate(SeaweedFS_s3_request_count{code!~"2.."}[15m]))
+              /
+              sum(rate(SeaweedFS_s3_request_count[15m]))
+            ) > 0.05
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "SeaweedFS S3 non-2xx response rate above 5%"
+            description: "{{ $value | humanizePercentage }} of S3 requests over the last 15 minutes returned a non-2xx status. CNPG backup uploads may be failing."


### PR DESCRIPTION
Closes #3051

## Summary

SeaweedFS was invisible to Prometheus — no ServiceMonitors in the
`seaweedfs` namespace, and the namespace's default-deny NetworkPolicies
blocked cross-namespace ingress to `:9327` anyway. This PR is a
strictly-additive change that turns on scrape coverage and adds the
first alerts.

Three logical changes, all under
`kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/`:

### 1. ServiceMonitors via chart-native flag (`helm-release.yaml`)

Enabled `global.seaweedfs.monitoring.enabled: true`. The upstream
seaweedfs chart (v4.28.0) already ships per-component ServiceMonitors
gated on that single flag, with sane defaults:
- `name: seaweedfs-{master,volume,filer,s3}`, namespace `seaweedfs`
- `port: metrics` (the chart's existing `:9327` Service port)
- selector matches the existing `app.kubernetes.io/component=...` labels
- `interval: 30s`, `scrapeTimeout: 5s`
- no `gatewayHost` / push-gateway behaviour triggered (that's a
  separate `global.seaweedfs.monitoring.gatewayHost` field, left null)

`kube-prometheus-stack` is configured with
`serviceMonitorSelectorNilUsesHelmValues: false`, so the chart's
unlabelled ServiceMonitors are picked up automatically. Verified by
running `helm template` against our exact `values:` block — four clean
ServiceMonitors are produced (master/volume/filer/s3), each selecting
only its own component's pods.

### 2. NetworkPolicy allow-prometheus-scrape rules (`network-policy.yaml`)

Added one new ingress NetworkPolicy per component
(`seaweedfs-{master,volume,filer,s3}-allow-prometheus-scrape`),
mirroring exactly the cnpg `cloudnative-pg-allow-prometheus-scrape`
pattern from `apps/databases/cloudnative-pg/chart/network-policy.yaml`.

Each rule:
- selects only its own component's pods
- allows ingress from `namespace=monitoring`,
  `app.kubernetes.io/name=prometheus`
- on `:9327/TCP` only

**No existing NetworkPolicy is modified or removed** — no default-deny
rule, no intra-namespace rule, no DNS-egress rule is touched. The
diff for `network-policy.yaml` is purely insertions of the four new
documents.

### 3. PrometheusRule (`prometheusrule.yaml`, new file)

Three alerts:

| Alert | Severity | for | Source metric |
|---|---|---|---|
| `SeaweedFSComponentDown` | warning | 5m | `up{namespace="seaweedfs"}` |
| `SeaweedFSVolumeServerSpaceCritical` | critical | 10m | `SeaweedFS_volumeServer_volumes / SeaweedFS_volumeServer_max_volume_count > 0.90` |
| `SeaweedFSS3RequestErrorsHigh` | warning | 15m | `sum(rate(SeaweedFS_s3_request_count{code!~"2.."}[15m])) / sum(rate(SeaweedFS_s3_request_count[15m])) > 0.05` |

`SeaweedFSComponentDown` depends only on the `up` metric and is safe
unconditionally.

The two optional alerts use the metric names documented by upstream
SeaweedFS (`SeaweedFS_volumeServer_*`, `SeaweedFS_s3_request_count`).
If those names don't match what the running pods actually emit, the
expressions should be adjusted or the rule dropped in a follow-up — see
"Live-Prometheus verification" below for why this PR can't confirm
them itself.

The kustomization is wired up via a one-line addition to
`kustomization.yaml`.

## Static verification

`flux-local test --all-namespaces --enable-helm` (run on this branch):

```
=========================== short test summary info ============================
FAILED .::cluster-apps-cilium::kube-system/cilium - flux_local.exceptions.Hel...
======================== 1 failed, 99 passed in 30.19s =========================
```

The single failure is the pre-existing `cluster-apps-cilium`
`${CLUSTER_NAME}` substitution failure tracked separately in #3053 —
reproduces on `main` without my changes. The four new SeaweedFS
kustomizations are among the 99 passes.

`kustomize build --enable-helm` on the seaweedfs app directory renders
clean and includes the new resources:

```
kind: PrometheusRule       name: seaweedfs
kind: NetworkPolicy        name: seaweedfs-master-allow-prometheus-scrape
kind: NetworkPolicy        name: seaweedfs-volume-allow-prometheus-scrape
kind: NetworkPolicy        name: seaweedfs-filer-allow-prometheus-scrape
kind: NetworkPolicy        name: seaweedfs-s3-allow-prometheus-scrape
```

`helm template` of the seaweedfs chart against the modified `values:`
block produces exactly four ServiceMonitors
(`seaweedfs-{master,volume,filer,s3}`), each with `port: metrics` and a
component-scoped selector. Confirmed no `gatewayHost` push-gateway side
effect on the master statefulset.

## Live-Prometheus verification — deferred

The issue's verification flow (steps 3–5) calls for live Prometheus
queries (`up{namespace="seaweedfs"}`, `count by (job) ({namespace="seaweedfs"})`,
and `{__name__=~"SeaweedFS_.*"}`) after Flux reconciles the change.
This PR's author (an agent operating with
`system:serviceaccount:kube-system:agents-readonly` cluster credentials)
cannot perform those queries pre-merge — the credentials lack both
write-access to apply the manifests onto the cluster ahead of Flux
picking them up, and `pods/portforward` access to reach Prometheus
or the SeaweedFS pods directly. The two optional alerts' metric names
should be re-checked against live output once this lands; if either
name doesn't match what the pods actually expose, drop or rewrite the
alert in a follow-up.

`SeaweedFSComponentDown` is unconditionally safe (depends only on
`up`) and satisfies the required-alert AC on its own.

## Scope guardrails

- No change to `defaultReplication`, any `replicas`, any `dataDirs`,
  storageClass, or PVC size. The HR diff is exactly the four added
  lines for `global.seaweedfs.monitoring.enabled: true` plus a
  comment.
- No existing NetworkPolicy modified, only four new ones added.
- No other PrometheusRule touched.
- No chart version change, no Grafana dashboard, no replication work
  (that's #3052, separate PR).
