### PR TITLE
longhorn: allow recurring-job pods to reach K8s API (fixes silent backup skip)

### DIFF
--- a/kubernetes/cluster0/apps/longhorn-system/longhorn/app/cilium-network-policy.yaml
+++ b/kubernetes/cluster0/apps/longhorn-system/longhorn/app/cilium-network-policy.yaml
@@ -100,3 +100,20 @@ spec:
   egress:
     - toEntities:
         - kube-apiserver
+---
+# Recurring-job pods (#3060) — see the matching NetworkPolicy
+# `longhorn-recurring-job-allow-k8s-api` in ./network-policy.yaml for the
+# full rationale and selector justification.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: longhorn-recurring-job-allow-kube-apiserver
+  namespace: longhorn-system
+spec:
+  endpointSelector:
+    matchExpressions:
+      - key: recurring-job.longhorn.io
+        operator: Exists
+  egress:
+    - toEntities:
+        - kube-apiserver

--- a/kubernetes/cluster0/apps/longhorn-system/longhorn/app/network-policy.yaml
+++ b/kubernetes/cluster0/apps/longhorn-system/longhorn/app/network-policy.yaml
@@ -44,17 +44,28 @@
 #   - engine-image-ei-*    (DaemonSet)    — longhorn.io/component=engine-image
 #   - friday-backup-*      (Job pods from a CronJob; weekly backup) —
 #                                           recurring-job.longhorn.io=friday-backup
-#                                           This is the "longhorn-friday" pod
-#                                           investigated in #2952 — it's a
-#                                           short-lived backup job that only
-#                                           talks intra-ns to longhorn-backend
-#                                           :9500; folded into the wide
-#                                           intra-ns allow.
+#                                           Short-lived pod spawned by the
+#                                           Longhorn recurring-job controller.
+#                                           Despite being a "job" pod, it
+#                                           runs the longhorn-manager binary
+#                                           in `-d recurring-job` mode, which
+#                                           does an initial K8s API call to
+#                                           fetch the RecurringJob CR before
+#                                           talking to longhorn-backend:9500
+#                                           intra-ns. The intra-ns leg is
+#                                           covered by the wide intra-ns
+#                                           allow; the K8s API leg is covered
+#                                           by the dedicated
+#                                           `longhorn-recurring-job-allow-k8s-api`
+#                                           rule below (added in #3060 after
+#                                           the original #2952 classification
+#                                           missed this egress).
 #
 # External flows (NOT covered by the wide intra-ns allow):
 #   - DNS: every pod → CoreDNS :53 in kube-system
-#   - K8s API egress: longhorn-manager, longhorn-csi-plugin, csi-*, and
-#     longhorn-driver-deployer reconcile CRDs and watch resources
+#   - K8s API egress: longhorn-manager, longhorn-csi-plugin, csi-*,
+#     longhorn-driver-deployer, and recurring-job pods reconcile CRDs and
+#     watch resources
 #   - Traefik ingress: longhorn-ui :8000 from networking ns
 #   - Prometheus scrape ingress: longhorn-manager :9500 (ServiceMonitor
 #     `longhorn-prometheus-servicemonitor` selects app=longhorn-manager,
@@ -427,6 +438,57 @@ spec:
       to:
         - ipBlock:
             cidr: 10.87.42.2/32
+---
+# -----------------------------------------------------------------------------
+# K8s API egress — recurring-job pods (#3060).
+#
+# Longhorn's recurring-job controller spawns a short-lived pod (e.g.
+# friday-backup-*) that runs the longhorn-manager binary in
+# `-d recurring-job` mode. Before it talks to longhorn-backend:9500
+# intra-ns, it does an initial K8s API call to fetch the RecurringJob CR
+# (GET /apis/longhorn.io/v1beta2/namespaces/longhorn-system/recurringjobs/<name>).
+# Without this rule that call hits the default-deny, times out after ~30s,
+# the controller exits 0 without bubbling up the error, and the job
+# silently produces no backups — exactly the regression #3060 fixes.
+#
+# Selector: `recurring-job.longhorn.io` with the Exists operator. This is
+# scoped precisely to recurring-job pods only. The simpler
+# `longhorn.io/managed-by: longhorn-manager` label is too broad — it also
+# matches every instance-manager pod, which already has its own scoped NFS
+# egress and does not need K8s API access. Using Exists (rather than the
+# exact value `friday-backup`) also covers any future recurring-job tasks
+# (snapshot, filesystem-trim, etc.) without further netpol changes.
+#
+# Dual-policy pattern: standard NetworkPolicy ipBlock (defence-in-depth) +
+# sibling CiliumNetworkPolicy `toEntities: [kube-apiserver]` (authoritative
+# under Cilium kubeProxyReplacement=true — see #2829 / #2947).
+# -----------------------------------------------------------------------------
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: longhorn-recurring-job-allow-k8s-api
+  namespace: longhorn-system
+spec:
+  podSelector:
+    matchExpressions:
+      - key: recurring-job.longhorn.io
+        operator: Exists
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.43.0.0/16  # Service CIDR (kubernetes.default.svc)
+    - ports:
+        - port: 443
+          protocol: TCP
+        - port: 6443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.87.42.2/32  # control plane node (defence-in-depth)
 ---
 # -----------------------------------------------------------------------------
 # NFS backup egress — longhorn-manager + instance-manager pods write the


### PR DESCRIPTION
## Summary

Fixes the silently-broken `friday-backup` recurring job by adding K8s-API
egress allow rules for recurring-job pods. Two new strictly-additive
resources mirror the existing `longhorn-manager-allow-{k8s-api,kube-apiserver}`
pattern; no existing policy is modified.

Closes #3060
Regression introduced by #2976 (Phase 4c netpol)
Symptom first surfaced by the `LonghornBackupMissed` alert from #3050

## Root cause (recap)

The recurring-job pod (`friday-backup-*`) runs `longhorn-manager -d recurring-job …`,
which does an initial `GET https://10.43.0.1:443/apis/longhorn.io/v1beta2/…/recurringjobs/friday-backup`
to fetch the CR before talking to `longhorn-backend` intra-ns. The wide
intra-namespace allow added in #2976 does NOT cover the cluster API service
(it lives in `default`), so the call hits the default-deny, times out after
~30s, and the controller's error path exits 0 — invisible failure since
2026-05-15.

## Selector chosen — and why

**`recurring-job.longhorn.io` with `Exists` operator.**

The issue suggested `longhorn.io/managed-by: longhorn-manager` as the
selector. Live verification on the cluster showed that label also matches
every `instance-manager-*` pod:

```
$ kubectl -n longhorn-system get pods -l longhorn.io/managed-by=longhorn-manager
friday-backup-manual-1779578156-jmmf7              # the one we want
instance-manager-10c62b70cef24a4b43e11d81fb0928e8  # already has scoped NFS egress
instance-manager-189a32b76630fba30315318b4c937228  # — does not need K8s API
instance-manager-448d201c859f84d3167fbb05202c60b3
instance-manager-989b7695172eba1bafbb782e3e94d1a0
```

Using that selector would widen K8s API egress to instance-manager pods
unnecessarily. The `recurring-job.longhorn.io` label is only set by
Longhorn on recurring-job pods, so `Exists` scopes precisely to the
intended class while still covering any future recurring-job task
(snapshot, filesystem-trim, etc.) without further netpol changes — strictly
better than the literal value `friday-backup`.

Verified: `kubectl -n longhorn-system get pods -l recurring-job.longhorn.io`
returns only the single recurring-job pod.

## Changes

Both under `kubernetes/cluster0/apps/longhorn-system/longhorn/app/`:

1. **`network-policy.yaml`** — add `longhorn-recurring-job-allow-k8s-api`
   NetworkPolicy (egress to 10.43.0.0/16:443 and 10.87.42.2/32:{443,6443},
   same shape as `longhorn-manager-allow-k8s-api`).
2. **`cilium-network-policy.yaml`** — add `longhorn-recurring-job-allow-kube-apiserver`
   CiliumNetworkPolicy (`toEntities: [kube-apiserver]`, authoritative under
   `kubeProxyReplacement=true`).
3. Comment fix at the top of `network-policy.yaml` — the previous design
   block classified recurring-job pods as "intra-ns only" (the root cause
   of the bug); now correctly describes the K8s API leg.

No change to: the default-deny rule, the wide intra-ns allow, any existing
allow-k8s-api rule, the RecurringJob spec, BackupTarget, schedule, or
retention.

## Verification (pre-merge, automated)

- ✅ `flux-local test --all-namespaces --enable-helm --path kubernetes/cluster0` → **100/100 passed**
- ✅ `kustomize build kubernetes/cluster0/apps/longhorn-system/longhorn/app` renders both new resources cleanly.

## Verification (post-merge, manual — for the repo owner)

```bash
# Wait for Flux to reconcile, then confirm the new policies landed:
kubectl -n longhorn-system get networkpolicy longhorn-recurring-job-allow-k8s-api
kubectl -n longhorn-system get ciliumnetworkpolicy longhorn-recurring-job-allow-kube-apiserver

# Trigger a manual run of the recurring job:
kubectl -n longhorn-system create job --from=cronjob/friday-backup friday-backup-test-$(date +%s)

# Watch the job pod's logs — should NOT show "connect: connection timed out".
# Should see backup activity, then completion.

# Confirm new Backup CRs were created:
kubectl get backups.longhorn.io -n longhorn-system --sort-by=.status.snapshotCreatedAt | tail -10
# Recent timestamps (today) should appear, not just the stale 2026-05-14 batch.

# Confirm the recurring job's execution counter advanced:
kubectl -n longhorn-system get recurringjob friday-backup -o jsonpath='{.status.executionCount}'
# Should be 98 (was 97 before the fix).
```
