### PR TITLE
monitoring: add cert-manager certificate expiry + not-ready alerts

### DIFF
--- a/kubernetes/cluster0/apps/cert-manager/cert-manager/app/kustomization.yaml
+++ b/kubernetes/cluster0/apps/cert-manager/cert-manager/app/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ./helm-release.yaml
   - ./network-policy.yaml
   - ./cilium-network-policy.yaml
+  - ./prometheusrule.yaml
 labels:
   - pairs:
       app.kubernetes.io/name: cert-manager

--- a/kubernetes/cluster0/apps/cert-manager/cert-manager/app/prometheusrule.yaml
+++ b/kubernetes/cluster0/apps/cert-manager/cert-manager/app/prometheusrule.yaml
@@ -1,0 +1,49 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: cert-manager
+  namespace: cert-manager
+spec:
+  groups:
+    - name: cert-manager.certificates
+      rules:
+        # Fires when any cert-manager-managed Certificate has <=7 days remaining
+        # before its notAfter date. Let's Encrypt renews 30 days out, so a
+        # 7-day alert gives ~23 days of runway before anything is at risk.
+        #
+        # The expression is `expiration_timestamp - time() < 7d`; once the cert
+        # has actually expired the delta is negative (still < 7d), so the alert
+        # keeps firing rather than silently resolving on expiry.
+        - alert: CertManagerCertificateExpiringSoon
+          expr: |
+            certmanager_certificate_expiration_timestamp_seconds - time() < 7 * 24 * 3600
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Certificate {{ $labels.namespace }}/{{ $labels.name }} expires in less than 7 days"
+            description: |
+              Certificate {{ $labels.namespace }}/{{ $labels.name }} (issuer {{ $labels.issuer_name }})
+              expires at {{ $value | humanizeTimestamp }}. cert-manager should have renewed
+              this 30 days before expiry -- investigate why renewal has not completed.
+
+        # Fires when a Certificate has been Ready=False for more than an hour.
+        # cert-manager exposes ready_status as a gauge per (namespace, name,
+        # condition) triple; the "True" condition series equals 1 when Ready
+        # and 0 otherwise, so `{condition="True"} == 0` selects certs that are
+        # currently not-Ready. `for: 1h` filters out transient flips during
+        # normal issuance/renewal.
+        - alert: CertManagerCertificateNotReady
+          expr: |
+            certmanager_certificate_ready_status{condition="True"} == 0
+          for: 1h
+          labels:
+            severity: warning
+          annotations:
+            summary: "Certificate {{ $labels.namespace }}/{{ $labels.name }} has not been Ready for more than 1 hour"
+            description: |
+              Certificate {{ $labels.namespace }}/{{ $labels.name }} has been in Ready=False
+              state for more than 1 hour. Check the Certificate status and cert-manager logs
+              for issuance errors.


### PR DESCRIPTION
Adds a `PrometheusRule` to the `cert-manager` app that covers the alerting gap that let #3291 through: no notification fired when `tinfoilforest-nz` silently failed to renew.

Two warning-severity alerts are added, both routing via the existing `email` Alertmanager receiver — no Alertmanager config changes required.

## What changed

- New `kubernetes/cluster0/apps/cert-manager/cert-manager/app/prometheusrule.yaml`.
- Referenced from `kustomization.yaml` in the same directory.

### `CertManagerCertificateExpiringSoon` (severity: warning)

```
certmanager_certificate_expiration_timestamp_seconds - time() < 7 * 24 * 3600
for: 15m
```

Fires when any cert-manager-managed Certificate has ≤7 days remaining. Let's Encrypt renews 30 days before expiry, so a 7-day alert gives ~23 days of runway before anything is at risk. The expression uses a bare `< 7d` comparison — once a cert has actually expired the delta is negative (still `< 7d`), so the alert keeps firing rather than silently resolving on expiry.

`for: 15m` filters out transient scrape gaps while still delivering a full week of runway on a 7-day-out alert.

### `CertManagerCertificateNotReady` (severity: warning)

```
certmanager_certificate_ready_status{condition="True"} == 0
for: 1h
```

Covers the "cert stuck in Issuing / Ready=False" case that #3291 also demonstrates. cert-manager exposes `ready_status` as a gauge per (namespace, name, condition) triple; the `condition="True"` series equals 1 when Ready and 0 otherwise. `for: 1h` filters out transient flips during normal issuance/renewal.

## Deviations from the issue proposal

None. The `expr`, `for`, and annotation shapes match the proposal in #3292 verbatim.

## Validation

- `kustomize build kubernetes/cluster0/apps/cert-manager/cert-manager/app/` builds cleanly and renders the `PrometheusRule` with the pair labels inherited from the kustomization.
- Live-fire "does it actually alert" is deliberately not gated on this PR — the AC only requires the rule loads cleanly (no `PrometheusRuleFailures`). Once merged, verify with:
  - `kubectl get prometheusrule -n cert-manager cert-manager`
  - `kubectl -n cert-manager get prometheusrule cert-manager -o jsonpath='{.status}'` (should be empty / no reconcile errors)
  - Prometheus operator logs should be quiet on this rule.

## In-flight parallel work

#3291 is being actioned in a parallel session and touches `network-policy.yaml` and `helm-release.yaml` in the same directory. This PR only adds `prometheusrule.yaml` and edits `kustomization.yaml`, so the two should merge cleanly in either order.

Closes #3292

## Acceptance Criteria

- [ ] [functional] A `PrometheusRule` is created at `kubernetes/cluster0/apps/cert-manager/cert-manager/app/prometheusrule.yaml`, references from `kustomization.yaml`, and appears in the cluster (`kubectl get prometheusrule -n cert-manager`).
- [ ] [functional] The rule includes a `CertManagerCertificateExpiringSoon` alert with severity=warning that fires when `certmanager_certificate_expiration_timestamp_seconds - time() < 7 * 24 * 3600` for any certificate.
- [ ] [functional] The rule includes a `CertManagerCertificateNotReady` alert with severity=warning that fires when a cert-manager `Certificate` has been `Ready=False` for >1 hour (using `certmanager_certificate_ready_status{condition="True"} == 0`).
- [ ] [functional] Alert annotations include the certificate `namespace` and `name` so the email body is actionable without opening Prometheus.
- [ ] [functional] Alerts route via the existing `email` receiver — no changes to Alertmanager config are required.
- [ ] [edge-case] The expiring-soon alert continues to fire (does not silently resolve) after a certificate has passed its `notAfter` date, so expired certs still produce notifications.
- [ ] [edge-case] The `for:` duration on the expiring-soon alert is long enough to avoid flapping on transient scrape gaps (e.g. `for: 15m`) and short enough that a 7-day-out alert still delivers with a full week of runway.
- [ ] [functional] The rule loads cleanly in Prometheus — the resource is `Healthy` under Prometheus operator and no `PrometheusRuleFailures` alert fires against it.
- [ ] [functional] The change is committed to the Flux `cluster-apps-cert-manager` source and survives reconciliation (no drift after `flux reconcile source git home-ops-cluster0`).
