### PR TITLE
revert: rancher/system-upgrade-controller v0.20.0 → v0.19.2 (#3178)

### DIFF
--- a/kubernetes/cluster0/apps/system-upgrade/system-upgrade-controller/app/kustomization.yaml
+++ b/kubernetes/cluster0/apps/system-upgrade/system-upgrade-controller/app/kustomization.yaml
@@ -3,11 +3,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 # renovate: datasource=github-releases depName=rancher/system-upgrade-controller
-  - https://github.com/rancher/system-upgrade-controller/releases/download/v0.20.0/crd.yaml
-  - https://github.com/rancher/system-upgrade-controller?ref=v0.20.0
+  - https://github.com/rancher/system-upgrade-controller/releases/download/v0.19.2/crd.yaml
+  - https://github.com/rancher/system-upgrade-controller?ref=v0.19.2
 images:
   - name: rancher/system-upgrade-controller
-    newTag: v0.20.0@sha256:c47e2e839e3ea7c622e76e0f406071518885dbc6791062615cfa24798104a268
+    newTag: v0.19.2@sha256:34fa058fe453da2e1d6cf9052d2961976d5c7294921f8a6a6fb75098a27b0e89
 patches:
   - patch: |
       $patch: delete


### PR DESCRIPTION
## Why

#3178 bumped `rancher/system-upgrade-controller` from `v0.19.2` → `v0.20.0`,
but **`v0.20.0` is not a real GitHub release / git tag.** The latest real
releases upstream are `v0.20.0-rc.1` and `v0.19.2`. Renovate's
`docker` datasource picked up a Docker Hub image tag (presumably a
pre-release pushed without a corresponding GitHub release) and bumped the
`renovate: datasource=github-releases` line alongside it. The result was a
kustomization referencing URLs that 404:

- `https://github.com/rancher/system-upgrade-controller/releases/download/v0.20.0/crd.yaml` → **404**
- `https://github.com/rancher/system-upgrade-controller?ref=v0.20.0` → **ref does not resolve, no such tag**

This breaks `flux build` (called by `flux-local test`) on the
`cluster-apps-system-upgrade-controller` Kustomization — kustomize
misclassifies the 404 HTML response from GitHub as "URL is a git
repository", which is a confusing error if you don't already know what's
wrong. Crucially, **this is currently failing CI on every open Renovate PR**,
because they all carry the v0.20.0 base.

## What

Inverts #3178 — restores the three references to `v0.19.2` and pins the
image back to the digest that was in `main` before the bump:

- `releases/download/v0.20.0/crd.yaml` → `v0.19.2/crd.yaml`
- `?ref=v0.20.0` → `?ref=v0.19.2`
- `v0.20.0@sha256:c47e2e83…2615cfa24798104a268` → `v0.19.2@sha256:34fa058f…6fb75098a27b0e89`

## Verification

Could not run `flux-local test` in this agent sandbox (no cgroup mount →
podman rootless fails to start), so verification was done by checking the
referenced URLs directly:

```
v0.20.0 crd.yaml          → 404
v0.20.0 archive (tag)     → 404 (no such tag)
v0.19.2 crd.yaml          → 200
v0.19.2 archive (tag)     → 200
```

The image digest matches `git show 79392aada^:…/kustomization.yaml` (i.e.
exactly the state of `main` before #3178 landed).

## Follow-up (out of scope here)

Renovate's `github-releases` datasource shouldn't have matched `v0.20.0`
when no such GitHub release exists — there's likely a config tweak needed
(strict tag-existence check, or downgrading docker-driven bumps from
"replace" to "in-range" semantics for github-releases-pinned packages).
That's a separate concern from this revert.

Reverts #3178.
