### PR TITLE
fix(authelia): stop CNPG owner-drift error on authelia-postgres-v17

### DIFF
--- a/kubernetes/cluster0/apps/auth/authelia/db/cluster-v17.yaml
+++ b/kubernetes/cluster0/apps/auth/authelia/db/cluster-v17.yaml
@@ -53,12 +53,30 @@ spec:
           name: cloudnative-pg-secret
           key: S3_SECRET_KEY
 
-  # bootstrap:
+  # Declare initdb.owner/database/secret so CNPG's app-user reconciler targets
+  # the real "authelia" role and the user-managed secret (authelia-db-secrets)
+  # whose password already matches the role in PG. Without this block CNPG
+  # defaults owner=app/database=app, but the cluster was originally bootstrapped
+  # with owner=authelia (see commit 1b7f392fd, later commented out in 4a869d26c),
+  # so the operator's -app secret (username=authelia) mismatched the defaulted
+  # owner and the reconciler errored every loop with:
+  #   "wrong username 'authelia' in secret, expected 'app'"
+  # Pointing at a user-managed secret also stops CNPG from re-managing the
+  # stale -app secret (ShouldCreateApplicationSecret becomes false), matching
+  # the pattern used by miniflux/home-assistant in this repo.
+  bootstrap:
+    initdb:
+      database: authelia
+      owner: authelia
+      secret:
+        name: authelia-db-secrets
+
   # use this to recover a net-new cluster from a backup
+  # bootstrap:
   #   recovery:
   #     source: authelia-db-backup-v17
 
-    # # use this to 'migrate' from an existing cnpg cluster (e.g. "postgres-v15") to the new cluster
+  # use this to 'migrate' from an existing cnpg cluster (e.g. "postgres-v15") to the new cluster
   # bootstrap:
   #   initdb:
   #     database: authelia

--- a/kubernetes/cluster0/apps/auth/authelia/db/kustomization.yaml
+++ b/kubernetes/cluster0/apps/auth/authelia/db/kustomization.yaml
@@ -4,5 +4,6 @@ kind: Kustomization
 resources:
   - cluster-v17.yaml
   - scheduled-backup.yaml
+  - secret.sops.yaml
   - network-policy.yaml
   - cilium-network-policy.yaml

--- a/kubernetes/cluster0/apps/auth/authelia/db/secret.sops.yaml
+++ b/kubernetes/cluster0/apps/auth/authelia/db/secret.sops.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: authelia-db-secrets
+    namespace: databases
+type: kubernetes.io/basic-auth
+stringData:
+    username: ENC[AES256_GCM,data:TEtHuPP9Chg=,iv:RcPrbZ3WnnvDCo/S2Bwslkb2R9fG4pxTcoL3JORh/cc=,tag:93Wvm4NVQ9pTQhR3KveJbg==,type:str]
+    password: ENC[AES256_GCM,data:YYzVnG4DBCF4YuNGBf1oExCGPCCAXsnQiaf4qSjC,iv:4oMrnQYw5TW/46CDCoQspG1++HVRSAsfnm1ec4Bk07Y=,tag:lmmMyjsqS5FPPTdfkI+V5w==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrSWhkcUhtVG5NMis5eDYz
+            SElUc29UeGlHVkZvN25YaFNPYnAySHllVnlnCkpKcDFjUU16SWNpNnhNR2xGK3c1
+            N09qNms1TnZHd01SSERDQkNlbHQ5aHMKLS0tIHlOZW51bm9nR2JDelBGNjU4QU93
+            TUxlMEdUeEg4bldDSGNBbWhKTGh6VWMKEJyB6LCZEJklJVpciS5mBKl7ZGEULPWO
+            NsKtp05mawITDyVRb14XeWQpDTtIxwmIgW8GAAG20HQAKKfYl7YH1w==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1582vh25trj6w7klwt38d44n5nr8njr8rrxxx5kcfu3y2ezx9ss3s6j24ex
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQM1FNeEhzWExPZUF1UnBD
+            Smw1eXVremgyanNOc1dzeFdHQzFSVG5NdWhFCkpPMzlid3h5d0wzKzgySXpPbWFG
+            NFJNNm9ZcHI0M0t4QkhPZFAwK2hDdVUKLS0tIFg5ekdVQWcxcVRFYlc0UEdWQUdp
+            Y1RmM1NCODgrOGtIRk80YjNSaWM0S1UKzwofwAgdFPwwKlV8ZnqmYh6jE8BML4eO
+            MO8z7gDeIu+LhCceMg58i4SCixGW1qLbrEwJ51UUk0+WP9tCyqqGqQ==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age185kanaq3uw2gjx5enu2v69nk9ner3lamdevrfgx3wqucsl9ewa2qlt2gf7
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-07-25T01:29:13Z"
+    mac: ENC[AES256_GCM,data:ZqW97PjMxirXZmFEyH4z/vU8T22NUcZ01csOaH7hesF3hPvQAi4gjGB2rMWR2b4V+xt5kJ5lEY44nAfJ2OiMH50Vo7LDUIrCFPrby67y/P0YrEBkulhX7VDAjLmHwkz7jVtjyOgt0PnovSteOlJmEgFCV1WSgDcxp10bNI8YHDQ=,iv:Q392OWeEChb16IfoxejkOu8Nqs8f3qTAulHvUO8CTuQ=,tag:N3r0Xqw8n5jPEIQjEhqWoA==,type:str]
+    version: 3.13.2


### PR DESCRIPTION
## What

Fix perpetual CNPG owner-drift reconcile error on the `authelia-postgres-v17` cluster.

## Symptom

The CNPG instance-manager for `authelia-postgres-v17` (namespace `databases`) has been logging this error every ~16 minutes on every reconcile:

```
while updating database owner password: wrong username 'authelia' in secret, expected 'app'
```

Authelia itself has been working fine — this was purely a reconcile-loop error that never converged.

## Root cause

The cluster was originally bootstrapped on 2025-08-08 with `bootstrap.initdb.owner: authelia` (commit `1b7f392fd`), then the entire bootstrap block was commented out shortly after (commit `4a869d26c`). Once the field went missing from the spec, CNPG's defaulter (`api/v1/cluster_defaults.go: defaultInitDB`) started filling in the API defaults `owner=app, database=app` on every reconcile.

The CNPG-managed connection secret `authelia-postgres-v17-app` kept `username=authelia` (matching the actual role/database CNPG created at bootstrap), so the app-user reconciler ([`internal/management/controller/instance_controller.go: reconcileUser`](https://github.com/cloudnative-pg/cloudnative-pg/blob/release-1.30/internal/management/controller/instance_controller.go)) saw `secret.username = "authelia"` but `cluster.GetApplicationDatabaseOwner()` returned `"app"` and errored before ever calling `SetUserPassword`.

### Why "immutable" is imprecise

The CNPG docs describe `bootstrap.initdb` as ignored for re-bootstrap purposes — but that only refers to whether `initdb` re-runs, not whether the field values are frozen. CNPG 1.30's `ValidateUpdate` (`internal/webhook/v1/cluster_webhook.go: validateClusterChanges`) has **no immutability check on `bootstrap.initdb`**, and `GetApplicationDatabaseOwner()` / `GetApplicationSecretName()` read the field live on every reconcile. So editing it here does take effect on the existing cluster without triggering a re-bootstrap.

## Why the naive fix would have locked out SSO

The stale `-app` secret's password does **not** match the password Authelia actually connects with (which lives in the SOPS-encrypted `authelia-secrets` `AUTHELIA_STORAGE_POSTGRES_PASSWORD`). Because the reconciler has always errored on the username check, it has never reached `SetUserPassword` and has never overwritten the Postgres role's password.

Simply uncommenting `owner: authelia` in the spec would have satisfied the reconciler and it would then immediately `ALTER USER authelia PASSWORD '<stale -app value>'` — locking Authelia (and therefore the whole cluster's SSO) out of Postgres on the next reconcile.

## Fix

Add a user-managed SOPS-encrypted Secret `authelia-db-secrets` in the `databases` namespace containing the password Authelia currently uses, and point `bootstrap.initdb.secret.name` at it (with `owner` and `database` explicitly set to `authelia`). This is the same pattern already used by the `miniflux` and `home-assistant` CNPG clusters in this repo.

Once merged and reconciled:

- `ShouldCreateApplicationSecret()` returns `false` because `initdb.secret.name` is set → CNPG stops managing the stale `authelia-postgres-v17-app` secret. The existing secret remains but becomes orphaned/inert.
- `GetApplicationSecretName()` now returns `authelia-db-secrets` and `GetApplicationDatabaseOwner()` returns `authelia` → `reconcileUser` reads the matching username and the current password, and the resulting `SetUserPassword('authelia', <current password>)` is a no-op ALTER. Authelia keeps working.

## Safety

- The password embedded in `secret.sops.yaml` is the value already in use — confirmed with @prismatic-koi before applying (Authelia pods have been Up 59d and actively serving auth, the reconciler has never touched the role password, so the SOPS value in `authelia-secrets` is authoritative for the current Postgres role).
- The credential is SOPS-encrypted to both cluster and personal age recipients, consistent with the miniflux/home-assistant precedent.
- The stale `authelia-postgres-v17-app` secret is intentionally left in place — it is no longer read or written by CNPG, and deleting it is out of scope for this PR (can be tidied up in a follow-up if desired).

## Post-merge verification

Run these ~2 minutes after Flux reconciles (or force with `flux reconcile source git home-ops-cluster0 && flux reconcile kustomization cluster-apps-authelia-db`):

```bash
# 1. Confirm the reconciler no longer logs the mismatch:
kubectl logs -n databases authelia-postgres-v17-6 -c postgres --tail=200 \
  | grep 'wrong username' | tail
# Expected: no new entries after the reconcile that consumes this PR.

# 2. Confirm the live spec has the intended values:
kubectl get cluster authelia-postgres-v17 -n databases \
  -o jsonpath='{.spec.bootstrap.initdb}{"\n"}'
# Expected: database=authelia, owner=authelia, secret.name=authelia-db-secrets.

# 3. Confirm Authelia still authenticates:
kubectl get pods -n auth -l app.kubernetes.io/name=authelia
# Expected: 2/2 Running, no restart bump.
```

## Files changed

- `kubernetes/cluster0/apps/auth/authelia/db/cluster-v17.yaml` — bootstrap block reinstated with explicit `owner`/`database`/`secret.name` and an inline comment explaining why.
- `kubernetes/cluster0/apps/auth/authelia/db/secret.sops.yaml` — new SOPS-encrypted `authelia-db-secrets` in namespace `databases`.
- `kubernetes/cluster0/apps/auth/authelia/db/kustomization.yaml` — include the new secret.
