### PR TITLE
Tighten Renovate auto-merge policy: fix Tier 1 typo, generalise minimumReleaseAge, add digest to db carve-out

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -43,6 +43,28 @@
       pinDigests: true,
     },
     {
+      // Defence-in-depth against the phantom-tag failure class: hold all
+      // docker + helm updates for 24h so upstream has time to either push
+      // the image their tag/appVersion points at, or yank a broken release
+      // before we ever see the PR. We've been bitten by this four times —
+      // seaweedfs #2862 + #3093, rancher/system-upgrade-controller #3178
+      // (broke CI for 2 days), and grafana 13.0.0 (retroactive Docker Hub
+      // delete after the bump merged).
+      //
+      // `internalChecksFilter: 'strict'` is required: without it Renovate
+      // would still open the PR and merely attach a pending status check.
+      // Strict mode defers PR creation entirely until the age threshold is
+      // met.
+      //
+      // The seaweedfs-specific 3-day hold below stays in place — Renovate
+      // takes the longer of multiple `minimumReleaseAge` values, so
+      // seaweedfs continues to wait 3 days while everything else waits 24h.
+      description: 'Hold all docker + helm updates for 24h (phantom-tag defence)',
+      matchDatasources: ['docker', 'helm'],
+      minimumReleaseAge: '24h',
+      internalChecksFilter: 'strict',
+    },
+    {
       matchDatasources: [
         'docker',
       ],

--- a/.github/renovate/automerge.json5
+++ b/.github/renovate/automerge.json5
@@ -59,7 +59,7 @@
       "description": "Never auto-merge Tier 1 critical infrastructure",
       "matchPackageNames": [
         "k3s-io/k3s",
-        "system-upgrade-controller",
+        "rancher/system-upgrade-controller",
         "rancher/k3s-upgrade",
         "cilium",
         "coredns",
@@ -94,7 +94,7 @@
         "valkey",
         "redis"
       ],
-      "matchUpdateTypes": ["major", "minor"],
+      "matchUpdateTypes": ["major", "minor", "digest"],
       "automerge": false
     },
     // Special handling for home-assistant (calendar versioning)


### PR DESCRIPTION
## Summary

Three small Renovate config changes from the Jan–Jun 2026 auto-merge audit:

1. **Fix Tier 1 carve-out typo** — `system-upgrade-controller` → `rancher/system-upgrade-controller` in `.github/renovate/automerge.json5`. The bare form did not match Renovate's actual depName, which is why three PRs slipped through the carve-out (#2781, #2784, and #3178 — the last broke CI for 2 days before being reverted by #3186). The sibling `rancher/k3s-upgrade` entry already uses the prefixed form correctly.
2. **Generalise `minimumReleaseAge: '24h'`** — apply it (plus `internalChecksFilter: 'strict'`) globally to all `docker` and `helm` datasource updates in `.github/renovate.json5`. Defence-in-depth against the phantom-tag failure class we've seen four times (seaweedfs ×2, rancher/system-upgrade-controller, grafana 13.0.0). The seaweedfs-specific 3-day rule stays — Renovate takes the longer of multiple `minimumReleaseAge` values, so seaweedfs continues to wait 3 days while everything else waits 24h.
3. **Add `"digest"` to the database carve-out** — `["major", "minor"]` → `["major", "minor", "digest"]` in `.github/renovate/automerge.json5`. Closes a stricter-than-it-behaves gap: postgres/valkey/redis digest churn was auto-merging via the global `:automergeDigest` preset despite the data-tier carve-out reading as "no auto-merge". Precedent: the seaweedfs carve-out lists `["major", "minor", "patch"]` and successfully overrides the global patch auto-merge.

## Validation

`renovate-config-validator` was not available on this host (no Node/npm toolchain; the podman storage backend is not provisioned in this worktree). Per the AC fallback ("If the tool isn't readily available, document the manual validation steps in the PR description"), I ran the following manual checks instead:

- **JSON5 syntax parse** — wrote a comment/quote-aware JSON5→JSON converter and parsed both files with `json.loads`. Both produce valid top-level objects; no stray brace, comma, or string-termination errors.
- **Schema-aware structural checks** on the parsed objects:
  - Tier 1 `matchPackageNames` contains `rancher/system-upgrade-controller` and **does not** contain the bare `system-upgrade-controller`.
  - Database carve-out `matchUpdateTypes` is exactly `["major", "minor", "digest"]`.
  - A new packageRule exists with `matchDatasources: ['docker', 'helm']`, `minimumReleaseAge: '24h'`, `internalChecksFilter: 'strict'`, and no `matchPackageNames` (i.e. it is global).
  - The seaweedfs-specific 3-day rule still exists unchanged.
- **depName verification** — confirmed against `kubernetes/cluster0/apps/system-upgrade/system-upgrade-controller/app/kustomization.yaml` line 5 (`# renovate: datasource=github-releases depName=rancher/system-upgrade-controller`).

## Acceptance Criteria

- [x] Tier 1 `matchPackageNames` contains `"rancher/system-upgrade-controller"` (not bare).
- [x] `.github/renovate.json5` sets `minimumReleaseAge: '24h'` + `internalChecksFilter: 'strict'` for the `docker` and `helm` datasources globally; the seaweedfs-specific 3-day hold is kept (longer wins).
- [x] Database carve-out `matchUpdateTypes` includes `"digest"`.
- [x] Manual validation documented above in lieu of `renovate-config-validator`.
- [x] Seaweedfs rule not broken by the global rule — still scoped to `helm` + `matchPackageNames: ['seaweedfs']`, `minimumReleaseAge: '3 days'`, and the no-automerge carve-out in `automerge.json5` is untouched.

Closes #3217
