### PR TITLE
chore(flux): drop vestigial tf-controller patches

### DIFF
--- a/kubernetes/cluster0/flux/config/flux.yaml
+++ b/kubernetes/cluster0/flux/config/flux.yaml
@@ -68,28 +68,4 @@ spec:
       target:
         kind: Deployment
         name: "(kustomize-controller|helm-controller|source-controller)"
-    - patch: |
-        - op: add
-          path: /spec/versions/1/schema/openAPIV3Schema/properties/spec/properties/eventSources/items/properties/kind/enum/-
-          value: Terraform
-      target:
-        kind: CustomResourceDefinition
-        name: alerts.notification.toolkit.fluxcd.io
-    - patch: |
-        - op: add
-          path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/resources/items/properties/kind/enum/-
-          value: Terraform
-      target:
-        kind: CustomResourceDefinition
-        name: receivers.notification.toolkit.fluxcd.io
-    - patch: |
-        - op: add
-          path: /rules/-
-          value:
-            apiGroups: ["infra.contrib.fluxcd.io"]
-            resources: ["*"]
-            verbs: ["*"]
-      target:
-        kind: ClusterRole
-        name: crd-controller-flux-system
 


### PR DESCRIPTION
The \`flux\` Kustomization in \`kubernetes/cluster0/flux/config/flux.yaml\`
carries three patches that only exist to support Weave tf-controller
(\`infra.contrib.fluxcd.io\`), which is no longer deployed in this
cluster:

1. JSON6902 add of \`Terraform\` to the \`eventSources.kind\` enum on the
   \`alerts.notification.toolkit.fluxcd.io\` CRD.
2. JSON6902 add of \`Terraform\` to the \`resources.kind\` enum on the
   \`receivers.notification.toolkit.fluxcd.io\` CRD.
3. JSON6902 add of an \`infra.contrib.fluxcd.io\` rule to the
   \`crd-controller-flux-system\` ClusterRole.

Verified vestigial:

- No \`infra.contrib.fluxcd.io\` CRDs on the cluster.
- No tf-controller / terraform Deployment in any namespace.
- No repo resources reference \`kind: Terraform\`; after this PR, the
  strings \`tf-controller\`, \`infra.contrib.fluxcd.io\`, and
  \`kind: Terraform\` appear zero times across the tree.

## Why now

Beyond removing dead weight, the alerts patch is actively blocking the
Flux v2.8.8 → v2.9.0 upgrade grouped in Renovate PR #3235. It targets
\`/spec/versions/1/...\` by positional index. v2.9.0 drops the
\`v1beta2\` version from \`alerts.notification.toolkit.fluxcd.io\`,
leaving \`versions: [v1beta3]\` — index 1 no longer exists, so the
JSON6902 add fails at reconciliation and the runtime \`flux\`
Kustomization would go into build failure. Flux Local CI does not
render the OCI-sourced flux Kustomization, so nothing catches this at
PR time; it would only surface after the flux group PR merges.

**Merge order:** this PR must land **before** #3235.

## Scope

Removes exactly the three patches above. Untouched:

- \`\$patch: delete\` NetworkPolicy patch.
- Controller args patch (\`--concurrent=8\`, \`--kube-api-qps=500\`,
  \`--kube-api-burst=1000\`, \`--requeue-dependency=5s\`).
- Resource-limits patch on
  \`(kustomize-controller|helm-controller|source-controller)\`.

## Validation

- \`yq eval '.' kubernetes/cluster0/flux/config/flux.yaml\` parses clean.
- Remaining \`spec.patches\` length: 3.
- \`git diff --stat\`: 1 file, 24 deletions, 0 insertions.
- Repo-wide grep for tf-controller / \`infra.contrib.fluxcd.io\` /
  \`kind: Terraform\` returns zero matches.