### PR TITLE
coredns: adopt live install into Flux HelmRelease (safe in-place adoption)

### DIFF
--- a/kubernetes/cluster0/apps/kube-system/coredns/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/kube-system/coredns/app/helm-release.yaml
@@ -23,18 +23,51 @@ spec:
     remediation:
       retries: 3
   upgrade:
-    cleanupOnFail: true
+    # cleanupOnFail:false + keepHistory:true is a hard guard against the
+    # exact failure mode that caused the two outages on 2026-07-23: an
+    # upgrade that hits an immutable-field error would previously cause
+    # Helm to uninstall the release and take down cluster DNS. See the
+    # post-mortem on #3323.
+    cleanupOnFail: false
     remediation:
       retries: 3
   uninstall:
-    keepHistory: false
+    keepHistory: true
   values:
     fullnameOverride: coredns
     replicaCount: 2
     k8sAppLabelOverride: kube-dns
+    # Preserved from the pre-adoption manual manifests so the adopted pods
+    # keep the eviction protection every cluster DNS provider needs.
+    priorityClassName: system-cluster-critical
+    # Chart default omits `drop: [ALL]` and `readOnlyRootFilesystem`. The
+    # pre-adoption manual pod spec had both — preserving them here so
+    # adoption does not regress security posture.
+    securityContext:
+      capabilities:
+        add:
+          - NET_BIND_SERVICE
+        drop:
+          - ALL
+      readOnlyRootFilesystem: true
+    # deployment.selector + service.selector are pinned to the single-label
+    # selector that the manually-applied live objects use (`k8s-app:
+    # kube-dns`). Deployment.spec.selector is IMMUTABLE, so leaving the
+    # chart default (three labels) would break the first `helm upgrade` and
+    # is precisely the class of failure the upgrade guards above defend
+    # against — but avoiding it entirely is safer. Keeping the Service
+    # selector single-label also means no window with zero Endpoints while
+    # pod labels roll forward. See the coredns chart README, section
+    # "Adopting existing CoreDNS resources".
+    deployment:
+      selector:
+        matchLabels:
+          k8s-app: kube-dns
     service:
       name: kube-dns
       clusterIP: 10.43.0.10
+      selector:
+        k8s-app: kube-dns
     serviceAccount:
       create: true
     servers:

--- a/kubernetes/cluster0/apps/kube-system/coredns/ks.yaml
+++ b/kubernetes/cluster0/apps/kube-system/coredns/ks.yaml
@@ -6,23 +6,48 @@ metadata:
   name: cluster-apps-coredns
   namespace: flux-system
 spec:
-  # The CoreDNS HelmRelease in ./app/ is intentionally NOT reconciled — the
-  # historical Flux Kustomization line in apps/kube-system/kustomization.yaml
-  # was disabled long before Phase 4 because the live CoreDNS install pre-
-  # dates Flux management of the chart and re-adopting it without an outage
-  # window is risky.
-  #
-  # Phase 4c (#2952) re-enables this Flux Kustomization but points it at a
-  # dedicated ./policy/ directory containing only the NetworkPolicy and
-  # CiliumNetworkPolicy that lock down the in-cluster CoreDNS pods (selector
-  # k8s-app=kube-dns). Same pattern as
-  # apps/kube-system/local-path-provisioner/{policy,ks.yaml} from Phase 4b.
+  # Sibling to ./app below: this Kustomization reconciles the NetworkPolicy
+  # and CiliumNetworkPolicy that lock down the in-cluster CoreDNS pods
+  # (selector k8s-app=kube-dns). Same policy/app split pattern as
+  # apps/kube-system/local-path-provisioner (Phase 4b) and
+  # apps/cert-manager/cert-manager (which uses a policy-free split of
+  # app/issuers).
   path: ./kubernetes/cluster0/apps/kube-system/coredns/policy
   prune: false # never should be deleted
   sourceRef:
     kind: GitRepository
     name: home-ops-cluster0
   wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-apps-coredns-app
+  namespace: flux-system
+spec:
+  # Sibling to the policy Kustomization above: reconciles the CoreDNS
+  # HelmRelease itself. This was disabled for months while the live CoreDNS
+  # install pre-dated Flux management of the chart; the in-place Helm
+  # adoption (see PR that introduced this line) re-enables it. Two outages
+  # on 2026-07-23 were caused by a Flux HelmRelease uninstalling this
+  # release on an immutable-field error, so the guards live in three
+  # places: prune:false here (never let Flux delete the HR from cluster
+  # state), and upgrade.cleanupOnFail:false + uninstall.keepHistory:true on
+  # the HelmRelease itself.
+  path: ./kubernetes/cluster0/apps/kube-system/coredns/app
+  prune: false # never should be deleted — sole DNS provider for the cluster
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-cluster0
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: coredns
+      namespace: kube-system
   interval: 30m
   retryInterval: 1m
   timeout: 5m

--- a/kubernetes/cluster0/apps/kube-system/kustomization.yaml
+++ b/kubernetes/cluster0/apps/kube-system/kustomization.yaml
@@ -6,10 +6,11 @@ resources:
   - ./namespace.yaml
   # Flux-Kustomizations
   - ./cilium/ks.yaml
-  # The CoreDNS HelmRelease in ./coredns/app/ remains intentionally disabled
-  # (live CoreDNS predates Flux management of the chart). Phase 4c (#2952)
-  # re-enables this Flux Kustomization pointing at ./coredns/policy/ — see
-  # ./coredns/ks.yaml for the rationale.
+  # ./coredns/ks.yaml defines TWO sibling Flux Kustomizations: the
+  # NetworkPolicy set (cluster-apps-coredns, ./coredns/policy) and the
+  # CoreDNS HelmRelease itself (cluster-apps-coredns-app, ./coredns/app).
+  # See the per-Kustomization comments in that file for the adoption story
+  # and the two-outage post-mortem that shaped the guards.
   - ./coredns/ks.yaml
   - ./intel-device-plugin/ks.yaml
   # The Flux Kustomization at ./local-path-provisioner/ks.yaml points at a


### PR DESCRIPTION
## Summary

Adopt the live, plain-manifest CoreDNS install on `cluster0` into the existing Flux `HelmRelease` at `kubernetes/cluster0/apps/kube-system/coredns/app/helm-release.yaml` (chart `coredns` 1.32.0), via **in-place Helm adoption** so nothing is recreated and DNS never drops.

CoreDNS is the cluster's **sole** DNS provider. Two full-DNS outages on 2026-07-23 (issue #3323) shaped this PR — the guards below are the direct response.

Refs #3323 (see "Correcting #3323" below — this PR does not fully supersede that issue; the follow-up chart bump to 1.46.2 tracked there is out of scope here).

## Ground truth (verified live, before this PR)

Issue #3323's "ground truth" section is **FALSE** — there is no k3s-managed CoreDNS on this cluster. Verified today:

```
$ kubectl -n kube-system get addon,helmchart | grep -i coredns
(empty — no k3s addon or HelmChart for coredns)

$ helm ls -A | grep coredns
(empty — no Helm release named coredns before this PR)

$ kubectl -n kube-system get deploy,svc,cm,sa | grep -Ei 'coredns|kube-dns'
deployment.apps/coredns          2/2     2            2           17m
service/kube-dns                  ClusterIP   10.43.0.10      <none>        53/UDP,53/TCP,9153/TCP
configmap/coredns                 1      22m
serviceaccount/coredns                                       22m

$ kubectl get clusterrole,clusterrolebinding | grep -i coredns
clusterrole/system:coredns                          22m
clusterrolebinding/helm-kube-system-coredns         3h18m   (dangling — see below)
clusterrolebinding/system:coredns                   22m
```

CoreDNS is currently a set of **manually `kubectl apply`d plain manifests** (no Helm release, no Flux Kustomization managing them, no k3s owner). Two-outage post-mortem in the "Correcting #3323" section below.

## Diff evidence: `helm template` (chart 1.32.0 + HR values) vs live

`helm template coredns coredns/coredns --version 1.32.0 --namespace kube-system --values <this-PR's HR values>` produces the manifests below. Then compared against `kubectl -n kube-system get <obj> -o yaml`, stripped of status / managedFields / kubectl `last-applied-configuration` / resourceVersion / uid / generation.

### Identity fields (must match live so adoption is safe)

| Object | Field | Live | Chart-rendered | Match |
|---|---|---|---|---|
| Deployment | `metadata.name` | `coredns` | `coredns` | ✓ |
| Deployment | `spec.selector.matchLabels` (**IMMUTABLE**) | `{k8s-app: kube-dns}` | `{k8s-app: kube-dns}` | ✓ (via new `deployment.selector` value) |
| Service | `metadata.name` | `kube-dns` | `kube-dns` | ✓ |
| Service | `spec.clusterIP` (**IMMUTABLE**) | `10.43.0.10` | `10.43.0.10` | ✓ (unchanged from PR #3324) |
| Service | `spec.selector` | `{k8s-app: kube-dns}` | `{k8s-app: kube-dns}` | ✓ (via new `service.selector` value) |
| ConfigMap | `metadata.name` | `coredns` | `coredns` | ✓ |
| ServiceAccount | `metadata.name` | `coredns` | `coredns` | ✓ |

Every identity field is stable. **No object will be recreated by adoption.**

### Key finding not called out in the spec

Chart 1.32.0 renders `Deployment.spec.selector.matchLabels` with **three labels** by default (`k8s-app`, `app.kubernetes.io/instance`, `app.kubernetes.io/name`), but the live manually-applied Deployment uses a **single-label** selector `{k8s-app: kube-dns}`. `spec.selector` is **immutable**, so a naive adoption at the previous HR values would have failed the first `helm upgrade` — which is precisely the class of failure the `cleanupOnFail:true` guard would have converted into another uninstall-driven outage.

Fixed by overriding `deployment.selector.matchLabels` and `service.selector` to the single-label form. The chart README explicitly documents this override for adopting existing CoreDNS deployments; verified against the rendered output.

`k8sAppLabelOverride: kube-dns` was already in place — verified against `_helpers.tpl` in chart 1.32.0 that the override is honoured (populates the `coredns.k8sapplabel` template used by `k8s-app: {{ ... }}` in every template).

### Spec drift (documented; rolls out safely under `strategy.rollingUpdate.maxUnavailable: 1`)

The Deployment will roll pods once after adoption. With 2 replicas + `maxUnavailable: 1`, at least 1 pod stays Ready throughout. Concrete drift:

| Object | Drift | Assessment |
|---|---|---|
| Deployment | Container image: `docker.io/coredns/coredns@sha256:9caab...` (digest) → `coredns/coredns:1.11.3` (tag). Same 1.11.3 content. | Rolling restart; safe. |
| Deployment | Pod template labels: adds `app.kubernetes.io/name` + `app.kubernetes.io/instance`. Still matches single-label Deployment selector. | Rolling restart; safe. |
| Deployment | Pod template annotations: adds `checksum/config`, `scheduler.alpha.kubernetes.io/tolerations`. | Rolling restart; safe. |
| Deployment | `nodeAffinity`: live is pinned to `kubernetes.io/hostname in (node1,node2)` (image-cache workaround) → chart's `node-role.kubernetes.io/control-plane Exists` (control-plane pool). | Intended — restores the normal control-plane placement. Only node0 lacks the image cache, and image pulls resolve via the node's OS resolver, not in-cluster DNS. Rolling restart with one old pod always Ready. |
| Deployment | `topologySpreadConstraints.labelSelector`: `{k8s-app: kube-dns}` → `{app.kubernetes.io/instance: coredns}`. Post-adoption pods carry both labels; spread semantics unchanged. | Cosmetic; safe. |
| Deployment | `resources`: live `req cpu=100m mem=70Mi, lim mem=170Mi` → chart `req/lim cpu=100m mem=128Mi`. Adds CPU limit + slight memory bump. | Small change; well within control-plane node capacity. |
| Deployment | `readinessProbe`: live has no `initialDelaySeconds` + `timeoutSeconds:1`, `failureThreshold:3`; chart has `initialDelaySeconds:30`, `timeoutSeconds:5`, `failureThreshold:5`. Chart is more forgiving. | Safe; slightly slower initial readiness. |
| Deployment | Container port names: `dns/dns-tcp/metrics` → `udp-53/tcp-53/tcp-9153`. Numeric ports unchanged. | Nothing targets by name; safe. |
| Service | Loses metrics port `9153/TCP`. | Not scraped from `kube-dns` — Prometheus scrapes via the separate headless `prometheus-kube-prometheus-coredns` Service. Verified. |
| Service | Loses legacy `prometheus.io/scrape` + `prometheus.io/port` annotations. | kube-prometheus-stack does not use these. Safe. |
| Service | Loses API-defaulted fields (`sessionAffinity`, `internalTrafficPolicy`, `clusterIPs`, `ipFamilies`, `ipFamilyPolicy`). | API server backfills all of them on apply. Zero functional change. |
| ConfigMap | Corefile: `.:53 { ... }` → `dns://.:53 { ... }`. Functionally identical (both handle UDP+TCP on 53); triggers a pod restart via `checksum/config`. | Rolling restart; safe. |
| SA/CM/Svc/Deploy | Adds full Helm ownership labels. | Metadata only; safe. |

### Regressions caught + fixed in this PR

- **`priorityClassName: system-cluster-critical`** — live pods have this; chart default drops it. Preserved via `priorityClassName` value. Without it, the cluster's sole DNS provider would be evicted under node pressure like any normal workload.
- **`securityContext.capabilities.drop: [ALL]` + `readOnlyRootFilesystem: true`** — live container had both; chart default only sets `capabilities.add: [NET_BIND_SERVICE]`. Preserved so adoption does not regress security posture.

### RBAC mismatch (chart `coredns` vs manual `system:coredns`)

The chart renders `ClusterRole/coredns` + `ClusterRoleBinding/coredns` (both binding SA `coredns`). Live has `ClusterRole/system:coredns` + `ClusterRoleBinding/system:coredns` (also binding SA `coredns`, with the same rule set).

- **During adoption:** the chart CREATES its own `coredns` ClusterRole+Binding. The SA `coredns` is now bound to **both** (identical rules) — no permission gap.
- **Post-adoption cleanup step:** delete the manual `system:coredns` ClusterRole + ClusterRoleBinding. This is one of the live cutover steps (below).

Two ClusterRoles have identical rules — confirmed by inspecting both:

```
$ kubectl get clusterrole system:coredns -o yaml | yq '.rules'
- apiGroups: [""]
  resources: [endpoints, services, pods, namespaces]
  verbs: [list, watch]
- apiGroups: [discovery.k8s.io]
  resources: [endpointslices]
  verbs: [list, watch]

(chart's `coredns` ClusterRole: same two rules — see helm template output above)
```

Also noted (out of scope for this PR): `ClusterRoleBinding/helm-kube-system-coredns` is a dangling artefact from a much earlier k3s helm-controller install — it binds a **non-existent** ServiceAccount (`kube-system/helm-coredns`, confirmed `NotFound`) to `cluster-admin`. Harmless (subject does not exist) but should be cleaned up separately; not touching it here to keep this PR focused.

## Live cutover runbook (executes AFTER go-ahead from Ben)

All steps run from the operator's terminal against `cluster0`. **Do not run any of these while any coredns pod is not Ready.**

1. `flux reconcile source git home-ops-cluster0` — pull this PR (once merged).
2. **Pre-label live objects for Helm adoption** — makes `helm upgrade --install` adopt rather than fail:
   ```bash
   for obj in deployment/coredns service/kube-dns configmap/coredns serviceaccount/coredns; do
     kubectl -n kube-system label   "$obj" app.kubernetes.io/managed-by=Helm --overwrite
     kubectl -n kube-system annotate "$obj" meta.helm.sh/release-name=coredns meta.helm.sh/release-namespace=kube-system --overwrite
   done
   ```
3. **Reconcile the new Flux Kustomization + HR:**
   ```bash
   flux reconcile kustomization cluster-apps-coredns-app
   flux -n kube-system reconcile helmrelease coredns
   ```
4. **Watch (separate terminal, all through the rollout):**
   ```bash
   kubectl -n kube-system get pods -l k8s-app=kube-dns -w
   kubectl -n kube-system get svc kube-dns -w   # clusterIP MUST stay 10.43.0.10
   flux -n kube-system get hr coredns -w
   ```
5. **Verify Helm release now exists + adoption is complete:**
   ```bash
   kubectl -n kube-system get secret -l owner=helm | grep coredns  # sh.helm.release.v1.coredns.v1 present
   helm -n kube-system list                                        # coredns 1.32.0
   flux -n kube-system get hr coredns                              # Ready=True
   ```
6. **DNS smoke test:**
   ```bash
   nslookup kubernetes.default.svc.cluster.local 10.43.0.10
   kubectl -n kube-system get hr -A | grep -v True   # every HR still Ready
   ```
7. **Clean up orphan manual RBAC** (only after step 5 confirms the chart's `coredns` ClusterRole+Binding are present and SA `coredns` still has permissions):
   ```bash
   kubectl delete clusterrolebinding system:coredns
   kubectl delete clusterrole        system:coredns
   ```

**Abort criteria (stop and roll back to the manual manifests, keeping running pods Ready):**
- Any zero-Ready window during the rollout.
- Service `kube-dns` clusterIP changes off `10.43.0.10`.
- HR remediation loop starts triggering.
- `helm history -n kube-system coredns` shows an uninstalled/failed revision.

## Correcting issue #3323

Will be actioned as part of this PR (a follow-up comment on #3323 with a correction + two-outage post-mortem). The false k3s ground truth in the current issue body will be struck through with the verified reality:

> **Correction (2026-07-24):** the "Ground truth" section above is FALSE for cluster0's current state. There is **no** k3s-managed CoreDNS on cluster0. No `custom-coredns-helmchart.yaml` on any CP node; no `addon/custom-coredns-helmchart`; no `helmchart/coredns`; no `helm-install-coredns` Job. CoreDNS is running as plain, manually-applied Deployment/Service/ConfigMap/SA/ClusterRole+Binding — a bare recovery scaffold, not a k3s-managed install.
>
> **Two-outage post-mortem (2026-07-23):** the earlier Flux HelmRelease had `service.clusterIP: 10.42.0.10` (a pod-CIDR address, not the service-CIDR `10.43.0.10` that CoreDNS actually served on) and `upgrade.cleanupOnFail: true`. When the HelmRelease was accidentally reconciled, `helm upgrade` immediately failed on the immutable `Service.spec.clusterIP` — Helm's cleanup-on-fail then **uninstalled** the release, which took the entire cluster's DNS with it. A manual rollback re-created the objects, but the orphaned HelmRelease resource re-reconciled and detonated the exact same way a second time. Only removing the orphan HR (and later, this adoption PR) stopped the loop.

The scope of #3323 as originally written was "migrate from k3s helm-controller to Flux". Cluster reality (verified today) is that there is no k3s ownership to migrate away from — the mahi is instead "adopt the plain manifest CoreDNS install into a Flux HelmRelease." This PR does that adoption, so **`Refs #3323`** rather than `Closes`; the follow-up chart bump 1.32.0 → 1.46.2 tracked as a phase of #3323 remains out of scope here.

## Acceptance criteria mapping

- [x] `upgrade.cleanupOnFail: false` + `uninstall.keepHistory: true` — added, with comment explaining the two-outage guard rationale.
- [x] `ks.yaml` split into sibling policy + app Kustomizations — done; `cluster-apps-coredns-app` health-checks the HR.
- [x] `helm template` diff evidence + identity-stability confirmation — inline above.
- [x] `k8sAppLabelOverride` honoured by 1.32.0 — verified against `_helpers.tpl` template `coredns.k8sapplabel`.
- [x] Selector immutability landmine caught + defused — new `deployment.selector` + `service.selector` values pin single-label form.
- [x] Regressions caught (`priorityClassName`, hardened `securityContext`) restored via values.
- [ ] Live pre-labelling + reconcile + verify — runbook above; **pending Ben's go-ahead.**
- [ ] `sh.helm.release.v1.coredns.v1` secret present — will be after step 3 of the runbook.
- [ ] `system:coredns` orphan RBAC removed — step 7 of the runbook.
- [ ] Issue #3323 corrected — will be commented on the issue once the live cutover completes.

## Waiting on Ben

The code changes are complete and stand up to `helm template` diff review. The **live cutover (steps 2, 3, 7 above) is real surgery on the cluster's only DNS** — I am pausing for your explicit go-ahead before executing. Ready when you are.
