### PR TITLE
chore(deps): update helm release traefik to v41 (with v41 values migration)

### DIFF
--- a/kubernetes/cluster0/apps/networking/traefik/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/networking/traefik/app/helm-release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: traefik
-      version: 40.3.0
+      version: 41.0.0
       sourceRef:
         kind: HelmRepository
         name: traefik-charts
@@ -104,8 +104,7 @@ spec:
           tls:
             enabled: true
             options: "default"
-    logs:
-      general:
-        level: "INFO"
-      access:
-        enabled: true
+    log:
+      level: "INFO"
+    accessLog:
+      enabled: true


### PR DESCRIPTION
Bumps the [traefik](https://github.com/traefik/traefik-helm-chart) Helm chart from `40.3.0` → `41.0.0` and migrates the values in `kubernetes/cluster0/apps/networking/traefik/app/helm-release.yaml` to v41's new schema.

Supersedes #3174 — Renovate's PR was chart-bump-only, so CI failed on the v41 schema. This PR does the bump _and_ the values migration in one commit.

## Value-key migrations performed

Per upstream chart PR [traefik/traefik-helm-chart#1887](https://github.com/traefik/traefik-helm-chart/pull/1887) (logs syntax aligned with upstream Traefik):

| v40 key | v41 key |
|---|---|
| `logs.general.level: "INFO"` | `log.level: "INFO"` |
| `logs.access.enabled: true` | `accessLog.enabled: true` |

That's the full delta for this release — the other v41 breaking changes don't apply here:

- **`providers.file.content` (string → object)**: we don't use the file provider, only `kubernetesCRD` / `kubernetesIngress` / `kubernetesGateway`.
- **`image.registry` / `image.repository` defaulting to `null`**: we don't set either, so the chart's auto-resolution kicks in unchanged.
- **Filter / field key camelCasing** (`statuscodes` → `statusCodes`, `defaultmode` → `defaultMode`, removal of `fields.general` nesting): we don't configure `accessLog.filters` or `accessLog.fields`, so nothing to rename.

## Validation

Rendered locally against the v41 chart pulled fresh from `helm.traefik.io/traefik`:

```
$ helm template traefik ./traefik-v41-chart/traefik -f values.yaml --namespace networking | grep -E '\-\-log|\-\-accesslog|\-\-api'
- --api.dashboard=true
- --log.level=INFO
- --accesslog=true
- --accesslog.fields.defaultmode=keep
- --accesslog.fields.headers.defaultmode=drop
- --api.insecure=true
```

`helm lint` against the same chart + values: `0 chart(s) failed`.

Also verified the **negative case**: feeding the old `logs.general.level` / `logs.access.enabled` keys to the v41 chart silently drops them (no `--log.level` / `--accesslog` flags emitted), confirming the migration was necessary to keep access logs on through the upgrade.

`flux-local test` wasn't run from the agent sandbox (no cgroup support for rootless podman in this environment).

## Upstream release notes

https://github.com/traefik/traefik-helm-chart/releases/tag/v41.0.0

Closes #3174
