### PR TITLE
fix(rollout): blocky + changedetection-browser rollout hygiene

### DIFF
--- a/kubernetes/cluster0/apps/monitoring/changedetection-io/browser/helm-release.yaml
+++ b/kubernetes/cluster0/apps/monitoring/changedetection-io/browser/helm-release.yaml
@@ -23,6 +23,9 @@ spec:
     controllers:
       main:
         replicas: 3
+        strategy: RollingUpdate
+        rollingUpdate:
+          unavailable: 1
         containers:
           app:
             image:
@@ -73,6 +76,20 @@ spec:
                     port: 3000
                   initialDelaySeconds: 30
                   periodSeconds: 60
+                  timeoutSeconds: 10
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  # Reuses the same unauthenticated /docs/ endpoint as the liveness
+                  # probe above (see the comment there and issue #3037). Only ready
+                  # once the HTTP server is listening. See issue #3342.
+                  httpGet:
+                    path: /docs/
+                    port: 3000
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
                   timeoutSeconds: 10
                   failureThreshold: 3
             resources:

--- a/kubernetes/cluster0/apps/networking/blocky/app/config.yaml
+++ b/kubernetes/cluster0/apps/networking/blocky/app/config.yaml
@@ -36,6 +36,17 @@ data:
         search.${SECRET_PUBLIC_DOMAIN}: ${TRAEFIK_IP}
 
     blocking:
+      loading:
+        # "fast": serve DNS immediately on startup; blocklists load in the
+        # background and blocking enables once ready. See issue #3342.
+        strategy: fast
+        # Tolerate a slow/dead source instead of blocking/crashing startup.
+        downloads:
+          timeout: 30s
+          attempts: 3
+          cooldown: 10s
+        # Don't fail a whole source over a handful of bad lines.
+        maxErrorsPerSource: 5
       denylists:
         suspicious:
           - https://raw.githubusercontent.com/PolishFiltersTeam/KADhosts/master/KADhosts.txt

--- a/kubernetes/cluster0/apps/networking/blocky/app/helm-release-primary.yaml
+++ b/kubernetes/cluster0/apps/networking/blocky/app/helm-release-primary.yaml
@@ -41,6 +41,14 @@ spec:
   values:
     controllers:
       blocky-primary:
+        strategy: RollingUpdate
+        rollingUpdate:
+          # Quoted "0": app-template's chart template uses `with .unavailable`,
+          # and Go templates treat the bare int 0 as falsy, silently dropping
+          # maxUnavailable from the rendered manifest. A quoted string survives
+          # `with`. See issue #3342 (zero-downtime DNS rollout requires this).
+          unavailable: "0"
+          surge: 1
         containers:
           app:
             image:
@@ -59,6 +67,20 @@ spec:
                     port: &port 53
                   initialDelaySeconds: 15
                   periodSeconds: 30
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  # Unauthenticated HTTP endpoint that is 200 as soon as blocky is
+                  # serving (independent of blocklist loading, which runs in the
+                  # background thanks to blocking.loading.strategy: fast).
+                  httpGet:
+                    path: /metrics
+                    port: 4000
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                  timeoutSeconds: 3
                   failureThreshold: 3
             securityContext:
               allowPrivilegeEscalation: false

--- a/kubernetes/cluster0/apps/networking/blocky/app/helm-release-secondary.yaml
+++ b/kubernetes/cluster0/apps/networking/blocky/app/helm-release-secondary.yaml
@@ -41,6 +41,14 @@ spec:
   values:
     controllers:
       blocky-secondary:
+        strategy: RollingUpdate
+        rollingUpdate:
+          # Quoted "0": app-template's chart template uses `with .unavailable`,
+          # and Go templates treat the bare int 0 as falsy, silently dropping
+          # maxUnavailable from the rendered manifest. A quoted string survives
+          # `with`. See issue #3342 (zero-downtime DNS rollout requires this).
+          unavailable: "0"
+          surge: 1
         containers:
           app:
             image:
@@ -55,6 +63,20 @@ spec:
                     port: &port 53
                   initialDelaySeconds: 15
                   periodSeconds: 30
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  # Unauthenticated HTTP endpoint that is 200 as soon as blocky is
+                  # serving (independent of blocklist loading, which runs in the
+                  # background thanks to blocking.loading.strategy: fast).
+                  httpGet:
+                    path: /metrics
+                    port: 4000
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                  timeoutSeconds: 3
                   failureThreshold: 3
             securityContext:
               allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary

Config-only rollout-hygiene fix for the two apps that produced the noisy/slow-rollout alert storm from #3342 (2026-07-28, 11:00-12:20 NZST). No image version bumps, no blocklist content changes.

### blocky (`kubernetes/cluster0/apps/networking/blocky/app/`)

- `config.yaml`: added `blocking.loading` with `strategy: fast` (serve DNS immediately, load blocklists in the background), plus download resilience (`downloads.timeout/attempts/cooldown`) and `maxErrorsPerSource` so a single slow/dead list URL can't block or crash startup. Verified field names against the upstream v0.34.0 `docs/configuration.md` (`Sources Loading` / `Downloads` / `Init Strategy` sections) rather than guessing.
- `helm-release-primary.yaml` / `helm-release-secondary.yaml`:
  - Added a `readinessProbe` (`httpGet /metrics` on port 4000 — already unauthenticated, already scraped by the ServiceMonitor) so the Service only routes to a pod once it's actually serving.
  - Switched `strategy` from the implicit default (effectively `Recreate` behaviour due to no readiness gate) to `RollingUpdate` with `maxUnavailable: 0` / `maxSurge: 1`, so the new pod must be Ready before the old one is removed — zero DNS-serving gap. Both instances kept consistent.
  - Note: `unavailable: "0"` is deliberately a quoted string. app-template's Deployment template guards the field with Helm's `with`, and Go templates treat bare `0` as falsy, silently dropping `maxUnavailable` from the rendered manifest. Confirmed via local `helm template` against the chart before/after quoting.

### changedetection-browser (`kubernetes/cluster0/apps/monitoring/changedetection-io/browser/helm-release.yaml`)

- Added `strategy: RollingUpdate` / `rollingUpdate.unavailable: 1` so only one of the three replicas drops during a rollout instead of all three at once.
- Added a `readinessProbe` reusing the existing unauthenticated `/docs/` endpoint (port 3000) already used for liveness — see the in-file comment and #3037 for why `/docs/` was chosen over auth-gated endpoints.

## Validation

`podman` isn't functional in this sandbox, so `flux-local test` (the CI job) couldn't be run directly. Instead, validated with `helm template` against the pinned `app-template` chart (v5.0.1) using each HelmRelease's actual `.spec.values`:

- All three renders succeed (`helm template` exit 0).
- Confirmed rendered `Deployment.spec.strategy.rollingUpdate` shows `maxUnavailable: 0` / `maxSurge: 1` for both blocky instances, and `maxUnavailable: 1` for changedetection-browser.
- Confirmed rendered `readinessProbe` blocks match spec (blocky: `/metrics:4000`; changedetection-browser: `/docs/:3000`).
- `kustomize build` on the blocky app dir renders the ConfigMap cleanly with the new `blocking.loading` block.
- `yq e '.'` on all four changed files confirms valid YAML.

The CI `flux-local` workflow will still run its full test/diff on the PR itself.

## Out of scope (per issue)

No image version bumps, no blocklist content changes — rollout hygiene only.

Closes #3342