### PR TITLE
fix(cert-manager): allow DNS egress to public resolvers + drop pod-level dnsConfig

### DIFF
--- a/kubernetes/cluster0/apps/cert-manager/cert-manager/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/cert-manager/cert-manager/app/helm-release.yaml
@@ -23,14 +23,14 @@ spec:
       retries: 3
   values:
     installCRDs: true
+    # --dns01-recursive-nameservers* pins the DNS-01 *self-check* to the two
+    # public resolvers (avoiding split-horizon / stale internal views for
+    # `_acme-challenge` TXT propagation). Pod-level DNS is intentionally left
+    # at the cluster default (CoreDNS) so ACME directory + Cloudflare API
+    # lookups resolve normally. See #3291.
     extraArgs:
       - --dns01-recursive-nameservers=1.1.1.1:53,9.9.9.9:53
       - --dns01-recursive-nameservers-only
-    podDnsPolicy: "None"
-    podDnsConfig:
-      nameservers:
-        - "1.1.1.1"
-        - "9.9.9.9"
     prometheus:
       enabled: true
       servicemonitor:

--- a/kubernetes/cluster0/apps/cert-manager/cert-manager/app/network-policy.yaml
+++ b/kubernetes/cluster0/apps/cert-manager/cert-manager/app/network-policy.yaml
@@ -21,7 +21,12 @@ spec:
       app.kubernetes.io/component: controller
   policyTypes: [Ingress, Egress]
 ---
-# Allow DNS resolution to CoreDNS in kube-system
+# Allow DNS resolution to CoreDNS in kube-system, plus recursive-nameserver
+# queries to the public resolvers used for the DNS-01 self-check
+# (`--dns01-recursive-nameservers=1.1.1.1:53,9.9.9.9:53` on the controller).
+# Without the two ipBlock entries below, the DNS-01 self-check for wildcard
+# certs (e.g. `*.tinfoilforest.nz`) cannot verify `_acme-challenge` TXT
+# propagation on public DNS and renewals stall. See #3291.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -43,6 +48,10 @@ spec:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: kube-system
+        - ipBlock:
+            cidr: 1.1.1.1/32
+        - ipBlock:
+            cidr: 9.9.9.9/32
 ---
 # Allow Prometheus to scrape cert-manager controller metrics on :9402
 # ServiceMonitor "cert-manager" targets all three cert-manager components by


### PR DESCRIPTION
Closes #3291

## Summary

The `tinfoilforest-nz` wildcard cert (`*.tinfoilforest.nz`) expired on
2026-07-14 because the recent NetworkPolicy overhaul (#2951) blocks
cert-manager's egress to the public DNS resolvers it was configured to use.
ACME directory + Cloudflare API lookups time out with
`read udp ...->9.9.9.9:53: i/o timeout`, so cert-manager can never even
reach Let's Encrypt to renew.

## Changes

Both edits are in the Flux `cluster-apps-cert-manager` source under
`kubernetes/cluster0/apps/cert-manager/cert-manager/app/`:

1. **`network-policy.yaml`** — widen `cert-manager-allow-dns` to permit
   53/UDP+TCP egress to `1.1.1.1/32` and `9.9.9.9/32` in addition to the
   existing kube-system rule. Required for the DNS-01 self-check regardless
   of change 2 (the controller keeps
   `--dns01-recursive-nameservers=1.1.1.1:53,9.9.9.9:53` +
   `--dns01-recursive-nameservers-only` to pin the self-check to public
   resolvers and avoid split-horizon views of `_acme-challenge` TXT records).

2. **`helm-release.yaml`** — drop the pod-level `podDnsPolicy: "None"` +
   `podDnsConfig` block so ACME + Cloudflare API lookups resolve through
   CoreDNS (already permitted by `cert-manager-allow-dns`). Shrinks the
   DNS egress surface to just the self-check.

`cert-manager-default-deny` remains in place; no new broad egress is opened
(80/443 already handled by `cert-manager-allow-external-acme-egress`).

## Post-merge steps

Once Flux reconciles the change, nudge the stuck renewal so cert-manager
retries immediately rather than waiting on backoff:

```
flux reconcile source git home-ops-cluster0
flux reconcile helmrelease cert-manager -n cert-manager   # if needed
kubectl -n networking delete certificaterequest tinfoilforest-nz-18
kubectl -n networking delete order tinfoilforest-nz-18-3384490524   # if it still exists
kubectl -n networking describe certificate tinfoilforest-nz            # watch until Ready=True
```

## Acceptance Criteria

- [ ] [functional] The cert-manager controller pod can resolve `acme-v02.api.letsencrypt.org` — controller logs show no `i/o timeout` / `lookup ... on 9.9.9.9:53` errors after the change is applied.
- [ ] [functional] The `tinfoilforest-nz` Certificate reports `Ready=True` with a `Not After` date in the future, and its `Issuing` condition is cleared.
- [ ] [functional] A fresh Order for `tinfoilforest-nz` reaches state `valid` with a populated `Status` (ACME URL and authorizations present), and a new secret revision is written to `tinfoilforest-nz-tls`.
- [ ] [functional] The DNS-01 self-check succeeds: the challenge for `*.tinfoilforest.nz` transitions to `valid` (recursive-nameserver queries to `1.1.1.1:53`/`9.9.9.9:53` are permitted by policy).
- [ ] [security] The `cert-manager-allow-dns` NetworkPolicy permits port-53 egress only to `kube-system` and the two named recursive nameservers (`1.1.1.1/32`, `9.9.9.9/32`) - not to `0.0.0.0/0`.
- [ ] [security] `cert-manager-default-deny` remains in place; no policy is added that opens egress beyond what is required for DNS and ACME (80/443).
- [ ] [edge-case] After the fix, at least one other cert-manager-managed certificate in the cluster (e.g. `internal-root-ca` / `trust-manager`) remains `Ready=True` - confirming the policy change did not regress internal issuance.
- [ ] [functional] The fix is committed to the Flux `cluster-apps-cert-manager` source so the change survives reconciliation (verified by the resources not drifting after a Flux reconcile).