### PR TITLE
feat(grafana): set default timezone to Pacific/Auckland

### DIFF
--- a/kubernetes/cluster0/apps/monitoring/grafana/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/monitoring/grafana/app/helm-release.yaml
@@ -18,6 +18,9 @@ spec:
   install:
     createNamespace: true
   values:
+    grafana.ini:
+      users:
+        default_timezone: Pacific/Auckland
     rbac:
       pspEnabled: false # disable psp, deprecatd in k8s 1.25
     replicas: 1


### PR DESCRIPTION
Sets the Grafana org/server-wide default display timezone to `Pacific/Auckland` so every dashboard and user defaults to NZ time instead of UTC.

## Change

Config-only change to the grafana HelmRelease (`kubernetes/cluster0/apps/monitoring/grafana/app/helm-release.yaml`). Adds a `grafana.ini` block under `spec.values`:

```yaml
grafana.ini:
  users:
    default_timezone: Pacific/Auckland
```

This maps to Grafana's `[users] default_timezone` ini setting, which becomes the fallback timezone for any user/dashboard that hasn't explicitly overridden it.

## Scope

- Display-only. Prometheus and Grafana still store timestamps as UTC epoch internally; only the rendered time axis / panel labels shift to NZ time.
- No changes to datasources, dashboards, sidecar, persistence, or any other part of the HelmRelease.
- Standalone `grafana/grafana` chart (not kube-prometheus-stack).

Flux will roll this out on the next reconcile of `home-ops-cluster0`.