### PR TITLE
chore(renovate): group flux deps and disable auto-merge for flux

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -103,6 +103,31 @@
       internalChecksFilter: 'strict',
     },
     {
+      // Group both Flux dependencies into a single PR. The Flux version is
+      // carried in two places that Renovate tracks independently:
+      //   - `kubernetes/cluster0/bootstrap/flux/kustomization.yaml` — Kustomize
+      //     `?ref=vX.Y.Z` on `github.com/fluxcd/flux2/manifests/install`
+      //     (datasource: github-tags, manager: kustomize, package: fluxcd/flux2).
+      //   - `kubernetes/cluster0/flux/config/flux.yaml` — OCIRepository with
+      //     `ref.tag: "vX.Y.Z"` on `oci://ghcr.io/fluxcd/flux-manifests`
+      //     (datasource: docker, manager: flux, package:
+      //     ghcr.io/fluxcd/flux-manifests).
+      //
+      // These must always move in lockstep — one is what a fresh cluster
+      // installs on bootstrap, the other is what the running cluster
+      // reconciles against. Drift between them means a rebuild would install
+      // a different Flux version than what's running. Without this group,
+      // Renovate opens two separate PRs and rate-limiting can land one
+      // without the other (as happened around PR #3228).
+      description: 'Group Flux (bootstrap kustomize + OCIRepository) into one PR',
+      matchPackageNames: [
+        'fluxcd/flux2',
+        'ghcr.io/fluxcd/flux-manifests',
+      ],
+      groupName: 'flux',
+      groupSlug: 'flux',
+    },
+    {
       // Flux manager + OCIRepository hybrid digest shape is broken:
       // Renovate writes `tag: <semver>@sha256:<digest>` instead of populating
       // the separate `ref.digest` field (renovatebot/renovate#42082). flux-local

--- a/.github/renovate/automerge.json5
+++ b/.github/renovate/automerge.json5
@@ -63,7 +63,9 @@
         "rancher/k3s-upgrade",
         "cilium",
         "coredns",
-        "traefik"
+        "traefik",
+        "fluxcd/flux2",
+        "ghcr.io/fluxcd/flux-manifests"
       ],
       "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest"],
       "automerge": false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,7 +143,7 @@ gh issue edit <number>
   minor updates auto-merge for Docker images and Helm charts; all GitHub
   Actions updates auto-merge. Carve-outs that always require a human:
   Tier 1 infrastructure (k3s, system-upgrade-controller, rancher/k3s-upgrade,
-  cilium, coredns, traefik) on any update type; Tier 2 infrastructure
+  cilium, coredns, traefik, flux) on any update type; Tier 2 infrastructure
   (cert-manager, trust-manager, cloudnative-pg, external-dns,
   kube-prometheus-stack, longhorn, plus the Tier 1 list) on major/minor;
   databases (postgres*, valkey, redis) on major/minor; home-assistant


### PR DESCRIPTION
Closes #3233.

## Why

Flux carries its version in **two** files that Renovate treats as independent
dependencies (different package names, datasources, and managers), so a single
logical Flux upgrade opens **two separate PRs**:

| File | Renovate sees |
|---|---|
| `kubernetes/cluster0/bootstrap/flux/kustomization.yaml` | `fluxcd/flux2` (datasource: `github-tags`, manager: `kustomize`) — Kustomize `?ref=vX.Y.Z` on `github.com/fluxcd/flux2/manifests/install` |
| `kubernetes/cluster0/flux/config/flux.yaml` | `ghcr.io/fluxcd/flux-manifests` (datasource: `docker`, manager: `flux`) — `OCIRepository` with `ref.tag: "vX.Y.Z"` on `oci://ghcr.io/fluxcd/flux-manifests` |

The two must always move together — one is what a fresh cluster installs on
**bootstrap**, the other is what the running cluster **reconciles against**.
Drift between them means a rebuild would install a different Flux version than
what's running.

This drift actually landed just before the issue was filed: PR #3228 bumped the
bootstrap file from v2.8.8 → v2.9.0 while the `ghcr.io/fluxcd/flux-manifests`
bump sat in Renovate's rate-limit queue.

## Package-name verification

Per issue #3233's AC, package names were verified against Renovate's own PR
titles rather than guessed:

- **`fluxcd/flux2`** — confirmed by PR #3228's title
  `chore(deps): update dependency fluxcd/flux2 to v2.9.0` (`update dependency
  <name>` is Renovate's standard template for the github-tags datasource, and
  `<name>` is the `depName` verbatim).
- **`ghcr.io/fluxcd/flux-manifests`** — confirmed by merged PR #3024's title
  `chore(deps): update container image ghcr.io/fluxcd/flux-manifests to v2.8.8`
  (`update container image <name>` is Renovate's standard template for the
  docker datasource with a fully-qualified registry). Also independently
  confirmed by the earlier PR #2911 (v2.8.7 bump) with the same title shape.

## What changes

1. **Group the two Flux packages into a single Renovate PR.** New
   `packageRules` entry in `.github/renovate.json5` matches both
   `fluxcd/flux2` and `ghcr.io/fluxcd/flux-manifests` and assigns them
   `groupName: 'flux'` (with `groupSlug: 'flux'` to keep branch names short
   and stable). Future Flux bumps will open as one PR touching both files.

2. **Never auto-merge Flux.** Both packages are added to the existing Tier 1
   never-auto-merge rule in `.github/renovate/automerge.json5`, alongside
   `k3s-io/k3s`, `rancher/system-upgrade-controller`, `rancher/k3s-upgrade`,
   `cilium`, `coredns`, and `traefik`. Coverage spans `major`, `minor`,
   `patch`, `pin`, and `digest` updates.

3. **Docs.** `AGENTS.md`'s Renovate Configuration bullet extends the Tier 1
   roster to include `flux`.

### Note on scope vs. issue #3233

Issue #3233 declared "auto-merge policy changes" out of scope with the
rationale *"Flux is Tier 1, always human-reviewed."* That assumption was
factually inaccurate — Flux was **not** in the Tier 1 rule prior to this
change, so patch updates on either package (and Docker minor updates on
`flux-manifests`) would previously have auto-merged per the top-level
"Auto-merge patch updates" and "Auto-merge minor updates for Docker images"
rules. Ben confirmed the scope expansion in the spawn prompt for this
worker: add Flux to Tier 1 alongside the grouping change so we don't leave
the (incorrect) status quo behind. Both AGENTS.md's Tier 1 roster and the
`automerge.json5` rule are updated together to keep the docs in sync with
the config.

## Interaction with existing rules

- The 24h phantom-tag hold on `matchDatasources: ['docker', 'helm']` continues
  to apply to `ghcr.io/fluxcd/flux-manifests` (docker datasource). Group PRs
  use "AND" semantics — the grouped PR won't open until the OCI image has
  aged past 24h, at which point both refs bump together. This matches the
  behaviour called out in issue #3233's "Interaction with existing rules"
  section.
- The new rule's `matchPackageNames` uses exact string matches (no
  `/regex/` slashes), so no other `fluxcd/*` package could accidentally
  fall into the group.

## Scope (unchanged)

Config-only change; applies to **future Renovate runs**. This PR intentionally
does **not** touch:

- PR #3228 (already-open bootstrap bump)
- The queued `flux-manifests` branch in Renovate's rate-limit slot
- Pre-existing `matchPackagePatterns` uses elsewhere in
  `.github/renovate/automerge.json5` (separate cleanup)

## Verification

- `renovate-config-validator` exits 0 against `.github/renovate.json5`,
  `.github/renovate/automerge.json5`, and `.github/renovate/labels.json5`
  (`INFO: Config validated successfully against 3 file(s)`). Pre-existing
  `matchPackagePatterns` warnings on `linuxserver/qbittorrent` and
  `linuxserver/calibre-web` are unrelated and explicitly out of scope.
- Both JSON5 files parse cleanly.
- New rule uses `matchPackageNames` (not deprecated `matchPackagePatterns`),
  matching neighbouring modern-style rules.
- Existing rules and comments preserved verbatim.
