### PR TITLE
revert(seaweedfs): roll back chart 4.30.0 → 4.29.0 (image 4.30 doesn't exist)

### DIFF
--- a/.github/renovate/automerge.json5
+++ b/.github/renovate/automerge.json5
@@ -27,6 +27,18 @@
       "automergeType": "pr",
       "ignoreTests": false
     },
+    // Never auto-merge the seaweedfs Helm chart. The chart's appVersion has
+    // shipped image refs that don't exist on Docker Hub twice now (4.29→4.30
+    // via #3093 was the most recent; image tag `chrislusf/seaweedfs:4.30`
+    // doesn't exist, only variant tags do). Until upstream stops doing this,
+    // every seaweedfs chart bump needs human eyes before it lands.
+    {
+      "description": "Never auto-merge seaweedfs Helm chart (broken appVersion/image-tag bumps)",
+      "matchDatasources": ["helm"],
+      "matchPackageNames": ["seaweedfs"],
+      "matchUpdateTypes": ["major", "minor", "patch"],
+      "automerge": false
+    },
     // Enable automerge for GitHub Actions
     {
       "description": "Auto-merge GitHub Actions updates",

--- a/kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/helm-release.yaml
@@ -10,7 +10,7 @@ spec:
   chart:
     spec:
       chart: seaweedfs
-      version: 4.30.0
+      version: 4.29.0
       sourceRef:
         kind: HelmRepository
         name: seaweedfs


### PR DESCRIPTION
## What

Reverts the seaweedfs Helm chart from **4.30.0 → 4.29.0**, and adds a Renovate
automerge carve-out so seaweedfs chart bumps never auto-land again.

## Why

PR #3093 auto-merged the seaweedfs Helm chart 4.29.0 → 4.30.0 on 2026-05-30.
Chart 4.30.0 bumps `appVersion` to `"4.30"`, but **`chrislusf/seaweedfs:4.30`
does not exist on Docker Hub** — only variant tags like
`4.30_large_disk_*` exist; the latest plain tag is `3.98`.

The chart's `seaweedfs.image` template helper defaults the image tag to
`.Chart.AppVersion` when `image.tag` is unset (which it is in our values),
so every component now tries to pull `chrislusf/seaweedfs:4.30` and falls
into `ImagePullBackOff`.

### Current cluster impact

- `seaweedfs-master-0`, `seaweedfs-filer-0`, `seaweedfs-volume-1`, and one
  s3 replica: `ImagePullBackOff` on `chrislusf/seaweedfs:4.30`
- `seaweedfs-volume-0` and the other s3 replica: still serving on
  `chrislusf/seaweedfs:4.29` (this is why nothing has fully toppled over yet)

Chart 4.29.0 is therefore a known-good rollback target — half the cluster is
still happily running on its image.

## How

1. `kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/helm-release.yaml`:
   `chart.spec.version` 4.30.0 → 4.29.0. Nothing else changed (image tag
   values block deliberately left untouched — we're reverting the chart,
   not pinning the image).
2. `.github/renovate/automerge.json5`: new packageRule scoped to
   `matchDatasources: ["helm"]` + `matchPackageNames: ["seaweedfs"]` that
   disables automerge for patch + minor + major. Placed after the generic
   "Auto-merge minor updates for Helm charts" rule so it wins (Renovate
   packageRules: last match wins).

Flux will reconcile back to chart 4.29.0 once this merges; no manual cluster
intervention.

## Related

- #3093 — the auto-merged 4.29 → 4.30 bump being reverted here
- #3094 — prior attempt to fix this by pinning `image.tag: "3.98"`; closed
  unmerged in favour of this straight revert

## Why also the renovate carve-out

This is the **second** time the seaweedfs chart's `appVersion` has shipped
ahead of the matching Docker image (see #3094 for the prior occurrence).
Until upstream stops doing this, every seaweedfs chart bump needs human
eyeballs before it lands — so seaweedfs is now opted out of automerge
across all update types.

## Validation

- `helm-release.yaml` diff is a single-line version revert.
- `automerge.json5` re-parses cleanly (JSON5, 10 packageRules, seaweedfs
  carve-out lands at index 3 immediately after the generic Helm minor
  automerge rule, so it overrides it).
