### PR TITLE
Drop stale persistence follow-up note in Grafana HelmRelease

### DIFF
--- a/kubernetes/cluster0/apps/monitoring/grafana/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/monitoring/grafana/app/helm-release.yaml
@@ -35,9 +35,6 @@ spec:
             namespace: networking
             sectionName: websecure
     persistence:
-      # NOTE: persistence is intentionally left enabled for now. A follow-up PR
-      # will flip this to false once declarative provisioning of datasources +
-      # dashboards has been verified to survive a fresh PVC.
       enabled: true
       storageClass: longhorn
       existingClaim: pvc-grafana


### PR DESCRIPTION
Declarative provisioning of datasources and dashboards has since been verified to survive a fresh PVC, so the TODO comment about a future follow-up is no longer accurate and just adds noise.