### PR TITLE
feat(longhorn): bump chart 1.11.2 → 1.12.0 (re-attempt after netpol fix)

### DIFF
--- a/kubernetes/cluster0/apps/longhorn-system/longhorn/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/longhorn-system/longhorn/app/helm-release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: longhorn
-      version: 1.11.2
+      version: 1.12.0
       sourceRef:
         kind: HelmRepository
         name: longhorn-charts


### PR DESCRIPTION
## Why this re-attempt is safe

The previous 1.11.2 → 1.12.0 bump (#3106) failed because the chart's `longhorn-pre-upgrade` Helm hook Job runs a one-shot `longhorn-manager` pod that queries the kube-apiserver, and the hook pod's labels (`app.kubernetes.io/name=longhorn`, `job-name=longhorn-pre-upgrade`, **no** `app=longhorn-manager`) did not match any of our per-component allow rules in the `longhorn-system` default-deny netpol — the API call timed out and Flux rolled back. #3122 restored 1.11.2 cleanly. #3125 (issue #3124) then added a dual-policy `longhorn-helm-hook-allow-k8s-api` / `longhorn-helm-hook-allow-kube-apiserver` pair scoped via `matchExpressions { key: job-name, operator: In, values: [longhorn-pre-upgrade, longhorn-post-upgrade, longhorn-uninstall] }`. Both policies are live (`kubectl get networkpolicy,ciliumnetworkpolicy -n longhorn-system | grep helm-hook` shows them present and `CNP Valid=True`), and `cluster-apps-longhorn` is `Ready=True`. Runtime reachability via a probe pod has **not** been independently verified — this upgrade attempt itself is the canary. If the netpol is wrong the pre-upgrade hook fails again and Flux rolls back to 1.11.2 the same shape as last time (no data-plane risk). The chart's pre-upgrade-job template only adds a `LONGHORN_DISTRO` env var between 1.11.2 and 1.12.0 (verified via diff of `templates/preupgrade-job.yaml`), so the hook pod's label shape is unchanged and #3125's selector still matches.

## Release notes summary

Sources: [longhorn/longhorn v1.12.0 release notes](https://github.com/longhorn/longhorn/releases/tag/v1.12.0), [longhorn/charts longhorn-1.12.0](https://github.com/longhorn/charts/releases/tag/longhorn-1.12.0), [Upgrade docs (1.12.0)](https://longhorn.io/docs/1.12.0/deploy/upgrade/upgrading-longhorn-manager/).

### Breaking changes / removals

- **V2 Backing Image removal.** V2 Backing Images are removed in 1.12.0. V2 volumes that depend on a backing image must be backed-up-then-restored (or deleted) **before** upgrade; "attempting to upgrade without migration may result in volume attachment failures" — verbatim from the release notes. Source: [v1.12.0 release notes "Removal" / longhorn#13181](https://github.com/longhorn/longhorn/releases/tag/v1.12.0). **N/A here** — we do not use V2 backing images (see cluster-state evidence below).
- **Downgrade prevention is permanent.** "Once you successfully upgrade to v1.12.0, you will not be allowed to revert to the previously installed version." — verbatim from the [1.12.0 upgrade guide](https://longhorn.io/docs/1.12.0/deploy/upgrade/). If the data-plane upgrade goes sideways post-pre-upgrade-hook, the rollback path is restore-from-backup, not chart-version revert.
- **Kubernetes ≥ v1.25 required** to upgrade from 1.11.x to 1.12.0 ([upgrade docs "Installation"/"Upgrade" notes](https://longhorn.io/docs/1.12.0/deploy/upgrade/)). Already satisfied (we run k3s v1.36.1).
- **Encrypted-volume engine-image constraint.** Encrypted migratable volumes now require engine image CLI API version ≥ 12; live migration of encrypted volumes is unsupported on older engines. Source: [longhorn#9205](https://github.com/longhorn/longhorn/issues/9205). N/A here — we have no encrypted volumes (all 27 volumes report `spec.encrypted=false`).

### Deprecations

- The upstream upgrade guide explicitly states "**There are no deprecated or incompatible changes introduced in v1.12.0.**" — verbatim from [docs/1.12.0/deploy/upgrade/](https://longhorn.io/docs/1.12.0/deploy/upgrade/).
- The release notes do flag two **experimental** features that remain experimental and should not be relied on:
  - **UBLK frontend for V2** — only functional on Linux kernel < 6.17; `EINVAL` on ≥ 6.17 ([longhorn#11977](https://github.com/longhorn/longhorn/issues/11977)). N/A — V2 disabled.
  - **Sharding Storage (Experimental)** is roadmap for 1.12.1, not 1.12.0 ([longhorn#1061](https://github.com/longhorn/longhorn/issues/1061)).

### New features

- **V2 Data Engine — Generally Available.** "We are pleased to announce that the V2 Data Engine has officially graduated to General Availability" — verbatim. V2 still does not support live upgrades between 1.12 patch releases ("V2 volumes do not support live upgrades between Longhorn v1.12 patch releases and must be detached before upgrading"). Source: [1.12.0 release notes "V2 Data Engine"](https://github.com/longhorn/longhorn/releases/tag/v1.12.0). N/A operationally — `v2-data-engine` setting is `false`.
- **Topology-aware PV node affinity control** via the `csi-allowed-topology-keys` setting and the `strictTopology` StorageClass parameter ([longhorn#12684](https://github.com/longhorn/longhorn/issues/12684)).
- **IPv6 support for V2 volumes** ([longhorn#10928](https://github.com/longhorn/longhorn/issues/10928)) and **dual-stack cluster support** for V1 and V2, with the caveat that "Dual-stack clusters with mixed IP family ordering across nodes are not supported" — verbatim ([longhorn#11531](https://github.com/longhorn/longhorn/issues/11531)).
- **`longhornctl` on-demand snapshot checksum calculation** ([longhorn#11442](https://github.com/longhorn/longhorn/issues/11442)).
- **Toggle for Kubernetes Metrics Server integration** via the new `kubernetes-metrics-server-metrics-enabled` setting; "reduces repeated scrape warnings and unnecessary API calls when the Kubernetes Metrics Server API is unavailable" ([longhorn#13011](https://github.com/longhorn/longhorn/issues/13011)).
- **Configurable engine-image DaemonSet liveness probe** (`engineImagePodLivenessProbe{Period,Timeout,FailureThreshold}` Helm values, all default `~`) "to reduce unnecessary engine-image pod restarts on resource-constrained clusters" ([longhorn#12846](https://github.com/longhorn/longhorn/issues/12846)).
- **Helm: optional `persistence.annotations`, `persistence.shareManagerNodeSelector`, `persistence.shareManagerTolerations`, `persistence.createStorageClass`, `metrics.serviceMonitor.sampleLimit`** added as additive defaults. None are required; we don't set any of them.

### Behavioural changes

- **Default `data-engine-cpu-mask` changes from `0x1` (1 core) to `0x3` (2 cores)** for V2. Single-core master-reactor model "can delay or starve RPC processing, resulting in increased latency, timeout events, and operational instability" — verbatim ([longhorn#13237](https://github.com/longhorn/longhorn/issues/13237)). N/A here — V2 disabled and our current setting (`{"v2":"0x1"}`) is unused.
- **`global.imageRegistry` default flips from `"docker.io"` to `""`** in `values.yaml`. Fix for [longhorn#12685](https://github.com/longhorn/longhorn/issues/12685) ("`global.imageRegistry: 'docker.io'` default always wins"). Per-image `registry: ""` paths now resolve to docker.io implicitly via Helm template logic. We do not override `global.imageRegistry`, so this is transparent (images continue pulling from docker.io).
- **Encrypted volume size correction** — LUKS2's 16 MiB header is now pre-allocated in the replica backend, so dm-crypt exposes the full requested size after engine upgrade ([longhorn#9205](https://github.com/longhorn/longhorn/issues/9205)). N/A — no encrypted volumes.
- **`longhorn-manager` informer caching is optimised** to reduce cluster-wide memory in clusters with many non-Longhorn pods ([longhorn#12771](https://github.com/longhorn/longhorn/issues/12771)). Pure improvement.
- **`longhornManager.distro` Helm value added (default `"longhorn"`)** — surfaced as `LONGHORN_DISTRO` env var on manager/pre-upgrade pods for upgrade-responder reporting ([longhorn#13160](https://github.com/longhorn/longhorn/issues/13160), [longhorn#12778](https://github.com/longhorn/longhorn/issues/12778)). Informational only.

### Critical stability fixes

- **Instance-manager nil-pointer panic during replica rebuild storms** — "could terminate all iSCSI targets served by the instance-manager and trigger cascading volume detachments across multiple PVCs" ([longhorn#13087](https://github.com/longhorn/longhorn/issues/13087)). Directly relevant to V1 — this is a meaningful stability win for us.
- **Replica auto-balance scheduling loop fix** for `best-effort` mode ([longhorn#12926](https://github.com/longhorn/longhorn/issues/12926)). N/A — `replica-auto-balance=disabled` here.
- **Replica CR leak during failed local scheduling** when `dataLocality=best-effort` ([longhorn#13152](https://github.com/longhorn/longhorn/issues/13152)). N/A — `default-data-locality=disabled` here.
- **CSI storage-capacity tracking fix** for compute-only nodes returning 0 capacity ([longhorn#12807](https://github.com/longhorn/longhorn/issues/12807)). N/A — `csi-storage-capacity-tracking=false` here.

## Upgrade prerequisites

Drawn from [longhorn.io/docs/1.12.0/deploy/upgrade/](https://longhorn.io/docs/1.12.0/deploy/upgrade/) and [.../upgrade/longhorn-manager/](https://longhorn.io/docs/1.12.0/deploy/upgrade/upgrading-longhorn-manager/) "Manual Checks Before Upgrade" and "Preparing for the Upgrade" sections.

| # | Upstream prerequisite | Status here |
|---|---|---|
| 1 | Source version must be in the v1.11.x line (no version skipping; 1.5+ enforces this) | **Satisfied** — currently on `v1.11.2` (`kubectl get hr longhorn -n longhorn-system -o jsonpath='{.spec.chart.spec.version}'` → `1.11.2`; `current-longhorn-version` setting → `v1.11.2`) |
| 2 | Kubernetes ≥ v1.25 | **Satisfied** — `kubectl version` reports server `v1.36.1+k3s1` |
| 3 | All V2 Data Engine volumes detached and replicas stopped (V2 has no live upgrade) | **Satisfied (N/A)** — `v2-data-engine` setting is `false`; every volume reports `spec.dataEngine=v1` |
| 4 | V2 volumes that use backing images must be backup-restored or deleted before upgrade ("attempting to upgrade without migration may result in volume attachment failures") | **Satisfied (N/A)** — `kubectl -n longhorn-system get backingimages.longhorn.io` returns `No resources found`; no V2 volumes exist |
| 5 | No "Faulted" volumes | **Satisfied** — 26/26 volumes `state=attached`, `robustness=healthy` (see cluster-state evidence) |
| 6 | No failed BackingImages | **Satisfied (N/A)** — no BackingImages at all |
| 7 | Don't change default StorageClass parameters in the Helm values (changes can cause chart upgrade failure) | **Satisfied** — our HelmRelease only sets `defaultSettings.backupTarget`, `longhornUI.replicas`, and `metrics.serviceMonitor.enabled`; we do not touch `persistence.*` parameters |
| 8 | (Recommended) Create a Longhorn system backup before upgrade | **Deliberately deferred** — recurring per-volume backups to NFS continue running (we keep the standard recurring-job configuration). A full Longhorn system backup is recommended but not required by the upgrade flow itself; the rollback story for a hook failure is already "Flux rolls back to 1.11.2 cleanly" (proven by #3122). If the data-plane upgrade itself fails post-hook, recovery is per-volume restore-from-NFS, not system-level rollback. |

No prerequisite requires a separate prior PR. No removed/renamed Helm values affect our HelmRelease (verified by `diff` of `charts/longhorn/values.yaml` between `longhorn-1.11.2` and `longhorn-1.12.0` — all changes are additive new defaults plus image-tag bumps).

## Cluster-state evidence

`kubectl version` (server):
```
Server Version: v1.36.1+k3s1
```

`kubectl get hr longhorn -n longhorn-system -o jsonpath='{.spec.chart.spec.version}'`:
```
1.11.2
```

HelmRelease readiness:
```
Ready  UpgradeSucceeded  Helm upgrade succeeded for release longhorn-system/longhorn.v51 with chart longhorn@1.11.2
```

`kubectl get kustomization -n flux-system cluster-apps-longhorn`:
```
Ready=True  Applied revision: main@sha1:70bfdf5c5c723c3fed51426db3f79e593cb761a7
```

Volume health (`kubectl -n longhorn-system get volumes.longhorn.io`, grouped):
```
state=attached, count=26  (1 PV is Detached because its workload is offline; no Faulted volumes)
robustness=healthy, count=26
spec.encrypted=false for all 27
spec.dataEngine=v1 for all 27
```

Node health (`kubectl -n longhorn-system get nodes.longhorn.io`):
```
NAME    READY   ALLOWSCHEDULING   SCHEDULABLE   AGE
node0   True    true              True          318d
node1   True    true              True          318d
node2   True    true              True          318d
node3   True    true              True          2y251d
```

Engine images (`kubectl -n longhorn-system get engineimages.longhorn.io`):
```
NAME          INCOMPATIBLE   STATE      IMAGE                                          REFCOUNT
ei-c9fa6d45   false          deployed   docker.io/longhornio/longhorn-engine:v1.11.2   130
```

V2 / backing-image state:
```
$ kubectl -n longhorn-system get backingimages.longhorn.io
No resources found in longhorn-system namespace.

$ kubectl -n longhorn-system get settings.longhorn.io v2-data-engine -o jsonpath='{.value}'
false
```

Netpol fix from #3125 live and matching the hook-pod selector:
```
networkpolicy.networking.k8s.io/longhorn-helm-hook-allow-k8s-api    job-name in (longhorn-post-upgrade,longhorn-pre-upgrade,longhorn-uninstall)
ciliumnetworkpolicy.cilium.io/longhorn-helm-hook-allow-kube-apiserver    Valid=True
```

## Rollback plan

If the pre-upgrade hook fails the same way as in #3106, Flux will mark the HelmRelease `UpgradeFailed` and roll back to 1.11.2 automatically (already proven by #3122's history — the data-plane was never disrupted across those retries). The Kustomization will go `Ready=False` again, which gates the same ~17 downstream HRs (overseerr, plex, jellyfin, home-assistant, etc.). In that case: revert this PR with a one-line revert (same shape as #3122) and treat any remaining netpol gap as a follow-up issue. The downgrade-prevention warning in the upstream notes (`v1.12.0 → v1.11.2 not supported`) only applies if the upgrade **succeeds** past the pre-upgrade hook and then later fails; a pre-upgrade-hook failure leaves the cluster on 1.11.2 throughout.

## Post-merge verification

After Flux reconciles, run:

```bash
# 1. HelmRelease succeeded on 1.12.0
kubectl -n longhorn-system get hr longhorn -o jsonpath='{.status.conditions[?(@.type=="Ready")].message}{"\n"}'
# expect: "Helm upgrade succeeded for release longhorn-system/longhorn.v52 with chart longhorn@1.12.0"

# 2. Kustomization back to Ready=True
kubectl get kustomization -n flux-system cluster-apps-longhorn

# 3. longhorn-manager pods on v1.12.0
kubectl -n longhorn-system get pods -l app=longhorn-manager \
  -o jsonpath='{range .items[*]}{.metadata.name}{"  "}{.spec.containers[0].image}{"\n"}{end}'
# expect: all 4 on longhornio/longhorn-manager:v1.12.0

# 4. Engine image v1.12.0 deployed and old v1.11.2 still healthy (engine live-upgrade is supported 1.11→1.12, but volumes keep running on v1.11.2 until manually/auto-upgraded)
kubectl -n longhorn-system get engineimages.longhorn.io

# 5. No Degraded volumes after upgrade
kubectl -n longhorn-system get volumes.longhorn.io \
  -o custom-columns=NAME:.metadata.name,STATE:.status.state,ROBUSTNESS:.status.robustness \
  | grep -vE 'healthy|^NAME' || echo "all healthy"

# 6. Instance-manager pods rolled to v1.12.0
kubectl -n longhorn-system get pods -l longhorn.io/component=instance-manager \
  -o jsonpath='{range .items[*]}{.metadata.name}{"  "}{.spec.containers[0].image}{"\n"}{end}'

# 7. current-longhorn-version setting updated
kubectl -n longhorn-system get settings.longhorn.io current-longhorn-version -o jsonpath='{.value}{"\n"}'
# expect: v1.12.0
```

Per-volume engines stay on `v1.11.2` until manually or auto-upgraded via the Longhorn UI — that is the upstream-documented two-step pattern (manager upgrade → engine upgrade) and is out of scope for this PR.

## References

- #3106 — original failing 1.12.0 bump
- #3122 — revert to 1.11.2
- #3124 — root-cause issue for the netpol gap
- #3125 — netpol fix that unblocks this re-attempt
- [longhorn/longhorn v1.12.0 release notes](https://github.com/longhorn/longhorn/releases/tag/v1.12.0)
- [Longhorn 1.12.0 upgrade guide](https://longhorn.io/docs/1.12.0/deploy/upgrade/) / [Upgrading Longhorn Manager](https://longhorn.io/docs/1.12.0/deploy/upgrade/upgrading-longhorn-manager/)
