### PR TITLE
media: allow overseerr → plex ingress on :32400

### DIFF
--- a/kubernetes/cluster0/apps/media/plex/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/plex/app/helm-release.yaml
@@ -138,6 +138,24 @@ spec:
               ports:
                 - port: 32400
                   protocol: TCP
+      # Allow overseerr → plex API calls (library lookups, request submission).
+      # Same Cilium endpoint-identity reason as allow-monitoring-ingress above:
+      # the 0.0.0.0/0 CIDR rule below doesn't match cluster-local senders.
+      allow-overseerr-ingress:
+        controller: main
+        policyTypes: [Ingress]
+        rules:
+          ingress:
+            - from:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: media
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/instance: overseerr
+              ports:
+                - port: 32400
+                  protocol: TCP
       # Intentionally open to all sources: Plex clients stream directly via the
       # LoadBalancer IP (LAN and Plex relay traffic from the internet both arrive here)
       allow-32400-ingress:


### PR DESCRIPTION
## Summary

Hubble flow logs show `overseerr media → plex media :32400` traffic being
dropped. Cilium resolves cluster-local pod-to-pod traffic by endpoint
identity, so plex's existing broad `0.0.0.0/0` ingress rule does not match
the overseerr endpoint and the connection falls through to `default-deny`.
The existing `allow-monitoring-ingress` rule in the same file already
documents this exact footgun.

This PR adds an `allow-overseerr-ingress` entry to plex's
`networkpolicies:` block, mirroring `allow-monitoring-ingress`. It permits
TCP :32400 ingress from pods in namespace `media` carrying label
`app.kubernetes.io/instance: overseerr`.

## Out of scope

- Any change to overseerr's helm-release (its egress side is already
  covered by `allow-plex-egress`).
- The separate `overseerr → world 101.98.3.x :32400` drops also visible in
  Hubble — those will be resolved by reconfiguring the Plex server
  connection inside the overseerr UI to use
  `http://plex.media.svc.cluster.local:32400` and are not part of this PR.

## Verification

After Flux reconciles:

```bash
kubectl -n media get networkpolicy | grep overseerr

hubble observe --namespace media \
  --from-label app.kubernetes.io/instance=overseerr \
  --to-label app.kubernetes.io/instance=plex \
  --verdict DROPPED --last 50
# Should be empty (or only timestamps from before the reconcile).
```

Closes #3224