### PR TITLE
fix(seaweedfs): pin image tag to 3.98 (chart 4.29.0 appVersion points at non-existent 4.30)

### DIFF
--- a/kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/helm-release.yaml
@@ -28,6 +28,14 @@ spec:
     remediation:
       retries: 3
   values:
+    # Pin the container image tag explicitly. The chart derives the image tag
+    # from .Chart.AppVersion when image.tag is unset (see seaweedfs.image helper),
+    # and chart 4.29.0's appVersion resolves to "4.30" — but chrislusf/seaweedfs
+    # publishes no plain "4.30" image tag, so the pods hit ImagePullBackOff.
+    # Owning the tag here decouples it from appVersion. See #3073.
+    image:
+      # renovate: datasource=docker depName=chrislusf/seaweedfs
+      tag: "3.98"
     global:
       seaweedfs:
         enableSecurity: false


### PR DESCRIPTION
## Problem

SeaweedFS pods are in `ImagePullBackOff`.

Renovate PR #3073 bumped the seaweedfs Helm chart 4.28.0 → 4.29.0. The chart derives the container image tag from `.Chart.AppVersion` whenever `image.tag` is left unset — see the `seaweedfs.image` template helper:

```
{{- $tag := default .Chart.AppVersion .Values.image.tag | toString -}}
```

For the deployed chart this appVersion resolves to **`4.30`**, but `chrislusf/seaweedfs` publishes **no plain `4.30` image tag** on Docker Hub. Only variant tags exist for 4.30 (e.g. `4.30_large_disk_foundationdb`); the latest plain tag is `3.98`. Every rolling pod therefore tried to pull `chrislusf/seaweedfs:4.30` → "not found" → `ImagePullBackOff`. The still-healthy pods are pinned to the last good tag (`3.96`).

> Note: the original diagnosis referenced a `global.imageTag` value — that key does **not** exist in this chart and setting it would be a no-op. The image tag is controlled by top-level `image.tag`, which is what this PR sets.

## Fix

Pin `spec.values.image.tag: "3.98"` (latest published plain tag) so the deployed image no longer depends on the chart appVersion. Verified by rendering `helm template` with the real HelmRelease values against chart 4.29.0:

```
image: chrislusf/seaweedfs:3.98   # all components
```

- Chart version **unchanged** at `4.29.0`.
- A `# renovate: datasource=docker depName=chrislusf/seaweedfs` annotation keeps the pinned tag tracked for future updates, matching the repo's existing renovate-comment convention.
- No manual cluster mutations — Flux will reconcile on merge.

## Verification
- `3.98` confirmed present on Docker Hub (`/v2/repositories/chrislusf/seaweedfs/tags/3.98` → 200).
- Plain `4.30` confirmed **absent** (404).
- YAML validated with `yq`; chart render produces the expected image ref.

Relates to #3073.