### PR TITLE
revert(longhorn): pin chart to 1.11.2 — 1.12 pre-upgrade hook fails

### DIFF
--- a/kubernetes/cluster0/apps/longhorn-system/longhorn/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/longhorn-system/longhorn/app/helm-release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: longhorn
-      version: 1.12.0
+      version: 1.11.2
       sourceRef:
         kind: HelmRepository
         name: longhorn-charts


### PR DESCRIPTION
## Summary

Reverts the Longhorn Helm chart bump from PR #3106 (1.11.2 → 1.12.0). The 1.12.0 upgrade fails repeatedly in Flux's pre-upgrade hook:

```
UpgradeFailed: Helm upgrade failed for release longhorn-system/longhorn
with chart longhorn@1.12.0: pre-upgrade hooks failed: failed early due to
stalled resources: [Job/longhorn-system/longhorn-pre-upgrade status: 'Failed']
```

Each attempt rolls back to 1.11.2 and Flux retries, failing again on the next cycle.

## Runtime status

- 1.11.2 is healthy — all longhorn pods are `Running` and volumes continue to serve I/O.
- No data-plane disruption observed during the failed upgrade attempts.

## Impact

The `cluster-apps-longhorn` Flux Kustomization stays in a failed state because of the repeated pre-upgrade hook failure. That gates ~17 downstream Kustomizations which declare `dependsOn: cluster-apps-longhorn`, including:

overseerr, openldap, jellyfin, plex, home-assistant, grafana, the *arr stack, syncthing, uptime-kuma, and others.

New config changes for those apps cannot reconcile until Longhorn is healthy. Pinning back to 1.11.2 unblocks the dependency graph.

## Follow-up

The 1.11 → 1.12 upgrade likely needs prerequisite steps (engine image preload, volume-health check, etc.) that should be investigated before re-attempting. Renovate will offer the bump again — treat the next 1.12.x PR as a **manual upgrade**, not a routine weekly patch.

## Changes

Single one-line revert of `version: 1.12.0` → `version: 1.11.2` in `kubernetes/cluster0/apps/longhorn-system/longhorn/app/helm-release.yaml`. No other files touched.
