### PR TITLE
plex: manage config PVC via repo on dynamic longhorn SC

### DIFF
--- a/kubernetes/cluster0/apps/media/plex/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/plex/app/helm-release.yaml
@@ -188,7 +188,7 @@ spec:
 
     persistence:
       config:
-        existingClaim: pvc-plex0
+        existingClaim: pvc-plex
         advancedMounts:
           main:
             app:

--- a/kubernetes/cluster0/apps/media/plex/app/kustomization.yaml
+++ b/kubernetes/cluster0/apps/media/plex/app/kustomization.yaml
@@ -3,6 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helm-release.yaml
+  - ./pvc.yaml
   - ./probe.yaml
 labels:
   - pairs:

--- a/kubernetes/cluster0/apps/media/plex/app/pvc.yaml
+++ b/kubernetes/cluster0/apps/media/plex/app/pvc.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-plex
+  namespace: media
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn
+  resources:
+    requests:
+      storage: 100Gi


### PR DESCRIPTION
## Background

The original `pvc-plex0` Longhorn volume became unrecoverable after a
cluster-wide ext4 `metadata_csum` feature-flag migration issue (the feature
was enabled on populated filesystems without rewriting structures to carry
checksum fields). Forensic recovery via `lost+found` surfaced the SQLite
library/blobs DBs but PRAGMA verification was inconclusive, so the decision
was made to nuke the volume and start fresh.

The Longhorn volume backing `pvc-plex0` has already been deleted
out-of-band by the operator.

While rebuilding from scratch, we're also switching off the historical
out-of-band `longhorn-static` PVC pattern and bringing Plex's config
persistence into the repo on the dynamic `longhorn` storage class, renamed
to `pvc-plex` to match repo conventions (`pvc-jellyfin`, `pvc-sonarr`, etc. —
drop the trailing `0`).

## Change summary

- **New** `kubernetes/cluster0/apps/media/plex/app/pvc.yaml` — defines
  `PersistentVolumeClaim/pvc-plex` in namespace `media`
  (`accessModes: [ReadWriteOnce]`, `storageClassName: longhorn`,
  `resources.requests.storage: 100Gi`).
- **Edit** `kubernetes/cluster0/apps/media/plex/app/kustomization.yaml`
  — registers `./pvc.yaml` in the `resources:` list alongside the existing
  `helm-release.yaml` and `probe.yaml`.
- **Edit** `kubernetes/cluster0/apps/media/plex/app/helm-release.yaml`
  — `persistence.config.existingClaim` switched from `pvc-plex0` to
  `pvc-plex`.

`kustomize build kubernetes/cluster0/apps/media/plex/app` exits 0 and
emits both `PersistentVolumeClaim/pvc-plex` and `HelmRelease/plex` (plus
the existing `Probe/plex`). No `pvc-plex0` references remain anywhere
under `kubernetes/cluster0/apps/media/plex/`.

## Operator action required before merge / Flux reconciliation

The orphaned `pvc-plex0` `PersistentVolumeClaim` and its bound
`PersistentVolume` object still exist in Kubernetes (only the Longhorn
volume itself was deleted). **Please clean those up out-of-band** before
Flux reconciles this change — otherwise they'll linger as stranded
resources. The new `pvc-plex` name doesn't collide with anything, but
tidiness matters.

## Post-merge steps (operator)

1. Confirm Flux has reconciled and the new `pvc-plex` PVC is `Bound` on
   the `longhorn` storage class.
2. Scale Plex up.
3. Re-claim the server via plex.tv.
4. Re-add libraries pointing at the existing NFS mounts
   (`/movies`, `/tv`, `/music`).
5. Let Plex re-scan the NFS-mounted media (this will take a while —
   expect re-download of metadata/posters since the library DB was lost
   with the old volume).
