### PR TITLE
seaweedfs: enable volume-server replication (defaultReplication 000 -> 001)

### DIFF
--- a/kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/helm-release.yaml
@@ -31,6 +31,16 @@ spec:
     global:
       seaweedfs:
         enableSecurity: false
+        # Enable volume-server replication at the SW layer. `enableReplication`
+        # gates whether `replicationPlacement` is applied; at chart v4.28.0 the
+        # master/filer statefulset templates only pass -defaultReplication=<...>
+        # from the global value when this flag is true (otherwise they fall back
+        # to master.defaultReplication, which defaults to "000"). See #3052.
+        # `001` = one extra copy on a different volume server (same DC, same
+        # rack — we have no DC/rack topology). Satisfiable with the existing
+        # 2 volume servers.
+        enableReplication: true
+        replicationPlacement: "001"
         # Render chart-native ServiceMonitors for master/volume/filer/s3 so
         # kube-prometheus-stack scrapes the :9327 /metrics endpoints. See #3051.
         monitoring:


### PR DESCRIPTION
## What

Flip SeaweedFS from zero SW-layer replication (`defaultReplication=000`) to one extra copy on a different volume server (`defaultReplication=001`).

Single-file change to `kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/helm-release.yaml`:

```yaml
global:
  seaweedfs:
    enableReplication: true
    replicationPlacement: "001"
```

## Why both keys?

I checked the chart at the pinned version (`seaweedfs/seaweedfs` v4.28.0) — both keys are required. From `templates/master/master-statefulset.yaml`:

```yaml
{{- if .Values.global.seaweedfs.enableReplication }}
-defaultReplication={{ .Values.global.seaweedfs.replicationPlacement }} \
{{- else }}
-defaultReplication={{ .Values.master.defaultReplication }} \
{{- end }}
```

Without `enableReplication: true`, the chart falls back to `master.defaultReplication` (defaults to `"000"`) and ignores `replicationPlacement` entirely. The same gate exists in `templates/filer/filer-statefulset.yaml` for `-defaultReplicaPlacement`.

## Why `001` (and not `100` / `010`)?

`defaultReplication=XYZ` in SeaweedFS means:

- X = replicas in *other DCs* → we have 1 DC, must be 0
- Y = replicas in *other racks* → we have no rack topology, must be 0
- Z = replicas on *other volume servers in the same rack* → this is the lever

`001` is satisfiable with the existing 2 volume servers, so `volume.replicas` stays at 2.

## Rendered effect

`helm template` of the seaweedfs chart at v4.28.0 with the new values renders:

```
-defaultReplication=001 \      # seaweedfs-master command
-defaultReplicaPlacement=001 \ # seaweedfs-filer command
```

(Pre-change, both render as `=000`.)

Once Flux reconciles, this is verifiable in-cluster:

```bash
kubectl -n seaweedfs get sts seaweedfs-master \
  -o jsonpath='{.spec.template.spec.containers[0].command}' \
  | tr ',' '\n' | grep replication
# expected: "-defaultReplication=001"
```

## Storage impact

SW-layer replication doubles the *logical* SW data footprint (each byte stored on two volume servers instead of one). PVC sizes are **not** changed.

| | Before | After (post-rebalance) |
|---|---|---|
| Volume-server PVC size | 50Gi × 2 | 50Gi × 2 (unchanged) |
| Longhorn replicas per PVC | 3 | 3 (unchanged) |
| Physical storage allocated | ~300Gi | ~300Gi |
| Actual SW-layer data used | ~30Gi | ~60Gi |

The PVCs have plenty of headroom; no resize is needed for this change.

## Post-merge manual ops step (NOT done by this PR)

Existing volumes were written under the `000` policy. SeaweedFS only enforces a new policy on *newly-written* volumes — existing data must be explicitly rebalanced. After this PR merges and Flux reconciles, the repo owner runs the SW shell rebalance:

```bash
kubectl -n seaweedfs exec -it seaweedfs-master-0 -- /bin/sh -c \
  'echo "lock
volume.fix.replication
unlock" | weed shell'
```

(SW shell expects each command on its own line; the `;`-separated form works on some weed versions but is brittle across releases — newlines are the safe form.)

`volume.fix.replication` walks every volume, finds ones with fewer copies than the policy requires, and provisions the missing copies on other volume servers. This is a read-mostly operation but will roughly double SW-layer storage usage as it runs.

**This PR does not run that command.** Per the issue, it's a manual step.

## Verification

- [x] Chart values inspected at v4.28.0 (`helm pull seaweedfs/seaweedfs --version 4.28.0 --untar`) — confirmed `enableReplication` gates `replicationPlacement` in both the master and filer statefulset templates.
- [x] `helm template` of the chart with these values renders `-defaultReplication=001` on the master and `-defaultReplicaPlacement=001` on the filer (quoted above).
- [x] `flux-local test --all-namespaces --enable-helm` passes — 99 passed, 1 pre-existing cilium failure (cluster-name validation; tracked in #3053) unrelated to this change.

## Scope guardrails (all held)

- `volume.replicas: 2` unchanged
- `volume.dataDirs[*].size` / `storageClass` unchanged
- `master`, `filer`, `s3` sections unchanged
- No `kubectl exec` / `weed shell` / `volume.fix.replication` invoked
- ServiceMonitor / NetworkPolicy / PrometheusRule untouched (those live in #3054 / #3056)

Closes #3052
