### PR TITLE
feat(media): migrate overseerr to seerr

### DIFF
--- a/kubernetes/cluster0/apps/media/overseerr/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/overseerr/app/helm-release.yaml
@@ -24,16 +24,31 @@ spec:
     remediation:
       retries: 5
   values:
+    defaultPodOptions:
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
     controllers:
       main:
         containers:
           app:
             image:
-              repository: ghcr.io/sct/overseerr
-              tag: 1.35.0@sha256:6197516c9d7b58ccf113455e32aafb94df5d91995fe50e8c2cae6ba6c7c7b7de
+              repository: ghcr.io/seerr-team/seerr
+              tag: v3.3.0@sha256:c92d2dc117f62185e7bcb88cd56efd374ea79210eaf433275449e8d5988eb5a8
             env:
               TZ: "${TIMEZONE}"
               LOG_LEVEL: "info"
+            securityContext:
+              runAsNonRoot: true
+              runAsUser: 1000
+              runAsGroup: 1000
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              privileged: false
+              capabilities:
+                drop: ["ALL"]
+              seccompProfile:
+                type: RuntimeDefault
             resources:
               requests:
                 cpu: 100m


### PR DESCRIPTION
## Summary

Migrate the Overseerr deployment to its successor, **Seerr**, by bumping the
image to `ghcr.io/seerr-team/seerr:v3.3.0` (multi-arch index digest pinned)
and tightening the Pod/container `securityContext`.

The seerr binary auto-migrates the existing overseerr config DB on first
start (per the upstream migration guide), so this is an **in-place upgrade**:

- HelmRelease name → `overseerr`
- PVC → `pvc-overseerr`
- Service / Route / NetworkPolicies / Probe / kustomization entries → all
  remain named `overseerr`

Renaming was deliberately avoided to keep the blast radius small — sibling
manifests (`radarr`/`sonarr`/`blackbox-exporter` network policies and the
`requests.<domain>` route) all reference `overseerr` by selector/name, and
churning those in the same PR would dramatically expand the surface area.

Upstream migration guide: <http://docs.seerr.dev/migration-guide/#kubernetes>

## Changes

Only `kubernetes/cluster0/apps/media/overseerr/app/helm-release.yaml` is
modified:

- Image swap → `ghcr.io/seerr-team/seerr:v3.3.0@sha256:c92d2dc117f62185e7bcb88cd56efd374ea79210eaf433275449e8d5988eb5a8`
  (replacing `ghcr.io/sct/overseerr:1.35.0@sha256:6197516…`).
- Pod-level `defaultPodOptions.securityContext`: `fsGroup: 1000`,
  `fsGroupChangePolicy: OnRootMismatch` — re-chowns the existing PVC
  contents (currently owned by root from the sct/overseerr image) to
  GID 1000 on first mount, so seerr's non-root UID can read/write the
  config volume without a manual `chown` step.
- Container-level `securityContext` on `app`: `runAsNonRoot: true`,
  `runAsUser: 1000`, `runAsGroup: 1000`, `allowPrivilegeEscalation: false`,
  `capabilities.drop: [ALL]`, `readOnlyRootFilesystem: false`,
  `privileged: false`, `seccompProfile.type: RuntimeDefault`.
- Unchanged: TZ, LOG_LEVEL, port 5055, route hostname, persistence
  (`existingClaim: pvc-overseerr`), and every NetworkPolicy entry.

## ⚠️ Before merging

**Take a Longhorn snapshot of `pvc-overseerr`.** Seerr migrates the config DB
in place on first boot — if the migration goes sideways we want a quick
rollback path. Snapshot via the Longhorn UI (Volume → `pvc-overseerr` → Take
Snapshot) before approving the merge. I have **not** taken the snapshot from
this PR — it's on you.

## After merging — smoke test

Once Flux has reconciled (or after `flux reconcile source git
home-ops-cluster0`):

- [ ] `kubectl -n media get helmrelease overseerr` → `READY=True`
- [ ] `kubectl -n media get pod -l app.kubernetes.io/instance=overseerr`
      shows `1/1 Running`
- [ ] `kubectl -n media logs deploy/overseerr` (or
      `statefulset/overseerr`, whichever the chart renders) shows the
      seerr migration log line on first boot
- [ ] Blackbox probe target stays green in Prometheus / Grafana
- [ ] <https://requests.${SECRET_PUBLIC_DOMAIN}> loads in a browser and
      the existing requests/library state is intact

## Out of scope

- Renaming the HelmRelease / PVC / Service / route / network policies —
  intentionally deferred.
- Manual Flux reconcile — Flux will pick this up on its normal cadence.
- Backups — handled manually by the operator (see "Before merging").
