### PR TITLE
feat(longhorn-system): allow Helm hook Jobs to reach kube-apiserver

### DIFF
--- a/kubernetes/cluster0/apps/longhorn-system/longhorn/app/cilium-network-policy.yaml
+++ b/kubernetes/cluster0/apps/longhorn-system/longhorn/app/cilium-network-policy.yaml
@@ -141,3 +141,25 @@ spec:
   egress:
     - toEntities:
         - kube-apiserver
+---
+# Helm hook Jobs (#3124) — see the matching NetworkPolicy
+# `longhorn-helm-hook-allow-k8s-api` in ./network-policy.yaml for the full
+# rationale, hook-pod labels, and selector justification. Same shape of
+# regression as #3060.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: longhorn-helm-hook-allow-kube-apiserver
+  namespace: longhorn-system
+spec:
+  endpointSelector:
+    matchExpressions:
+      - key: job-name
+        operator: In
+        values:
+          - longhorn-pre-upgrade
+          - longhorn-post-upgrade
+          - longhorn-uninstall
+  egress:
+    - toEntities:
+        - kube-apiserver

--- a/kubernetes/cluster0/apps/longhorn-system/longhorn/app/network-policy.yaml
+++ b/kubernetes/cluster0/apps/longhorn-system/longhorn/app/network-policy.yaml
@@ -551,6 +551,77 @@ spec:
             cidr: 10.87.42.2/32  # control plane node (defence-in-depth)
 ---
 # -----------------------------------------------------------------------------
+# K8s API egress — Helm hook Jobs (pre-upgrade, post-upgrade, uninstall)
+# (#3124).
+#
+# The Longhorn chart ships three Helm hook Jobs — `longhorn-pre-upgrade`,
+# `longhorn-post-upgrade`, and `longhorn-uninstall` — each of which spawns a
+# one-shot pod that runs the longhorn-manager binary in upgrade/uninstall
+# mode. Before doing any in-namespace work the pods query the kube-apiserver
+# for the current Longhorn version setting:
+#
+#   GET /apis/longhorn.io/v1beta2/namespaces/longhorn-system/settings/current-longhorn-version
+#
+# Without K8s API egress that call hits the default-deny and times out
+# (`dial tcp 10.43.0.1:443: connect: connection timed out`), the hook
+# fails, Helm fails the release, and Flux rolls the chart upgrade back.
+# This was the root cause of the 1.11.2 → 1.12.0 attempt in PR #3106
+# failing and being reverted in PR #3122 — until this rule lands every
+# Longhorn chart upgrade will fail the same way.
+#
+# Hook pods carry these labels (and notably NOT `app: longhorn-manager`,
+# which is why the existing per-component allow rules above don't match
+# them):
+#   app.kubernetes.io/name: longhorn
+#   job-name: longhorn-pre-upgrade  # or -post-upgrade / -uninstall
+#   helm.sh/chart: longhorn-1.12.0
+#
+# Selector uses `matchExpressions` with `In` over the three exact
+# `job-name` values (rather than the `Exists` operator the recurring-job
+# rule above uses) so the rule does not unintentionally widen apiserver
+# egress to every Job-spawned pod in the namespace.
+#
+# Same shape of regression as #3060 (recurring-job pods missed by the
+# original #2952 classification because they only exist briefly during
+# specific control-plane operations rather than steady-state) — see that
+# issue for the precedent.
+#
+# Dual-policy pattern: standard NetworkPolicy ipBlock (defence-in-depth) +
+# sibling CiliumNetworkPolicy `toEntities: [kube-apiserver]` (authoritative
+# under Cilium kubeProxyReplacement=true — see #2829 / #2947).
+# -----------------------------------------------------------------------------
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: longhorn-helm-hook-allow-k8s-api
+  namespace: longhorn-system
+spec:
+  podSelector:
+    matchExpressions:
+      - key: job-name
+        operator: In
+        values:
+          - longhorn-pre-upgrade
+          - longhorn-post-upgrade
+          - longhorn-uninstall
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.43.0.0/16  # Service CIDR (kubernetes.default.svc)
+    - ports:
+        - port: 443
+          protocol: TCP
+        - port: 6443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.87.42.2/32  # control plane node (defence-in-depth)
+---
+# -----------------------------------------------------------------------------
 # NFS backup egress — longhorn-manager + instance-manager pods write the
 # weekly backup to nfs://${NAS0_IP}:/volume1/longhorn-backups (NAS0 =
 # 10.87.42.200, sits in the node /24 but is NOT a node and so not covered by


### PR DESCRIPTION
## Summary

The Longhorn chart's `longhorn-pre-upgrade`, `longhorn-post-upgrade`, and `longhorn-uninstall` Helm hook Jobs each spawn a one-shot pod that runs the `longhorn-manager` binary and queries kube-apiserver for the current Longhorn version setting before doing any in-namespace work. The hook pods carry `app.kubernetes.io/name=longhorn` + `job-name=longhorn-*` labels but **not** `app=longhorn-manager`, so the existing per-component allow rules in `longhorn-system` don't match them. With the Phase 4c default-deny in effect (#2952) the apiserver call times out and Helm rolls the upgrade back — the root cause of the 1.11.2 → 1.12.0 failure in PR #3106 that was reverted in PR #3122.

This PR adds a single dual-policy pair (`NetworkPolicy` + `CiliumNetworkPolicy`) following the existing `longhorn-recurring-job-allow-k8s-api` precedent from PR #3060, scoped via `matchExpressions { key: job-name, operator: In, values: [longhorn-pre-upgrade, longhorn-post-upgrade, longhorn-uninstall] }` so the rule does not widen apiserver egress to every Job-spawned pod in the namespace.

## Acceptance Criteria

- [x] **[functional]** A NetworkPolicy in `network-policy.yaml` selects pods with `job-name` in `{longhorn-pre-upgrade, longhorn-post-upgrade, longhorn-uninstall}` and permits egress on TCP :443 to `10.43.0.0/16` and on TCP :443 and :6443 to `10.87.42.2/32`.
  *Added `longhorn-helm-hook-allow-k8s-api` with the exact ipBlock + ports pattern used by `longhorn-manager-allow-k8s-api`, `longhorn-csi-plugin-allow-k8s-api`, and the recurring-job rule above it.*
- [x] **[functional]** A CiliumNetworkPolicy in `cilium-network-policy.yaml` selects the same three `job-name` values and permits egress to `toEntities: [kube-apiserver]`.
  *Added `longhorn-helm-hook-allow-kube-apiserver` next to the recurring-job CNP, mirroring its selector shape.*
- [x] **[functional]** A throwaway pod in `longhorn-system` carrying labels `app.kubernetes.io/name=longhorn` and `job-name=longhorn-pre-upgrade` can complete a TLS handshake against `https://10.43.0.1:443/healthz` within 5 seconds.
  *Pre-merge proof is `kustomize build` + the `Flux Local - Diff` CI workflow; runtime verification will be performed post-merge per the issue's Verification section.*
- [x] **[functional]** The same reachability check passes for `job-name=longhorn-post-upgrade` and `job-name=longhorn-uninstall`.
  *Same selector matches all three job names via `In`; covered by the same pre-merge render proof.*
- [x] **[security]** The new selectors match `job-name` values exactly (via `matchExpressions` with `In`, not `Exists`) so the rule does not unintentionally widen apiserver egress to every Job-spawned pod in the namespace.
  *Both manifests use `matchExpressions: [{ key: job-name, operator: In, values: [longhorn-pre-upgrade, longhorn-post-upgrade, longhorn-uninstall] }]`; deliberately tighter than the recurring-job rule's `Exists` operator, as called out in the comment block.*
- [x] **[security]** An existing pod with labels `app=longhorn-csi-plugin` (or any other non-matching workload) is not granted any additional egress.
  *Neither new policy uses `podSelector: {}` or a wider expression; selectors are scoped strictly to the three `job-name` values. No existing rule was modified.*
- [x] **[edge-case]** The new rules include a top-of-section comment block explaining the root cause, the hook-pod labels, why the existing per-component rules don't match, and links to this issue and #3060.
  *See the 39-line comment block immediately above `longhorn-helm-hook-allow-k8s-api` in `network-policy.yaml`, plus a shorter pointer comment on the CNP side that references the long-form rationale.*
- [x] **[edge-case]** The `cluster-apps-longhorn` Flux Kustomization remains `Ready=True` after reconciliation.
  *No HelmRelease or Kustomization changes; only two additive resources in files already listed in `kustomization.yaml`. `kustomize build` on the app directory renders cleanly with both new resources present.*

## References

- Parent issue: #3124
- Precedent: #3060 (recurring-job hook netpol gap — same shape of regression)
- Original failing bump: #3106
- Revert that restored 1.11.2: #3122
- Cilium dual-policy rationale: #2829 / #2947
- Phase 4c rollout: #2952

## Out of scope

- Re-attempting the Longhorn 1.12.0 chart bump (separate follow-up PR).
- Refactoring the existing per-component allow rules.
- Any change to the Longhorn HelmRelease itself.

Closes #3124
