### PR TITLE
tooling: migrate actions/create-github-app-token from app-id to client-id

### DIFF
--- a/.github/workflows/flux-local.yaml
+++ b/.github/workflows/flux-local.yaml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ secrets.BOT_APP_ID }}
+          client-id: ${{ secrets.BOT_APP_CLIENT_ID }}
           private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
 
       - name: Checkout
@@ -77,7 +77,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ secrets.BOT_APP_ID }}
+          client-id: ${{ secrets.BOT_APP_CLIENT_ID }}
           private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
 
       - name: Checkout Pull Request Branch

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ secrets.BOT_APP_ID }}
+          client-id: ${{ secrets.BOT_APP_CLIENT_ID }}
           private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
 
       - name: Labeler

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ secrets.BOT_APP_ID }}
+          client-id: ${{ secrets.BOT_APP_CLIENT_ID }}
           private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
 
       - name: Checkout


### PR DESCRIPTION
## Summary

Migrate every `actions/create-github-app-token` invocation from the deprecated `app-id:` input to `client-id:` (per the action's v3 docs). Removes the `##[warning]Input 'app-id' has been deprecated with message: Use 'client-id' instead.` line from every workflow job that mints a token.

Four invocations migrated:

- `.github/workflows/flux-local.yaml` — `test` job
- `.github/workflows/flux-local.yaml` — `diff` matrix job (one step, runs per `resource` value)
- `.github/workflows/labeler.yaml`
- `.github/workflows/renovate.yaml`

The new secret `BOT_APP_CLIENT_ID` was added to repo secrets by the owner (the GitHub App's Client ID — `Iv23li…` — which is **not** the same value as the numeric App ID). The old `BOT_APP_ID` secret is intentionally left in place for now; cleanup can happen separately if desired.

## Scope guardrails (verified)

- ✅ Action version pin (`@bcd2ba49218906704ab6c1aa796996da409d3eb1` / v3.2.0) **unchanged**.
- ✅ `private-key:` input **unchanged**.
- ✅ No other inputs to `actions/create-github-app-token` added or changed.
- ✅ No other action's version or inputs changed.
- ✅ No kubernetes manifests touched — workflow-only PR.
- ✅ `grep -rn 'app-id\|BOT_APP_ID' .github/workflows/` returns nothing.

## Step 1 — fresh CI on PR #3044 (investigation)

The originating issue noted one failed run of `Flux Local - Diff (helmrelease)` on PR #3044 ([failed job](https://github.com/prismatic-koi/home-ops/actions/runs/26327423775/job/77507541611)) and asked me to determine whether the failure was consistent with the deprecated `app-id` path or transient.

I pushed an empty commit on the renovate branch (`prismatic-bot/ghcr.io-searxng-searxng-2026.x`, commit `28fff02`) to trigger a fresh CI run.

**Outcome: transient.** All 5 Flux Local jobs (including `Diff (helmrelease)`) passed cleanly on the fresh run ([run 26346431330](https://github.com/prismatic-koi/home-ops/actions/runs/26346431330)).

So: this PR **removes the deprecation warning** (the change that's certain). It **does not** fix the original failure, because that failure was not reproducible — it was a transient HTTPS-edge blip rather than a consistent symptom of the deprecated `app-id` path. The deprecation cleanup is worth doing on its own merits (the warning is real, it appears on every run, and eventually `app-id` will become a hard error).

## Step 4 — before/after of `Generate Token`

**Before** (from [run 26346431330, `Flux Local - Diff (helmrelease)`, `Generate Token` step](https://github.com/prismatic-koi/home-ops/actions/runs/26346431330) — taken on the unchanged code):

```
##[warning]Input 'app-id' has been deprecated with message: Use 'client-id' instead.
##[group]Run actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
with:
  app-id: ***
  private-key: ***
  skip-token-revoke: false
  github-api-url: https://api.github.com
##[endgroup]
Inputs 'owner' and 'repositories' are not set. Creating token for this repository (prismatic-koi/home-ops).
```

**After** (expected on this PR's CI run — to be confirmed by reviewers when CI lands):

```
##[group]Run actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
with:
  client-id: ***
  private-key: ***
  skip-token-revoke: false
  github-api-url: https://api.github.com
##[endgroup]
Inputs 'owner' and 'repositories' are not set. Creating token for this repository (prismatic-koi/home-ops).
```

The deprecation `##[warning]` line is gone; the `Creating token for this repository (prismatic-koi/home-ops).` line is preserved (token still scoped to this repo — AC #5).

## Acceptance criteria

- [x] Every invocation of `actions/create-github-app-token` uses `client-id:` (4/4).
- [x] Secret used is `BOT_APP_CLIENT_ID` (confirmed added by repo owner).
- [ ] After-the-change CI run shows no `##[warning]Input 'app-id' has been deprecated` line — verified by CI on this PR.
- [ ] All three previously-using jobs (`test`, `diff (helmrelease)`, `diff (kustomization)`) complete successfully — verified by CI on this PR.
- [ ] `Generate Token` continues to log `Creating token for this repository (prismatic-koi/home-ops).` — verified by CI on this PR.
- [x] No `app-id:` or `BOT_APP_ID` references remain in `.github/workflows/` (`grep` returns nothing).
- [x] Secret needed; owner confirmed it exists before this PR was opened.
- [x] PR description references issue, links to the original failed run, and quotes before/after of one `Generate Token` step.

Originally failed run referenced in #3059: <https://github.com/prismatic-koi/home-ops/actions/runs/26327423775/job/77507541611>

Closes #3059
