### PR TITLE
feat(longhorn): manage friday-backup RecurringJob, drop concurrency 4→2

### DIFF
--- a/kubernetes/cluster0/apps/longhorn-system/longhorn/app/kustomization.yaml
+++ b/kubernetes/cluster0/apps/longhorn-system/longhorn/app/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - prometheusrule.yaml
   - network-policy.yaml
   - cilium-network-policy.yaml
+  - recurring-job.yaml
 labels:
   - pairs:
       app.kubernetes.io/name: longhorn

--- a/kubernetes/cluster0/apps/longhorn-system/longhorn/app/recurring-job.yaml
+++ b/kubernetes/cluster0/apps/longhorn-system/longhorn/app/recurring-job.yaml
@@ -1,0 +1,15 @@
+apiVersion: longhorn.io/v1beta2
+kind: RecurringJob
+metadata:
+  name: friday-backup
+  namespace: longhorn-system
+spec:
+  name: friday-backup
+  task: backup
+  cron: 0 3 ? * FRI
+  groups:
+    - default
+  retain: 4
+  concurrency: 2
+  labels: {}
+  parameters: {}


### PR DESCRIPTION
## Symptom

The 2026-05-29 03:00 NZ run of `friday-backup` triggered 8 `LonghornBackupMissed` alerts. All 8 volumes failed at startup (15:00:00–15:00:20 UTC) with:

```
failed to create snapshot CR: Internal error occurred:
failed calling webhook "validator.longhorn.io":
Post "https://longhorn-admission-webhook.longhorn-system.svc:9502/v1/webhook/validation?timeout=10s":
context deadline exceeded
```

After the initial ~20s window the admission webhook recovered and every subsequent volume backed up cleanly.

## Root cause

Thundering-herd against the Longhorn admission webhook on cold start. With `spec.concurrency: 4`, four backup snapshot CRs hit the webhook simultaneously before it has warmed up, blowing past the 10s validation timeout.

## Fix

Lower `spec.concurrency` from 4 → 2 to flatten the burst. While here, bring the resource under GitOps — it was previously created out-of-band (via the Longhorn UI) and not tracked in this repo.

## Diff vs live CR

Constructed manually (kubectl diff requires write perms our local context doesn't have). Live spec was captured with `kubectl -n longhorn-system get recurringjob friday-backup -o yaml` and stripped of server-managed metadata; desired was rendered with `kubectl kustomize kubernetes/cluster0/apps/longhorn-system/longhorn/app`.

```diff
--- live
+++ desired
 apiVersion: longhorn.io/v1beta2
 kind: RecurringJob
 metadata:
+  labels:
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/name: longhorn
   name: friday-backup
   namespace: longhorn-system
 spec:
-  concurrency: 4
+  concurrency: 2
   cron: 0 3 ? * FRI
   groups:
   - default
   labels: {}
   name: friday-backup
   parameters: {}
   retain: 4
   task: backup
```

The only spec change is `concurrency: 4 → 2`. The added `app.kubernetes.io/{name,instance}` labels are injected by the existing `labels.pairs` block in `kustomization.yaml` and match the pattern already applied to every sibling resource in this Kustomization (HTTPRoute, PrometheusRule, etc.). Flux will additionally stamp its standard `kustomize.toolkit.fluxcd.io/*` labels on apply, also consistent with sibling resources.

## Alert handling

Not retriggering the failed backups. The next scheduled run is tomorrow morning (Friday) and that will clear the 8 outstanding `LonghornBackupMissed` alerts naturally.

## No tracking issue

Filed directly from operator kōrero — rationale captured in this PR body.
