### PR TITLE
fix(netpol): allow kube-apiserver -> longhorn admission webhook :9502

### DIFF
--- a/kubernetes/cluster0/apps/longhorn-system/longhorn/app/cilium-network-policy.yaml
+++ b/kubernetes/cluster0/apps/longhorn-system/longhorn/app/cilium-network-policy.yaml
@@ -23,6 +23,30 @@ spec:
     - toEntities:
         - kube-apiserver
 ---
+# Admission-webhook ingress (#2976 follow-up) — see the matching
+# NetworkPolicy `longhorn-admission-webhook-allow-apiserver` in
+# ./network-policy.yaml for the full diagnosis. Authoritative half of the
+# dual-policy pattern under Cilium kubeProxyReplacement=true: when the
+# apiserver calls the validating/mutating webhooks on :9502 the source IP
+# is on the host-network apiserver and standard NetworkPolicy ipBlock
+# matches are bypassed (same identity quirk as #2829 / #2947).
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: longhorn-admission-webhook-allow-apiserver
+  namespace: longhorn-system
+spec:
+  endpointSelector:
+    matchLabels:
+      longhorn.io/admission-webhook: longhorn-admission-webhook
+  ingress:
+    - fromEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "9502"
+              protocol: TCP
+---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:

--- a/kubernetes/cluster0/apps/longhorn-system/longhorn/app/network-policy.yaml
+++ b/kubernetes/cluster0/apps/longhorn-system/longhorn/app/network-policy.yaml
@@ -70,6 +70,13 @@
 #   - Prometheus scrape ingress: longhorn-manager :9500 (ServiceMonitor
 #     `longhorn-prometheus-servicemonitor` selects app=longhorn-manager,
 #     port name=manager → containerPort 9500)
+#   - Admission-webhook ingress: longhorn-manager pods labelled
+#     `longhorn.io/admission-webhook=longhorn-admission-webhook` serve the
+#     validating + mutating admission webhooks on :9502; the apiserver
+#     calls these for every Longhorn CRD write. Symmetric ingress
+#     counterpart to the K8s API egress allows below — needs the same
+#     dual-policy (NetworkPolicy + CiliumNetworkPolicy) treatment under
+#     Cilium kubeProxyReplacement=true. Missed by #2976, added in this PR.
 #   - Backup target NFS: instance-manager + longhorn-manager pods write the
 #     Friday backup to nfs://${NAS0_IP}:/volume1/longhorn-backups
 #     (NAS0 = 10.87.42.200 — same /24 as the nodes but NOT a node)
@@ -220,6 +227,59 @@ spec:
               app.kubernetes.io/name: prometheus
       ports:
         - port: 9500
+          protocol: TCP
+---
+# -----------------------------------------------------------------------------
+# longhorn admission webhook — apiserver ingress on :9502.
+#
+# This is the INGRESS counterpart to the K8s API egress allows below: when
+# the apiserver invokes Longhorn's validating/mutating admission webhooks
+# (Service `longhorn-admission-webhook`, port 9502, served by every
+# longhorn-manager pod) the connection originates AT the apiserver, so it
+# needs the same dual-policy treatment as the egress side under Cilium
+# kubeProxyReplacement=true (#2829 / #2947).
+#
+# PR #2976 added the egress half (longhorn-manager → kube-apiserver) but
+# missed this symmetric ingress. With default-deny in effect, apiserver →
+# webhook calls fail on some nodes (per-agent BPF state asymmetry — failures
+# were concentrated on the manager pods that re-attached to a particular
+# subset of nodes after the 2026-05-22 rolling restart), which manifested
+# as:
+#   - ~100% timeouts on the BackupStoreTimer 5-min reconcile loop on
+#     longhorn-manager pods on node1 (272/24h) and node2 (268/24h);
+#     ~0 on node0/node3.
+#   - 4 volumes failing admission on the 2026-06-04 weekly backup run with
+#     `failed calling webhook "validator.longhorn.io": context deadline
+#     exceeded` (10s timeout).
+#   - 2 LonghornBackupMissed alerts firing in Prometheus
+#     (pvc-zigbee2mqtt, pvc-jellyfin) — these clear naturally after the
+#     next successful backup of those volumes once the webhook path is
+#     healthy.
+#
+# Pod selector matches the live `longhorn-admission-webhook` Service
+# selector (`longhorn.io/admission-webhook=longhorn-admission-webhook`),
+# so the policy scope is exactly the webhook backends.
+#
+# Dual-policy pattern: standard NetworkPolicy ipBlock (defence-in-depth) +
+# sibling CiliumNetworkPolicy `fromEntities: [kube-apiserver]`
+# (authoritative under Cilium kubeProxyReplacement=true).
+# -----------------------------------------------------------------------------
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: longhorn-admission-webhook-allow-apiserver
+  namespace: longhorn-system
+spec:
+  podSelector:
+    matchLabels:
+      longhorn.io/admission-webhook: longhorn-admission-webhook
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - ipBlock:
+            cidr: 10.87.42.2/32  # control plane node (defence-in-depth; CiliumNP is authoritative)
+      ports:
+        - port: 9502
           protocol: TCP
 ---
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

PR #2976 ("phase 4c — Longhorn wide-then-tighten") introduced default-deny `NetworkPolicy` on `longhorn-system` and a dual-policy egress (NetworkPolicy `ipBlock` + `CiliumNetworkPolicy` `toEntities: kube-apiserver`) for longhorn-manager → kube-apiserver. It missed the **symmetric ingress**: kube-apiserver → longhorn admission webhook on `:9502`.

Under Cilium `kubeProxyReplacement=true` the apiserver runs in the host network namespace and the standard `ipBlock` match is bypassed — same identity quirk documented in #2829 (external-dns) and #2947 (cnpg-operator). The ingress had to be matched on the `kube-apiserver` Cilium entity; without that, apiserver → webhook calls were silently dropped on the subset of nodes whose Cilium agent had no per-pod allow installed.

This PR adds the paired NetworkPolicy + CiliumNetworkPolicy
`longhorn-admission-webhook-allow-apiserver`, scoped to pods labelled
`longhorn.io/admission-webhook=longhorn-admission-webhook` (verbatim match
of the live Service selector for `longhorn-admission-webhook`),
allowing ingress on TCP `:9502` from the `kube-apiserver` entity (CNP, authoritative) and from the `CONTROLPLANE_IP` `10.87.42.2/32` (NetworkPolicy, defence-in-depth). Selector and port verified against the live cluster:

```
$ kubectl -n longhorn-system get svc longhorn-admission-webhook -o jsonpath='{.spec.selector}'
{"longhorn.io/admission-webhook":"longhorn-admission-webhook"}
$ kubectl -n longhorn-system get pod longhorn-manager-7qrjn -o jsonpath='{...containers[0].ports}'
manager=9500/TCP admission-wh=9502/TCP recov-backend=9503/TCP
```

## Symptoms in cluster right now

Concentrated on the longhorn-manager pods on node1 and node2 (the per-agent BPF state asymmetry that followed the 2026-05-22 rolling restart):

| Pod | Node | Webhook timeouts / 24 h |
|---|---|---|
| `longhorn-manager-5lq4j` | node1 | 272 (≈100% of BackupStoreTimer calls) |
| `longhorn-manager-cpz96` | node2 | 268 (≈92%) |
| `longhorn-manager-7qrjn` | node0 | ~2 |
| `longhorn-manager-n4x95` | node3 | ~2 |


- 4 volumes failed admission on the 2026-06-04 weekly backup run with `failed to create snapshot CR: ... failed calling webhook "validator.longhorn.io": ... context deadline exceeded` (10 s timeout).
- 2 `LonghornBackupMissed` alerts currently firing in Prometheus: `pvc-zigbee2mqtt`, `pvc-jellyfin`.

The 2 currently-firing `LonghornBackupMissed` alerts will **clear naturally** after the next successful weekly backup of those two volumes once the webhook path is healthy — no manual `Alertmanager` silence needed.

## Verification (post-merge, post-Flux-reconcile)

1. Watch the `BackupStoreTimer` failure rate drop to ~0 in `longhorn-manager-5lq4j` and `longhorn-manager-cpz96` logs over the next 10 – 15 minutes:
   ```
   kubectl -n longhorn-system logs longhorn-manager-5lq4j -c longhorn-manager --since=15m | grep -iE "BackupStoreTimer|webhook"
   ```
2. If the failure rate doesn't fall (because the apiservers are holding stale HTTP/2 connections to the old failing endpoints), force a clean reconnect:
   ```
   kubectl -n longhorn-system rollout restart ds/longhorn-manager
   ```
   Prefer waiting a few minutes first — a daemonset restart is more disruptive than the underlying CNP change.
3. Confirm the new policies exist:
   ```
   kubectl -n longhorn-system get networkpolicy longhorn-admission-webhook-allow-apiserver
   kubectl -n longhorn-system get ciliumnetworkpolicy longhorn-admission-webhook-allow-apiserver
   ```

## Local validation

```
$ kubectl kustomize kubernetes/cluster0/apps/longhorn-system/longhorn/app/ | grep -c "longhorn-admission-webhook-allow-apiserver"
2
$ kubectl apply --dry-run=server -f <rendered>   # passes structural/schema validation (RBAC denies create, as expected for read-only agent)
```

## Notes

- The `ipBlock` in the `NetworkPolicy` uses `10.87.42.2/32` (the cluster's `CONTROLPLANE_IP`) — identical to every other apiserver `ipBlock` in this file (and in `cert-manager`, `cnpg`, `grafana`, `trust-manager`, `traefik`). The original spec talked of "3 apiserver node IPs", but the cluster's canonical control-plane VIP is a single `10.87.42.2` and that's what every existing egress rule uses, so I matched verbatim. The `CiliumNetworkPolicy` `fromEntities: [kube-apiserver]` is the authoritative half and matches the real node identities directly.
- Both files retain the dual-policy pattern documented in the top-of-file comment block; the new rule is documented in the same style and the top-of-file "External flows" list has been updated to mention the admission-webhook ingress flow.
