### PR TITLE
coredns: Phase 0 pre-flight - fix ClusterIP landmine, pin chart version

### DIFF
--- a/kubernetes/cluster0/apps/kube-system/coredns/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/kube-system/coredns/app/helm-release.yaml
@@ -10,7 +10,10 @@ spec:
   chart:
     spec:
       chart: coredns
-      version: 1.46.2
+      # Pinned to 1.32.0 (matches the live k3s-managed release) for Flux
+      # adoption; bump to 1.46.2 in a follow-up PR once adoption is verified
+      # green.
+      version: 1.32.0
       sourceRef:
         kind: HelmRepository
         name: coredns
@@ -31,7 +34,7 @@ spec:
     k8sAppLabelOverride: kube-dns
     service:
       name: kube-dns
-      clusterIP: 10.42.0.10
+      clusterIP: 10.43.0.10
     serviceAccount:
       create: true
     servers:


### PR DESCRIPTION
Refs #3323

Phase 0 (zero-runtime-risk prep) of the CoreDNS k3s-to-Flux ownership migration.

## Changes

Both edits are confined to `kubernetes/cluster0/apps/kube-system/coredns/app/helm-release.yaml`:

1. **Fix ClusterIP landmine**: `service.clusterIP` was `10.42.0.10` (pod CIDR - wrong), changed to `10.43.0.10` (service CIDR, matching the live `kube-dns` Service). `Service.spec.clusterIP` is immutable, so if this HR were ever enabled with the old value, the first `helm upgrade` would fail on the Service update and, combined with `cleanupOnFail: true` + `remediation.retries: 3`, could cascade into a full DNS outage. This fix is correct and worth landing on its own.

2. **Pin chart version**: `chart.spec.version` was `1.46.2` (14 minor versions ahead of the live release), changed to `1.32.0` to match the currently live k3s-managed release, with a comment explaining the pin. Adopting at the matching version means the first Flux reconcile (a later phase) will be a no-op/label-only diff rather than a simultaneous adoption + 14-version upgrade. A follow-up PR will bump this back to `1.46.2` once adoption is verified green.

## Zero runtime effect

The coredns Flux Kustomization (`kubernetes/cluster0/apps/kube-system/coredns/ks.yaml`) is deliberately left unchanged — `path:` still points at `./kubernetes/cluster0/apps/kube-system/coredns/policy`, so this HelmRelease remains unreconciled by Flux. This PR has no effect on the live cluster; it is purely a git-state correction ahead of later migration phases.