### PR TITLE
tooling: fix flux-local cluster-settings postBuild substitution for cilium

### DIFF
--- a/kubernetes/cluster0/apps/kube-system/cilium/ks.yaml
+++ b/kubernetes/cluster0/apps/kube-system/cilium/ks.yaml
@@ -20,6 +20,19 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 5m
+  # postBuild.substituteFrom is also injected by the parent `cluster-apps`
+  # Kustomization's patch (see kubernetes/cluster0/flux/apps.yaml). Declaring it
+  # explicitly here is a no-op at runtime (strategic-merge of identical content)
+  # but lets `flux-local test` discover the substitution: flux-local enumerates
+  # ks.yaml files directly via `kustomize cfg grep` and does not apply the
+  # parent's patches, so without this block ${CLUSTER_NAME} is left as a literal
+  # and the cilium chart's name validator fails locally. See issue #3053.
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: cluster-settings
+      - kind: Secret
+        name: cluster-secrets
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1


### PR DESCRIPTION
## Summary

`flux-local test --all-namespaces --enable-helm` on `origin/main` reports 99
pass / 1 fail, with the cilium HelmRelease failing the chart's `cluster.name`
validator because the literal string `${CLUSTER_NAME}` reached `helm template`
unsubstituted. The live cluster is unaffected — Flux performs the
`postBuild.substituteFrom` correctly in production. This PR restores the
signal-to-noise of `flux-local test` so worker agents can use it as a clean
pre-flight check.

Closes #3053.

## Root cause

flux-local enumerates Flux `Kustomization` resources by running
`kustomize cfg grep 'kind=^(Kustomization|ConfigMap|Secret)$'` recursively
from the repo root. This walks the raw `ks.yaml` files on disk; it does **not**
shell out to `flux build` on the parent `cluster-apps` Kustomization and so it
does **not** apply the strategic-merge patch defined in
`kubernetes/cluster0/flux/apps.yaml`:

```yaml
- patch: |-
    apiVersion: kustomize.toolkit.fluxcd.io/v1
    kind: Kustomization
    metadata:
      name: not-used
    spec:
      postBuild:
        substituteFrom:
          - kind: ConfigMap
            name: cluster-settings
          - kind: Secret
            name: cluster-secrets
  target:
    group: kustomize.toolkit.fluxcd.io
    kind: Kustomization
    labelSelector: substitution.flux.home.arpa/disabled notin (true)
```

That patch is what gives every child `Kustomization` its `postBuild.substituteFrom`
block in production. Because flux-local skips it, every child ks.yaml looks
to flux-local as if it has no substitution configured at all. The cilium ks
is the only one where this is visibly fatal because cilium's chart strictly
validates `cluster.name`; other charts happily template the literal
`${VAR}` placeholder.

You can confirm this against `flux-local --log-level DEBUG test ...` on
`main`: only `flux-system/cluster` and `flux-system/cluster-apps`
(the two Kustomizations whose own ks.yaml declares `postBuild.substituteFrom`
directly) ever emit `update_postbuild_substitutions={...}` lines. No child
Kustomization does.

## Approach chosen — Option 2 (kustomization layout)

Of the three options proposed in #3053:

1. **CLI flag / config file** — investigated. `flux-local test --help`,
   `flux-local build hr --help`, and `flux-local diagnostics --help` were all
   checked against the installed version (0.13.x). No `--var-file`,
   `--substitute-from-file`, repo-root config file, or equivalent surface
   exists. **Not viable.**
2. **Adjust the kustomization layout so flux-local can discover the
   `cluster-settings` ConfigMap automatically.** This is the option taken. See
   below for why it's a no-op at runtime.
3. **Wrapper script + AGENTS.md.** Considered, rejected — would bake in tech
   debt and force every worker to learn a new invocation.

### The change

Add an explicit `postBuild.substituteFrom` block to the `cluster-apps-cilium`
Kustomization in `kubernetes/cluster0/apps/kube-system/cilium/ks.yaml`,
declaring the same `ConfigMap/cluster-settings` and `Secret/cluster-secrets`
references that the parent `cluster-apps` patch already injects.

### Why this is safe (no runtime change)

The parent patch is a strategic-merge of identical fields. Adding the same
block explicitly on the child is idempotent — strategic-merge of `{A: x}`
into a doc that already contains `{A: x}` is `{A: x}`. Verified empirically:

```
$ flux build ks cluster-apps --dry-run --kustomization-file <apps.yaml-spec> \
      --path kubernetes/cluster0/apps > before.yaml      # on main
$ flux build ks cluster-apps --dry-run --kustomization-file <apps.yaml-spec> \
      --path kubernetes/cluster0/apps > after.yaml       # on this branch
$ diff before.yaml after.yaml
# (empty)
```

The rendered output that Flux applies to the live cluster is byte-identical.

### Why this is targeted (just cilium)

Per the spec's scope guardrail "Do NOT change the Flux postBuild substitution
pattern used by other helm-releases", I deliberately did not touch the other
~50 `ks.yaml` files even though they're in the same boat technically. They're
silently fine because their charts don't validate the placeholder strings.
Adding `postBuild.substituteFrom` to all of them would be a large invasive
change for zero benefit. If a future helm-release surfaces the same validator
problem, it can be addressed the same way, one file at a time.

## Verification

### Before (main)

```
============================= test session starts ==============================
collected 100 items

. ...................................................................... [ 70%]
.............................F                                           [100%]

=========================== short test summary info ============================
FAILED .::cluster-apps-cilium::kube-system/cilium - flux_local.exceptions.Hel...
======================== 1 failed, 99 passed in 32.26s =========================
```

Failure detail:

```
flux_local.exceptions.HelmException: Command 'helm template cilium ...' failed with return code 1
Error: execution error at (cilium/templates/validate.yaml:159:5): The cluster
  name is invalid: must consist of lower case alphanumeric characters and '-',
  and must start and end with an alphanumeric character
```

### After (this branch)

```
============================= test session starts ==============================
collected 100 items

. ...................................................................... [ 70%]
..............................                                           [100%]

============================= 100 passed in 28.46s =============================
```

### Rendered cilium chart now has the real cluster name

```
$ flux-local build hr cilium --namespace kube-system | grep cluster-name
  cluster-name: "home-ops-cluster0"
  config.yaml: "cluster-name: home-ops-cluster0\n..."
```

Not `${CLUSTER_NAME}`. ✅

### "Unable to find SubstituteReference" log line

In default and `-v` output it does not appear. At `--log-level DEBUG` flux-local
still emits transient `Unable to find SubstituteReference` warnings during its
first traversal pass (before it has populated its in-memory ConfigMap store),
then succeeds on the second pass — that's pre-existing behaviour for `cluster`
and `cluster-apps` on main, and now applies to `cluster-apps-cilium` too. The
substitution succeeds, the test passes, and the warning is invisible at
ordinary log levels.

## Acceptance criteria

- [x] `flux-local test --all-namespaces --enable-helm` returns 100/100 pass
- [x] Cilium renders with `cluster-name: "home-ops-cluster0"`, not a literal
- [x] No "Unable to find SubstituteReference" line in default flux-local output
- [x] No regressions — diff of `flux build ks cluster-apps --dry-run` before vs
      after is empty; full test suite goes from 99 → 100 passing with no
      previously-passing entries dropping
- [x] No wrapper added; AGENTS.md unchanged (workers keep the existing
      single-invocation verification step)
- [x] No live cluster behaviour change — same rendered manifests
- [x] PR references the issue with `Closes #3053` and documents the chosen
      option

## Files changed

- `kubernetes/cluster0/apps/kube-system/cilium/ks.yaml` — add explicit
  `postBuild.substituteFrom` with an inline comment explaining the parent-patch
  duplication and pointing at this issue.
