### PR TITLE
renovate: group and lockstep-gate system-upgrade-controller updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -191,6 +191,47 @@
       groupSlug: 'flux',
     },
     {
+      // Group + lockstep-gate rancher/system-upgrade-controller into one PR.
+      // The controller version is carried in two places Renovate tracks
+      // independently, both in
+      // kubernetes/cluster0/apps/system-upgrade/system-upgrade-controller/app/kustomization.yaml:
+      //   - `resources:` — two GitHub URLs (a `crd.yaml` release asset and a
+      //     `?ref=vX.Y.Z` repo ref), both tagged
+      //     `# renovate: datasource=github-releases depName=rancher/system-upgrade-controller`
+      //     (datasource: github-releases, package: rancher/system-upgrade-controller).
+      //   - `images:` — `newTag: vX.Y.Z@sha256:...` (datasource: docker,
+      //     package: rancher/system-upgrade-controller). This is a bare Docker
+      //     Hub `namespace/image`, so it also matches the "Hold Docker Hub
+      //     docker updates for 24h" rule above and is embargoed 24h.
+      //
+      // These must move in lockstep — the URLs are the manifests/CRD applied
+      // to the cluster, the image tag is what the controller actually runs.
+      // Grouping alone is not enough: the github-releases half is NOT gated
+      // by any minimumReleaseAge, so without an explicit gate here it opens
+      // its PR immediately while the docker half sits behind the 24h Docker
+      // Hub hold — the group would still bundle late, but only after the
+      // ungated half's PR already existed unbundled for up to 24h. Observed
+      // on PR #3316: the URL half opened ~1.5h after v0.20.1 hit Docker Hub,
+      // bumping the manifests/CRD to v0.20.1 while `images.newTag` stayed at
+      // v0.19.2 — the cluster ran the old controller image against the new
+      // manifests until a follow-up PR landed.
+      //
+      // The fix: apply the SAME 24h `minimumReleaseAge` +
+      // `internalChecksFilter: 'strict'` to both halves, keyed on
+      // `matchPackageNames` alone (no `matchDatasources`) so one rule catches
+      // both the docker image entry and the github-releases URL entries,
+      // which share the same depName. The github-releases datasource DOES
+      // publish release timestamps (unlike the non-Hub docker registries
+      // that motivated the timestamp caveat above), so a release-age gate
+      // resolves correctly here and will not pend forever.
+      description: 'Group rancher/system-upgrade-controller (CRD/manifest URLs + image tag) into one PR, gated 24h on both halves so neither opens ahead of the other',
+      matchPackageNames: ['rancher/system-upgrade-controller'],
+      groupName: 'system-upgrade-controller',
+      groupSlug: 'system-upgrade-controller',
+      minimumReleaseAge: '24h',
+      internalChecksFilter: 'strict',
+    },
+    {
       // Flux manager + OCIRepository hybrid digest shape is broken:
       // Renovate writes `tag: <semver>@sha256:<digest>` instead of populating
       // the separate `ref.digest` field (renovatebot/renovate#42082). flux-local


### PR DESCRIPTION
## Problem

`kubernetes/cluster0/apps/system-upgrade/system-upgrade-controller/app/kustomization.yaml` carries the controller version in two places Renovate tracks independently:

1. Two GitHub URLs under `resources:` (a `crd.yaml` release-asset URL and a `?ref=vX.Y.Z` repo ref), tagged `# renovate: datasource=github-releases depName=rancher/system-upgrade-controller`. This datasource is **not** gated by any `minimumReleaseAge` rule, so it opens a PR as soon as a new release exists.
2. The `images:` block `newTag: vX.Y.Z@sha256:...`, tracked via the `docker` datasource for `rancher/system-upgrade-controller`. This is a bare Docker Hub image, so it matches the existing "Hold Docker Hub docker updates for 24h" packageRule and is deferred 24h.

Observed on PR #3316: the URL half opened ~1.5h after v0.20.1 hit Docker Hub, bumping the manifests/CRD to v0.20.1 while `images.newTag` stayed at v0.19.2. Post-merge the cluster ran the old controller image against the new manifests until a follow-up image PR landed.

## Fix

Added a new `packageRule` matching `rancher/system-upgrade-controller` by `matchPackageNames` alone (no `matchDatasources` filter), so a single rule catches both the `github-releases` URL entries and the `docker` image entry (they share the same depName):

- `groupName`/`groupSlug: 'system-upgrade-controller'` bundles both halves into one PR.
- The same 24h `minimumReleaseAge` + `internalChecksFilter: 'strict'` is applied to *both* halves. Grouping alone isn't sufficient — without a shared gate the ungated github-releases half would still open its PR up to 24h before the docker half clears its embargo, defeating the point of bundling. The github-releases datasource does publish release timestamps (unlike the non-Hub docker registries that motivated the docker-only scoping in the sibling rule), so the gate resolves correctly and won't pend forever.

## After this change

A single controller version bump results in one PR that updates the `?ref=`/`crd.yaml` URLs **and** `images.newTag` to the same version, opened together after the shared 24h hold.

## Validation

- `.github/renovate.json5` parses successfully via `node config-validator.js` (renovate's own `renovate-config-validator`): `INFO: Config validated successfully against 1 file(s)`.
- Purely additive — existing rules (flux group, seaweedfs 3-day hold, Docker Hub/helm 24h holds, pinDigests carve-outs) are unchanged.

Refs #3316