### PR TITLE
chore(renovate): exempt ghcr.io/fluxcd/flux-manifests from 24h phantom-tag hold

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -65,6 +65,38 @@
       internalChecksFilter: 'strict',
     },
     {
+      // Exempt ghcr.io/fluxcd/flux-manifests from the 24h phantom-tag hold.
+      //
+      // Why this is safe / necessary:
+      //   (a) The OCI artifact publishes no release timestamp. Renovate
+      //       runs with the default `minimumReleaseAgeBehaviour=timestamp-required`,
+      //       so a missing timestamp is treated as "gate not yet cleared"
+      //       — the release is marked pending forever and no PR is ever
+      //       opened. Evidence from workflow run 28684588597:
+      //           DEBUG: Marking 1 release(s) as pending, as they do not
+      //             have a releaseTimestamp and we're running with
+      //             minimumReleaseAgeBehaviour=timestamp-required
+      //             "depName": "ghcr.io/fluxcd/flux-manifests"
+      //             "check": "minimumReleaseAge"
+      //   (b) The 24h phantom-tag defence exists to protect auto-merged
+      //       updates. flux is listed in Tier 1 of
+      //       .github/renovate/automerge.json5, which disables auto-merge
+      //       for `ghcr.io/fluxcd/flux-manifests` on every update type —
+      //       so a human always eyeballs the PR before it lands, and the
+      //       age gate adds nothing here.
+      //   (c) Without this exemption the Flux lockstep group rule below
+      //       is broken in practice: the bootstrap-kustomize half
+      //       (fluxcd/flux2, github-tags datasource — not gated) opens
+      //       alone while the OCIRepository half stays permanently
+      //       pending, so the two halves can never bundle into a single
+      //       PR. Observed on PR #3235 (branch prismatic-bot/flux), which
+      //       contains only the v2.8.8 → v2.9.0 kustomize bump.
+      description: 'Exempt ghcr.io/fluxcd/flux-manifests from the 24h phantom-tag hold (no releaseTimestamp; Tier 1 never auto-merges; unblocks the flux lockstep group)',
+      matchDatasources: ['docker'],
+      matchPackageNames: ['ghcr.io/fluxcd/flux-manifests'],
+      minimumReleaseAge: null,
+    },
+    {
       matchDatasources: [
         'docker',
       ],


### PR DESCRIPTION
## Summary

Adds a Renovate package rule that exempts `ghcr.io/fluxcd/flux-manifests` (docker datasource) from the repository-wide 24h `minimumReleaseAge` phantom-tag hold in `.github/renovate.json5`.

## Root cause

The repo holds all docker + helm updates for 24h as a phantom-tag defence:

```json5
{
  description: 'Hold all docker + helm updates for 24h (phantom-tag defence)',
  matchDatasources: ['docker', 'helm'],
  minimumReleaseAge: '24h',
  internalChecksFilter: 'strict',
},
```

The `ghcr.io/fluxcd/flux-manifests` OCI artifact publishes **no release timestamp**. Renovate runs with the default `minimumReleaseAgeBehaviour=timestamp-required`, so a missing timestamp is treated as "gate not yet cleared" — every release is marked pending forever and no PR is ever opened. From workflow run [28684588597](https://github.com/prismatic-koi/home-ops/actions/runs/28684588597):

```
DEBUG: Marking 1 release(s) as pending, as they do not have a releaseTimestamp
       and we're running with minimumReleaseAgeBehaviour=timestamp-required
       "depName": "ghcr.io/fluxcd/flux-manifests"
       "check": "minimumReleaseAge"
```

This permanently breaks the "Group Flux (bootstrap kustomize + OCIRepository) into one PR" rule in the same file: group PR #3235 (branch `prismatic-bot/flux`) contains only the `fluxcd/flux2` bootstrap kustomize half and can never gain the matching `flux/config/flux.yaml` OCIRepository half. The two version markers must move in lockstep — one is what a fresh cluster installs on bootstrap, the other is what the running cluster reconciles against.

## Why this is safe

1. **The 24h defence protects auto-merged updates.** flux is Tier 1 in `.github/renovate/automerge.json5` and never auto-merges on any update type — a human always eyeballs a Flux PR before it lands. The age gate adds nothing here.
2. **The Tier 1 no-automerge carve-out is untouched** and remains the enforcement point.
3. **No other package's gate is weakened** — no global `minimumReleaseAgeBehaviour` change, seaweedfs 3-day hold and the general 24h rule stay exactly as they are.

## The change

Single new package rule in `.github/renovate.json5`, placed immediately after the 24h phantom-tag rule (later rules override earlier ones):

```json5
{
  matchDatasources: ['docker'],
  matchPackageNames: ['ghcr.io/fluxcd/flux-manifests'],
  minimumReleaseAge: null,
},
```

Includes a thorough comment block covering (a) the no-releaseTimestamp root cause, (b) the Tier 1 no-automerge rationale, and (c) the broken lockstep group with the PR #3235 reference.

## Validation

```
$ node .../renovate/dist/config-validator.js --strict --no-global .github/renovate.json5
 INFO: Validating .github/renovate.json5 as repo config
 INFO: Config validated successfully against 1 file(s)
```

Also passes as a global config (default mode).

## Expected outcome

Once merged, on the next Renovate run the OCIRepository half will no longer be held pending. PR #3235 should be regenerated (or a fresh group PR opened) containing both `fluxcd/flux2` v2.8.8 → v2.9.0 (`kubernetes/cluster0/bootstrap/flux/kustomization.yaml`) and `ghcr.io/fluxcd/flux-manifests` v2.8.8 → v2.9.0 (`kubernetes/cluster0/flux/config/flux.yaml`).
