### PR TITLE
Drop Authelia forward-auth from Grafana HTTPRoute

### DIFF
--- a/kubernetes/cluster0/apps/monitoring/grafana/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/monitoring/grafana/app/helm-release.yaml
@@ -34,12 +34,6 @@ spec:
           - name: traefik-gateway
             namespace: networking
             sectionName: websecure
-        filters:
-          - type: 'ExtensionRef'
-            extensionRef:
-              group: 'traefik.io'
-              kind: 'Middleware'
-              name: 'forwardauth-authelia'
     persistence:
       # NOTE: persistence is intentionally left enabled for now. A follow-up PR
       # will flip this to false once declarative provisioning of datasources +
@@ -88,7 +82,7 @@ spec:
         providers:
           - name: default
             orgId: 1
-            folder: ''
+            folder: ""
             type: file
             disableDeletion: false
             editable: true


### PR DESCRIPTION
Grafana now handles its own auth (or auth was moved elsewhere), so routing every request through the forwardauth-authelia middleware was redundant and just adding a hop. Also normalises the empty-string quoting in the dashboard provider config to match the rest of the file's style.