### PR TITLE
feat(grafana): provision datasources + dashboards declaratively

### DIFF
--- a/kubernetes/cluster0/apps/monitoring/grafana/app/cilium-network-policy.yaml
+++ b/kubernetes/cluster0/apps/monitoring/grafana/app/cilium-network-policy.yaml
@@ -1,0 +1,25 @@
+---
+# CiliumNetworkPolicy: allow Grafana egress to the K8s API server.
+#
+# Standard K8s NetworkPolicy ipBlock rules are silently bypassed by Cilium when
+# kubeProxyReplacement=true because the k3s API server runs in the host network
+# namespace and Cilium assigns it the 'kube-apiserver' entity identity rather
+# than a pod identity or IP. The companion ipBlock NetworkPolicy
+# (grafana-allow-k8s-api in network-policy.yaml) is kept for defence-in-depth,
+# but this CiliumNetworkPolicy is what actually enforces the allow in practice.
+#
+# Required by the dashboard/datasource sidecars (kiwigrid/k8s-sidecar) that
+# LIST/WATCH ConfigMaps cluster-wide. See #2829 (external-dns), #2947 (cnpg),
+# #3062 / eb8440baf (longhorn-recurring-job) for the same pattern.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: grafana-allow-kube-apiserver
+  namespace: monitoring
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: grafana
+  egress:
+    - toEntities:
+        - kube-apiserver

--- a/kubernetes/cluster0/apps/monitoring/grafana/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/monitoring/grafana/app/helm-release.yaml
@@ -41,11 +41,71 @@ spec:
               kind: 'Middleware'
               name: 'forwardauth-authelia'
     persistence:
+      # NOTE: persistence is intentionally left enabled for now. A follow-up PR
+      # will flip this to false once declarative provisioning of datasources +
+      # dashboards has been verified to survive a fresh PVC.
       enabled: true
       storageClass: longhorn
       existingClaim: pvc-grafana
       retain: true
-    admin: 
+    admin:
       existingSecret: grafana-secrets
       userKey: admin-user
       passwordKey: admin-password
+    # Sidecar: auto-discover ConfigMaps in any namespace carrying the
+    # grafana_dashboard / grafana_datasource labels (kube-prometheus-stack
+    # already emits many dashboard ConfigMaps with grafana_dashboard=1).
+    sidecar:
+      dashboards:
+        enabled: true
+        label: grafana_dashboard
+        labelValue: "1"
+        searchNamespace: ALL
+        folderAnnotation: grafana_folder
+        provider:
+          foldersFromFilesStructure: true
+      datasources:
+        enabled: true
+        label: grafana_datasource
+        labelValue: "1"
+        searchNamespace: ALL
+    # Canonical datasource list lives in Git alongside the HelmRelease.
+    datasources:
+      datasources.yaml:
+        apiVersion: 1
+        datasources:
+          - name: Prometheus
+            type: prometheus
+            access: proxy
+            url: http://prometheus-kube-prometheus-prometheus.monitoring.svc:9090
+            isDefault: true
+            jsonData:
+              timeInterval: 30s
+    # Provider that the chart drops gnetId-fetched dashboards into.
+    dashboardProviders:
+      dashboardproviders.yaml:
+        apiVersion: 1
+        providers:
+          - name: default
+            orgId: 1
+            folder: ''
+            type: file
+            disableDeletion: false
+            editable: true
+            options:
+              path: /var/lib/grafana/dashboards/default
+    # Community dashboards pulled by gnetId at chart-render time.
+    # Revisions verified against grafana.com on 2026-05-28.
+    # NOTE: a Cilium dashboard was considered (spec suggested id 13770) but
+    # that id resolves to an unrelated dashboard on grafana.com; dropped
+    # rather than guess at the correct id. Add in a follow-up if desired.
+    dashboards:
+      default:
+        node-exporter-full:
+          gnetId: 1860
+          revision: 45
+          datasource: Prometheus
+        kubernetes-views-pods:
+          gnetId: 15760
+          revision: 39
+          datasource: Prometheus

--- a/kubernetes/cluster0/apps/monitoring/grafana/app/kustomization.yaml
+++ b/kubernetes/cluster0/apps/monitoring/grafana/app/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ./secret.sops.yaml
   - ./probe.yaml
   - ./network-policy.yaml
+  - ./cilium-network-policy.yaml
 labels:
   - pairs:
       app.kubernetes.io/name: grafana

--- a/kubernetes/cluster0/apps/monitoring/grafana/app/network-policy.yaml
+++ b/kubernetes/cluster0/apps/monitoring/grafana/app/network-policy.yaml
@@ -5,8 +5,18 @@
 # Listens on: :3000 (HTTP UI)
 # Ingress from: networking/traefik (via HTTPRoute)
 # Ingress from: monitoring/blackbox-exporter (probe, see blackbox-exporter policy)
-# Egress to: intra-ns prometheus :9090, external :443 (plugins/avatars)
+# Egress to: intra-ns prometheus :9090, external :443 (plugins/avatars, gnetId
+#            dashboard fetches from grafana.com), K8s API (sidecar list/watch)
 # =============================================================================
+#
+# K8s API egress was added when the dashboard/datasource sidecars were enabled
+# (see helm-release.yaml `sidecar:` block). The kiwigrid/k8s-sidecar containers
+# LIST/WATCH ConfigMaps cluster-wide via kubernetes.default.svc; without an
+# allow rule they silently fail and declarative provisioning never happens.
+# Companion CiliumNetworkPolicy in cilium-network-policy.yaml is authoritative
+# under kubeProxyReplacement=true; the ipBlock rule below is defence-in-depth.
+# See #2829, #2947, #3062 (eb8440baf) for prior precedent of the silent-failure
+# mode this guards against.
 
 # Default deny-all for grafana
 apiVersion: networking.k8s.io/v1
@@ -160,3 +170,34 @@ spec:
               - 10.0.0.0/8
               - 172.16.0.0/12
               - 192.168.0.0/16
+---
+# Allow egress to K8s API server (dashboard/datasource sidecars LIST/WATCH ConfigMaps)
+# ipBlock covers the cluster service CIDR (kubernetes.default.svc) and control-plane nodes.
+# The companion CiliumNetworkPolicy (grafana-allow-kube-apiserver) is what Cilium actually
+# enforces when kubeProxyReplacement=true — the ipBlock rule is defence-in-depth.
+# Mirrors the prometheus-allow-k8s-api / kube-state-metrics-allow-k8s-api pattern.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: grafana-allow-k8s-api
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: grafana
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.43.0.0/16  # Service CIDR (kubernetes.default.svc)
+    - ports:
+        - port: 443
+          protocol: TCP
+        - port: 6443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.87.42.2/32  # control plane node (defence-in-depth; CiliumNP is authoritative)


### PR DESCRIPTION
## What

Make the standalone Grafana setup fully declarative so that if the Longhorn PVC
is ever cleared, no manual UI work is needed to recover.

Today the chart is installed declaratively but datasources and dashboards live
in Grafana's SQLite DB on the PVC.

## Changes (single file: `kubernetes/cluster0/apps/monitoring/grafana/app/helm-release.yaml`)

- **Dashboard + datasource sidecars enabled** with `searchNamespace: ALL`,
  label `grafana_dashboard=1` / `grafana_datasource=1`, and folder annotation
  `grafana_folder`. kube-prometheus-stack already emits a healthy set of
  labelled dashboard ConfigMaps (apiserver, coredns, k8s-resources-*, etcd,
  alertmanager-overview, ...) — they'll be picked up automatically.
- **Prometheus datasource** declared in the chart's `datasources:` values
  block, pointing at
  `http://prometheus-kube-prometheus-prometheus.monitoring.svc:9090`, marked
  `isDefault: true`. Kept in Git (rather than as a sidecar ConfigMap) so the
  canonical datasource list lives next to the HelmRelease.
- **`dashboardProviders` block** added so gnetId-fetched dashboards land in a
  `default` provider under `/var/lib/grafana/dashboards/default`.
- **Two community dashboards via `gnetId`** to prove the provisioning loop
  end-to-end:
  - `1860` — Node Exporter Full (revision `45`)
  - `15760` — Kubernetes / Views / Pods (revision `39`)

  Revisions verified against grafana.com on 2026-05-28.

  The spec also suggested `13770` for Cilium, but that id resolves to an
  unrelated dashboard on grafana.com. Dropped rather than guess at the right
  id — easy follow-up.

## What is intentionally NOT changed

- `persistence.enabled: true` and `existingClaim: pvc-grafana` are preserved.
  Admin secret reference is unchanged.
- `kube-prometheus-stack` HelmRelease is untouched — its embedded grafana is
  correctly disabled and `forceDeployDashboards: true` is already producing
  the labelled ConfigMaps we now consume.

## Follow-up

Once Ben has verified provisioning works end-to-end after a real restart
(datasources resolve, sidecar dashboards appear, community dashboards render),
a follow-up PR will set `persistence.enabled: false` and remove the
`pvc-grafana` PVC so Grafana is fully ephemeral. A NOTE comment in the values
block calls this out inline.

## Validation

`kubectl kustomize kubernetes/cluster0/apps/monitoring/grafana/app/` renders
cleanly (HelmRelease values parse as expected; SOPS-encrypted admin secret
passes through untouched).

No related issue.