### PR TITLE
chore(renovate): hold seaweedfs chart bumps for 3 days (minimumReleaseAge)

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -64,16 +64,17 @@
     },
     {
       // Hold seaweedfs Helm chart bumps for 3 days — chart appVersion has
-      // shipped ahead of the matching chrislusf/seaweedfs Docker image twice
-      // now (see #3094, #3095). The delay gives upstream time to either
-      // publish the image or yank the chart before we see the PR.
+      // shipped ahead of the matching chrislusf/seaweedfs Docker image
+      // (most recently #3093, reverted in #3095). The delay gives upstream
+      // time to either publish the image or yank the chart before we see
+      // the PR.
       //
       // `internalChecksFilter: 'strict'` is required: without it Renovate
       // would still open the PR and merely attach a pending status check.
       // Strict mode defers PR creation entirely until the age threshold is
       // met. The no-automerge carve-out in .github/renovate/automerge.json5
       // stays in place as defence-in-depth.
-      description: "Hold seaweedfs Helm chart bumps for 3 days — chart appVersion has shipped ahead of the matching chrislusf/seaweedfs Docker image twice now (see #3094, #3095). The delay gives upstream time to either publish the image or yank the chart before we see the PR.",
+      description: "Hold seaweedfs Helm chart bumps for 3 days — chart appVersion has shipped ahead of the matching chrislusf/seaweedfs Docker image (most recently #3093, reverted in #3095). The delay gives upstream time to either publish the image or yank the chart before we see the PR.",
       matchDatasources: ['helm'],
       matchPackageNames: ['seaweedfs'],
       minimumReleaseAge: '3 days',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -63,6 +63,23 @@
       allowedVersions: '!/-(armhf|arm64|armv7|amd64|linux)$/',
     },
     {
+      // Hold seaweedfs Helm chart bumps for 3 days — chart appVersion has
+      // shipped ahead of the matching chrislusf/seaweedfs Docker image twice
+      // now (see #3094, #3095). The delay gives upstream time to either
+      // publish the image or yank the chart before we see the PR.
+      //
+      // `internalChecksFilter: 'strict'` is required: without it Renovate
+      // would still open the PR and merely attach a pending status check.
+      // Strict mode defers PR creation entirely until the age threshold is
+      // met. The no-automerge carve-out in .github/renovate/automerge.json5
+      // stays in place as defence-in-depth.
+      description: "Hold seaweedfs Helm chart bumps for 3 days — chart appVersion has shipped ahead of the matching chrislusf/seaweedfs Docker image twice now (see #3094, #3095). The delay gives upstream time to either publish the image or yank the chart before we see the PR.",
+      matchDatasources: ['helm'],
+      matchPackageNames: ['seaweedfs'],
+      minimumReleaseAge: '3 days',
+      internalChecksFilter: 'strict',
+    },
+    {
       // Flux manager + OCIRepository hybrid digest shape is broken:
       // Renovate writes `tag: <semver>@sha256:<digest>` instead of populating
       // the separate `ref.digest` field (renovatebot/renovate#42082). flux-local


### PR DESCRIPTION
## What

Adds a targeted `minimumReleaseAge` rule to `.github/renovate.json5` for the
**seaweedfs Helm chart**: Renovate will now wait 3 days after a chart release
appears in the Helm repo index before opening a PR to bump us to it.

## Why

The seaweedfs chart has shipped its `appVersion` ahead of the matching
`chrislusf/seaweedfs:<tag>` Docker image **twice** now:

- #3093 — chart `4.30.0` bumped via Renovate (appVersion `4.30`)
- #3094 — rollout broke: `chrislusf/seaweedfs:4.30` didn't exist on Docker Hub
- #3095 — revert back to `4.29.0` so the cluster could roll out

Same failure mode existed earlier in the chart's history. This isn't a
one-off; it's a recurring upstream release-ordering bug. A short soak gives
upstream a chance to either publish the missing image tag or yank the chart
before Renovate ever opens the PR against us.

## How

New entry in the top-level `packageRules` array:

```json5
{
  description: "Hold seaweedfs Helm chart bumps for 3 days …",
  matchDatasources: ['helm'],
  matchPackageNames: ['seaweedfs'],
  minimumReleaseAge: '3 days',
  internalChecksFilter: 'strict',
},
```

Both keys matter together:

- **`minimumReleaseAge: '3 days'`** — Renovate checks the chart's `created`
  timestamp in the Helm repo index and treats it as not-yet-stable until
  3 days have passed.
- **`internalChecksFilter: 'strict'`** — without this, Renovate would still
  open the PR and just attach a pending status check. Strict mode defers
  PR creation entirely until the age threshold is met. That's the behaviour
  we actually want.

## Scope: targeted, not global

This is deliberately **scoped to seaweedfs only**. We didn't reach for a
global `minimumReleaseAge` default because seaweedfs is the only package
in this repo that has repeatedly bitten us with broken appVersion/image-tag
release ordering. Slowing every dependency down to fix one badly-behaved
chart would be the wrong trade-off.

## Defence-in-depth

The existing no-automerge carve-out for seaweedfs in
`.github/renovate/automerge.json5` (added in #3095) **stays in place**. If a
bad chart bump somehow still slips through the 3-day window — e.g. the
image is published 4 days late — the PR will still require human eyes
before merging.

## Validation

- `node -e 'JSON5.parse(...)'` on the edited file → parses cleanly.
- No changes to schedule, automerge defaults, or any other Renovate
  behaviour.
