### PR TITLE
feat(monitoring): Loki SingleBinary on SeaweedFS S3 (Phase 1 of #3347)

### DIFF
--- a/kubernetes/cluster0/apps/monitoring/grafana/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/monitoring/grafana/app/helm-release.yaml
@@ -75,6 +75,16 @@ spec:
             isDefault: true
             jsonData:
               timeInterval: 30s
+          # Loki datasource — SingleBinary Loki backed by SeaweedFS S3 (#3347).
+          # Loki auth_enabled is false, so no basicAuth / X-Scope-OrgID needed.
+          - name: Loki
+            type: loki
+            access: proxy
+            url: http://loki.monitoring.svc:3100
+            jsonData:
+              # Cap concurrent line-limit queries; the SingleBinary Loki has
+              # modest resources and we don't need higher parallelism here.
+              maxLines: 1000
     # Provider that the chart drops gnetId-fetched dashboards into.
     dashboardProviders:
       dashboardproviders.yaml:

--- a/kubernetes/cluster0/apps/monitoring/grafana/app/network-policy.yaml
+++ b/kubernetes/cluster0/apps/monitoring/grafana/app/network-policy.yaml
@@ -147,6 +147,29 @@ spec:
             matchLabels:
               app.kubernetes.io/name: prometheus
 ---
+# Allow egress to intra-ns Loki on :3100 (datasource queries) — #3347
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: grafana-allow-loki-egress
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: grafana
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 3100
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: loki
+---
 # Allow egress to external :443 (plugin fetches, avatar downloads, etc.)
 # RFC1918 ranges excluded — intra-cluster traffic goes through explicit pod-selector rules.
 apiVersion: networking.k8s.io/v1

--- a/kubernetes/cluster0/apps/monitoring/kustomization.yaml
+++ b/kubernetes/cluster0/apps/monitoring/kustomization.yaml
@@ -10,4 +10,5 @@ resources:
   - ./changedetection-io/ks.yaml
   - ./grafana/ks.yaml
   - ./kube-prometheus-stack/ks.yaml
+  - ./loki/ks.yaml
   - ./uptime-kuma/ks.yaml

--- a/kubernetes/cluster0/apps/monitoring/loki/app/cilium-network-policy.yaml
+++ b/kubernetes/cluster0/apps/monitoring/loki/app/cilium-network-policy.yaml
@@ -1,0 +1,27 @@
+---
+# CiliumNetworkPolicy: allow Loki egress to the K8s API server.
+#
+# Standard K8s NetworkPolicy ipBlock rules are silently bypassed by Cilium when
+# kubeProxyReplacement=true because the k3s API server runs in the host network
+# namespace and Cilium assigns it the 'kube-apiserver' entity identity rather
+# than a pod identity or IP. The companion ipBlock NetworkPolicy
+# (loki-allow-k8s-api in network-policy.yaml) is kept for defence-in-depth,
+# but this CiliumNetworkPolicy is what actually enforces the allow in practice.
+#
+# Required by the loki-sc-rules sidecar (kiwigrid/k8s-sidecar) which the loki
+# chart runs by default to LIST/WATCH ConfigMaps and Secrets labelled
+# `loki_rule` cluster-wide. Without this rule the sidecar silently fails and
+# any rule discovery breaks. Mirrors the grafana-allow-kube-apiserver pattern;
+# see #2829, #2947, #3062 for prior precedent of the silent-failure mode.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: loki-allow-kube-apiserver
+  namespace: monitoring
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: loki
+  egress:
+    - toEntities:
+        - kube-apiserver

--- a/kubernetes/cluster0/apps/monitoring/loki/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/monitoring/loki/app/helm-release.yaml
@@ -1,0 +1,185 @@
+---
+# Grafana Loki — SingleBinary mode, backed by SeaweedFS S3.
+#
+# Retention correctness is the whole point of this deployment (see #3347):
+# the previous loki-stack removed in #2734 set limits_config.retention_period
+# but never enabled the compactor, so retention was silently a no-op. Here
+# the compactor is enabled with retention_enabled: true and delete_request_store
+# set to s3, which is what actually deletes chunks past retention_period.
+#
+# Chunks + index live in the SeaweedFS S3 bucket "loki"; the StatefulSet keeps
+# a small 10Gi Longhorn PVC for /var/loki (WAL, boltdb-shipper cache, ruler
+# WAL). No bulk log data lives on Longhorn.
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: loki
+  namespace: monitoring
+spec:
+  interval: 15m
+  chart:
+    spec:
+      chart: loki
+      version: 6.55.0
+      sourceRef:
+        kind: HelmRepository
+        name: grafana-charts
+        namespace: flux-system
+      interval: 15m
+  install:
+    remediation:
+      retries: 5
+  upgrade:
+    remediation:
+      retries: 5
+  values:
+    deploymentMode: SingleBinary
+
+    loki:
+      # Homelab single-tenant Loki — no multi-tenant auth.
+      auth_enabled: false
+
+      commonConfig:
+        # SingleBinary with 1 replica cannot satisfy the default RF=3.
+        replication_factor: 1
+
+      # TSDB schema v13 — mandated by the ACs and the current Loki default.
+      schemaConfig:
+        configs:
+          - from: "2024-04-01"
+            store: tsdb
+            object_store: s3
+            schema: v13
+            index:
+              prefix: loki_index_
+              period: 24h
+
+      storage:
+        type: s3
+        bucketNames:
+          chunks: loki
+          ruler: loki
+        s3:
+          endpoint: http://seaweedfs-s3.seaweedfs.svc:8333
+          region: us-east-1
+          s3ForcePathStyle: true
+          # In-cluster plaintext HTTP to the SeaweedFS S3 gateway; TLS is
+          # not configured on that endpoint. Not "insecure" in the internet
+          # sense — this is intra-cluster traffic.
+          insecure: true
+          # AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY are injected via
+          # singleBinary.extraEnvFrom below — Loki's S3 client reads them
+          # natively, so no plaintext creds land in the ConfigMap.
+
+      # THE critical block: this is what makes retention actually run.
+      # The previous loki-stack failure mode (#2734, #3347) was configuring
+      # retention_period without ever enabling the compactor.
+      compactor:
+        working_directory: /var/loki/compactor
+        retention_enabled: true
+        retention_delete_delay: 2h
+        retention_delete_worker_count: 150
+        delete_request_store: s3
+
+      limits_config:
+        # Bounded retention — 7 days (168h). Phase 3 will tighten limits further.
+        retention_period: 168h
+        reject_old_samples: true
+        reject_old_samples_max_age: 168h
+        max_cache_freshness_per_query: 10m
+        split_queries_by_interval: 15m
+        query_timeout: 300s
+        volume_enabled: true
+
+    singleBinary:
+      replicas: 1
+      # Inject SeaweedFS S3 credentials. Loki's S3 client reads
+      # AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY from the environment,
+      # keeping creds out of the ConfigMap and out of Git plaintext.
+      extraEnvFrom:
+        - secretRef:
+            name: loki-s3-credentials
+      persistence:
+        enabled: true
+        size: 10Gi
+        storageClass: longhorn
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          memory: 1Gi
+
+    # Disable the built-in gateway (nginx in front of Loki). We hit Loki
+    # directly from Grafana on the ClusterIP service.
+    gateway:
+      enabled: false
+
+    # Disable memcached-backed caches; the homelab volume doesn't justify
+    # the extra pods. Revisit if query latency becomes a problem.
+    chunksCache:
+      enabled: false
+    resultsCache:
+      enabled: false
+
+    # SingleBinary mode — zero out every SSD/distributed component so the
+    # chart doesn't render StatefulSets/Deployments for read/write/backend
+    # or the individual microservice targets.
+    write:
+      replicas: 0
+    read:
+      replicas: 0
+    backend:
+      replicas: 0
+    ingester:
+      replicas: 0
+    distributor:
+      replicas: 0
+    querier:
+      replicas: 0
+    queryFrontend:
+      replicas: 0
+    queryScheduler:
+      replicas: 0
+    indexGateway:
+      replicas: 0
+    compactor:
+      replicas: 0
+    bloomGateway:
+      replicas: 0
+    bloomPlanner:
+      replicas: 0
+    bloomBuilder:
+      replicas: 0
+    patternIngester:
+      replicas: 0
+
+    monitoring:
+      # Enable the chart's own ServiceMonitor — kube-prometheus-stack runs
+      # with nil selectors so it picks this up cluster-wide (see the repo's
+      # existing convention for ServiceMonitor discovery).
+      serviceMonitor:
+        enabled: true
+        metricsInstance:
+          # Deprecated Grafana Agent Operator integration; not used here.
+          enabled: false
+      # Disable the deprecated self-monitoring stack (Grafana Agent Operator,
+      # loki-canary). We use Alloy for log collection (Phase 2) and don't
+      # need the chart's own self-monitoring bundle.
+      selfMonitoring:
+        enabled: false
+        grafanaAgent:
+          installOperator: false
+      lokiCanary:
+        enabled: false
+      # No chart-shipped dashboards or rules — those are handled elsewhere.
+      dashboards:
+        enabled: false
+      rules:
+        enabled: false
+
+    lokiCanary:
+      enabled: false
+
+    test:
+      enabled: false

--- a/kubernetes/cluster0/apps/monitoring/loki/app/kustomization.yaml
+++ b/kubernetes/cluster0/apps/monitoring/loki/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helm-release.yaml
+  - ./secret.sops.yaml
+  - ./network-policy.yaml

--- a/kubernetes/cluster0/apps/monitoring/loki/app/kustomization.yaml
+++ b/kubernetes/cluster0/apps/monitoring/loki/app/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - ./helm-release.yaml
   - ./secret.sops.yaml
   - ./network-policy.yaml
+  - ./cilium-network-policy.yaml

--- a/kubernetes/cluster0/apps/monitoring/loki/app/network-policy.yaml
+++ b/kubernetes/cluster0/apps/monitoring/loki/app/network-policy.yaml
@@ -1,0 +1,150 @@
+---
+# =============================================================================
+# Loki NetworkPolicy — Phase 1 (#3347)
+# Pod label: app.kubernetes.io/name=loki, app.kubernetes.io/component=single-binary
+# Listens on:
+#   :3100 (HTTP push/query API — Grafana + Alloy in Phase 2)
+#   :9095 (gRPC — memberlist / compactor grpc; intra-pod at replicas=1 but
+#          left permissive for future singleBinary HA)
+#   :7946 (memberlist)
+# Egress to:
+#   seaweedfs/seaweedfs-s3 :8333 (chunk + index + delete-request store)
+#   kube-apiserver         :443/:6443 (kiwigrid/k8s-sidecar LIST/WATCH ConfigMaps
+#                           for loki_rule discovery — mirrors grafana pattern)
+# =============================================================================
+
+# Default deny-all for loki
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: loki-default-deny
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: loki
+  policyTypes: [Ingress, Egress]
+---
+# Allow DNS resolution
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: loki-allow-dns
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: loki
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+---
+# Allow ingress from Grafana (query API) on :3100
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: loki-allow-grafana-ingress
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: loki
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: grafana
+      ports:
+        - port: 3100
+          protocol: TCP
+---
+# Allow ingress from Prometheus (metrics scrape via ServiceMonitor) on :3100
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: loki-allow-prometheus-scrape
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: loki
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+      ports:
+        - port: 3100
+          protocol: TCP
+---
+# Allow egress to SeaweedFS S3 gateway on :8333 (chunk/index/delete store)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: loki-allow-seaweedfs-s3-egress
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: loki
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 8333
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: seaweedfs
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: seaweedfs
+              app.kubernetes.io/component: s3
+---
+# Allow egress to K8s API server — the kiwigrid/k8s-sidecar (loki-sc-rules)
+# container in the loki StatefulSet LISTs/WATCHes ConfigMaps and Secrets
+# cluster-wide via kubernetes.default.svc. Without this rule the sidecar
+# silently fails and any loki_rule-labelled rule discovery breaks.
+# Mirrors the grafana-allow-k8s-api pattern; ipBlock covers the service
+# CIDR and the control-plane node.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: loki-allow-k8s-api
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: loki
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.43.0.0/16  # Service CIDR (kubernetes.default.svc)
+    - ports:
+        - port: 443
+          protocol: TCP
+        - port: 6443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.87.42.2/32  # control plane node

--- a/kubernetes/cluster0/apps/monitoring/loki/app/secret.sops.yaml
+++ b/kubernetes/cluster0/apps/monitoring/loki/app/secret.sops.yaml
@@ -1,0 +1,39 @@
+# IMPORTANT: This file must be encrypted with SOPS before committing.
+# Run:  sops --encrypt --in-place secret.sops.yaml
+#
+# The AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY values here MUST match the
+# credentials of the `loki` identity in the seaweedfs-s3-config secret
+# (kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/s3-config.sops.yaml).
+apiVersion: v1
+kind: Secret
+metadata:
+    name: loki-s3-credentials
+    namespace: monitoring
+type: Opaque
+stringData:
+    AWS_ACCESS_KEY_ID: ENC[AES256_GCM,data:iaem8uzAh/klOVpLMqLw5jvKKScqquk1hM+up0CRicg=,iv:fxLRopkLKneyU/PmYT7PRuzvuJfAYwsy7DlX1fjgCMg=,tag:gDNn3fGoyG8ZSFaCPkwJKw==,type:str]
+    AWS_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:d8uEPssUVUwD9TrP3qu963ezQv0FsfJSAIR/JYs7oyjOWaql48rvTDfDllSg1SymayU0v9+r4p1GfmSZvJP5DQ==,iv:H3HGiVBeCOCugEUTQ5TFUc/nUZm6hYlGYJm4OYFrMTs=,tag:c1K475zNOEwCfbLT18/+XA==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBUQlUxK1FSOFIxMXhKdE5K
+            M2g3WVN5VUtyMTgrZlJuQjFNdHY2U2lWTWpZCmw4dTllM0w0aFFwMzVONG0zZUox
+            VitsNEVFT2JZZXZZT1pDcVJvUUR4K0UKLS0tIGc4UU0xaXlDcmh0VzhEWG91ZUVu
+            c1NwZEZpQldKMy9ZdWhBSDJsVElxMEUK69SQ+i6yd2d8nr4jEC77s4tRDCpjAl+N
+            mY012htvE6NRvPwYUIKs0ituNc83Ix24zRyx9fxXoc9q1ea2QGFHDA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1582vh25trj6w7klwt38d44n5nr8njr8rrxxx5kcfu3y2ezx9ss3s6j24ex
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBqbmRDMDJWNXdyMTl6bnhT
+            YlNJb2M3RmFGaXZmL0RNM1pQUDQwaEk3RVhrCm5MNXVmMjdVK0Q3RSs0QnVSUWEy
+            eVc1TzJ3SGs3NnJ4YTlRVVgrVU9jYmcKLS0tIHRaN1NsbFFOUzhOOERSZFlyTWhH
+            TEdyOU9qM3g3ZzloUFZFMXRwSjhxODAK92LkNoOiN5+oXmmnGX/eGa/vRHY/6ORr
+            PRG31xKZzoGrOTl6vkBOZeHvXRZ4RjRXKrVf4qaJuB1Rq1ML44FjHw==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age185kanaq3uw2gjx5enu2v69nk9ner3lamdevrfgx3wqucsl9ewa2qlt2gf7
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-07-28T09:14:36Z"
+    mac: ENC[AES256_GCM,data:KBoLSzm9jIYvDJRL+jwjhyYm0M+Z99rTNHLYktSp9PhUtoO5DPPTi+DpF881mHcR9h0JP6yHAoRowlpRx0FhQ5lX+K1u3IgkRDg51Y/ZDwYGmR2Q/udibIe0Tjfeo/rz0EcT/6rrVXRYA7TH09BTeRJlPBPLxIU9RKrcyiY2fdE=,iv:krl/6bdlDdHWkxgwRLGjB9a1p3ld68XfNJNFkvGK4Tk=,tag:YO1naWUhn9BwhZTbMcZ+RQ==,type:str]
+    version: 3.13.3

--- a/kubernetes/cluster0/apps/monitoring/loki/ks.yaml
+++ b/kubernetes/cluster0/apps/monitoring/loki/ks.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-apps-loki
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: cluster-apps-longhorn
+    - name: cluster-apps-seaweedfs
+  path: ./kubernetes/cluster0/apps/monitoring/loki/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-cluster0
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: loki
+      namespace: monitoring
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/network-policy.yaml
+++ b/kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/network-policy.yaml
@@ -648,6 +648,31 @@ spec:
         - port: 8333
           protocol: TCP
 ---
+# Allow ingress from monitoring/loki on :8333 (chunk + index + delete-request store)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: seaweedfs-s3-allow-loki-ingress
+  namespace: seaweedfs
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: seaweedfs
+      app.kubernetes.io/component: s3
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: loki
+      ports:
+        - port: 8333
+          protocol: TCP
+---
 # Allow ingress from intra-ns master pod (health checks)
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/s3-config.sops.yaml
+++ b/kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/s3-config.sops.yaml
@@ -4,28 +4,28 @@ metadata:
     name: seaweedfs-s3-config
     namespace: seaweedfs
 stringData:
-    seaweedfs_s3_config: ENC[AES256_GCM,data:SJyxqY/K1uAJcU+AYMffwOib+vVp4ASV+KRddyHhWLnxXxtZXYxFF1ppye8/W6cUDHpwDiVjk1NwNBNBNUyeiPDBdIkQyMBxATOKOUkXJrQJaxIBOg8p/V/MSON1ibuShmpWXwVBPCqaVbR+GHqaVk4ohYfsGyZnsm/BE6Nf8Pz61TG8PIFKbOsQl6mlFa6XY2P27kOMvNlBvEmRvVhTSmjY3K8ERI8wYCL2Ry/dkM0PqYkHKiACMHxRiFBHhYZxK1K5J/DHHOqkrcMrrxh7DALclwUPZdU83iWgeTQhcikmbxF/7yWtodklnUpCW6f4/q0DalaNxEp1ElEQYhEXEjydH4PsQkB/ULdVHHjuFUAz8BrcsC+i3LX5bRdJswVYcawNDU49iOS31cmWzIrQZHt0rzzUkvoCuGa3NGoJbXevbnsbKfmdVXNN1Ps+UDXPspafE32lnd4Jv6awnOrI5KvA5gj9aahcpIV9/tki7iT7eoH7Tf1mxqys7g10zmrX8Ln0tPlcyCP3UGjQfU6cURVy8ku6RxA9WyySZ2XUG+XZrL2asXFgF2dyHU9CA1+vTag7JQOV7hM/W3+hzZzqFc5hse1m9DGivv5HWJwm18b3PAQZACHwFSRKX38GYqfLgtwfO3+8q+8+CpggtYzmeyLy6GwNsuS9HO0AXrFVbQQSTe1p3T1EPstZHdN2IfSi8RcCKfzil7AEul/LnHXWfdZTZcrE66GpBAViq7BSihka,iv:HN/D71/mLPr0Y6t+hoZzj8WKWiMQHy4K11RJ46Pm4Ls=,tag:mPi6ZW+l51kcJNWsEVvL8w==,type:str]
+    seaweedfs_s3_config: ENC[AES256_GCM,data:xIiYogBYARTZ8K6hfw0i8OeJXJNnYLHm+VrnIMdtHFb9QZO1GUPq16yfaiD4Ba/wX1ntb++rVA2abmbLwwMjAo8WCkUB8hhCbXITjACYPoVHgQyF89Y540cYj1srRQ2ImacSKOqiLAuN9aCNDG0BAVbjB5+9YTNUGMoFmYRqUWL7qsE4W7eXc64keWA6Kk7yqQqgSXMBzpUEKQNks95+kYMGBAq2GSnQ/6a80uics0vuSl9DaM8ABPNa8u1Ji8L868Bh1KshxvPcyBUpd/2C7mfwy5LvDXb8356t4VDo7NWBFuhl9/pmcRoKfUI1189oGD22gCos8Os9d8/I4nE4Jwx54ZttuJYDBY8VP+MLsoQh6pPMsV5FCuKX0xnQYkJg45RESYtvIRW/iJ2DUrSfNXpDtA7EKOUO8j39/Y5LoQUeJf30+VHD43MYsHz1g20OZVET7ne4kbbPrLfPH81tv7xO0qnDV3l/34BcrZDuKfRXOVVBLI6X3gmDYflWbzBMYmv6zLBq2VRmgLdxiaSzfp5PRa9wTcpbC1Fv97ZDA9LQN4crWggqTfGeKYei4NXqv5gO9K+zGKdsOXvmKn+VpFBmSp8hUNfCO31ak1W22iePTqDRFAL418FWMc08JxoCpBjkyquze/u+hYJTaM4DLgxUiUFgN0jF6VUREplg+D12jRUGE/jBd50eExUtve7hBaqOxxPAqtmZKz8xIZa008rWzP4Q3w3huQYoCmzhIwetYJznOc3aN0R1gfdPJd95vB63KJtfVaYEDB1kowEgxo7Cq7o84c73rvWrZ/nSPMEGzoNOObMr7RWaEo9z2pUfDCxps73bxjx1biQnHLlBw7Gdpy09b965duQpNCM1Hy3osZxZ4j1xPhfI59EbR47Laq0I6Upr3pJUrC1f028GVYBBPs9FAMTFKo8jrtFGKip0JKlMJrKoghCq4kkH/+JRy0Rsq/B6+swL+ZhirTimQe7hPwZpEvzDfHas/bgtnWghSp2xCtDZnpf1g5Z5MOSQv6aGD8swLrOwO0IkzZic2HtkfQ+IPHKlSOD1yFjY2cuhCt3xZfcC7McquHUkGe58lVsgRs2yONGJZWKiyiThkBH2GSIkMyoQ9ypJ2w==,iv:JFuIFY1n+5euPx5Ybu7wS6C2FZmzS3zwYqOVAzHMSVA=,tag:9SwFRfa5QGijbfGk+lYE4Q==,type:str]
 sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxdlY0VGlFWThxRjAwNHZv
-            T2pETUlnWkxSTUlQNldZR25HOGR6SERHRXhZCjliQTVkOGVIeFRzSHRuODBhZkhY
-            TFEwbllJNWZqNVd0UEJSZHBtM0pxRXcKLS0tIE92eGt0eGZhZnhndTJQUE9GS3c4
-            K2Y4VjRNZDdWWXJQL3U4L3FtTlVHVWsKYjDxY7+BVFWGUE5EpA9prjZ/Gqdf3Nlo
-            1zX49Djbgvrw1X9CGCYCx2dWj1BedU2OoZYGEmWLIZMWSOE7l19zaQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB5MXRRZmIvbG5Bcno1T0Rz
+            WjVjR2R1SVpMaGhRSDQ3RDIzUXgvbVJRYXlRCmNiVzJTdFcxM091eHcrQkVaUm1U
+            cUtMZDhjVDZTQVpKdjFzbTJkSG9ZeVUKLS0tIFZpRWVKaUpxWnVBN3lpUWd4YzJu
+            bkZlTHk4cjdxakxZSzhBd3VabW5nMmMK0VfvJ8bK3xPZAYNewovCpaJB9/mGKtPR
+            hIUIGdv14AdMFFC0uyIQgqPHVwRHLug5u+8Mp8SCRVOLp7W3eFoCmw==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1582vh25trj6w7klwt38d44n5nr8njr8rrxxx5kcfu3y2ezx9ss3s6j24ex
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBycEtGSThnVElYN3ZzajBY
-            SVBJWWdlVWJ3N1JSZlkxWEhtV202anduM2pvClpHR3lNS0pFcC93dkRhczJqZHhE
-            ZEJYeGNBcjRkMnozN0thaVZFbXlKVVEKLS0tIEtkQTdmOUZIK0twR3AvTUVHQmF2
-            YWduQ3hFdVRHSEN0aHUySG9ZT1ROalUK8AmokjFM2h4odnDSvR1ehWs/FYxVHgEx
-            lhm8+xghqb+qZY7MvZDngi8grHX73Pc3JJ46E84QRwKvg6vdWDTBIw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBGcTZxSFQ4OFdwWC9PNlhl
+            VlZ4aU5tRjdBUE1LbllPY01wSXVGSnVIR3h3CmgyeXgwQlFhcWxGdk5rUDNZcjE1
+            WGM0OXExUmFyeDZSQVluQjhkdG1LRFUKLS0tIG1WZ2pSWDZCZ0pxdHNRUXMzT0lG
+            L1JTUTA3VmM3TEIrS3d3MlcwSGlzczQK0Ko+8zsdR21q0ZckP1zVtkqIN3hmyQXX
+            bCsRuvPZQCiG+BKjjbF3e32yIiOXSUzArwKfkHmxi6hAuhG+6RAd+Q==
             -----END AGE ENCRYPTED FILE-----
           recipient: age185kanaq3uw2gjx5enu2v69nk9ner3lamdevrfgx3wqucsl9ewa2qlt2gf7
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-05-15T06:42:57Z"
-    mac: ENC[AES256_GCM,data:bVpRVJ82OTAMTpjbh5U8I3dsat/31qGJPwMuMIRyhpyryzJlTskiewltpBVbkIt5vg4V7VMsnaMVFMKEzevMFW+OZdtpXGB/EBWbIaXuomE3LDHA+wcUBuMtqN0GFtE7HfGdmNuBOUxQxzpAAQvwaUzSeam9oXThdgVIuBlLv+8=,iv:aGQ5vnWourgeN+gqlTKDfIgacjDWnCehdREKoZEq8gs=,tag:IVKiNqPLiqtChPiGa39ZgA==,type:str]
-    version: 3.13.0
+    lastmodified: "2026-07-28T09:15:48Z"
+    mac: ENC[AES256_GCM,data:1l82bjIK/9WB0AcCnoj17lqMOJi9Gobvrc0Eqd3ykbJDNzCtSVFUtp3RbP3Aqxjvbc3g4uumDHQgO4w2OQ7JQItG+Nq4gQgq8MvPGdZ9pfM3XdC7ITyGRh5NlH1JJrDE5Qnqvxhk8OLOv5F+/71pzNF8C0rd4Al3QTfjmMO/oZw=,iv:b8V9ppUoKnZ1Qc3BOoo/ra8E3lwGtTCP2DSOaAoRdYg=,tag:JHhobXayiRnr4U8k6tDl8w==,type:str]
+    version: 3.13.3


### PR DESCRIPTION
Refs #3347.

**Phase 1 of the Loki reintroduction.** Deploys `grafana/loki` in SingleBinary mode, backed by the in-cluster SeaweedFS S3 store, with retention actually enforced by the compactor. Phase 2 (Alloy log collection) and Phase 3 (guardrails + growth alerting) follow in separate PRs.

## Why

The previous `loki-stack` deploy (removed in #2734) configured `limits_config.retention_period: 1d` but never enabled the compactor, so retention was silently a no-op. Combined with a Longhorn PVC that filled up, that produced the stuck-Terminating PVC mess in the git history. This PR designs that failure mode out:

- **Object storage, not Longhorn.** Chunks + index live in the SeaweedFS S3 bucket `loki` at `http://seaweedfs-s3.seaweedfs.svc:8333`. The StatefulSet keeps a small 10Gi Longhorn PVC for `/var/loki` (WAL, boltdb-shipper cache, ruler WAL) — no bulk log data on Longhorn.
- **Compactor is actually enabled.** `loki.compactor.retention_enabled: true`, `delete_request_store: s3`, `retention_period: 168h` (7 days, within the 7-14d bound the ACs specify).
- **TSDB schema v13** from the start (`from: 2024-04-01`, `store: tsdb`, `object_store: s3`).

## Changes

- `kubernetes/cluster0/apps/monitoring/loki/` — new app tree mirroring `uptime-kuma/`:
  - `ks.yaml` — `cluster-apps-loki` Flux Kustomization, depends on `cluster-apps-longhorn` and `cluster-apps-seaweedfs`, health-checks the HelmRelease.
  - `app/helm-release.yaml` — `grafana/loki` chart `6.55.0` (appVersion 3.6.7), SingleBinary mode, `replication_factor: 1`, extraEnvFrom the `loki-s3-credentials` secret so `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` land in env, not in the rendered ConfigMap. Chart's built-in ServiceMonitor enabled; self-monitoring / lokiCanary / dashboards / rules / built-in gateway / memcached caches all disabled. Every SSD & distributed component's replicas explicitly zeroed.
  - `app/secret.sops.yaml` — SOPS-encrypted `loki-s3-credentials` (AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY). Same access/secret pair as the new `loki` identity in `seaweedfs-s3-config`.
  - `app/network-policy.yaml` — default-deny + DNS + ingress from grafana/prometheus on :3100 + egress to seaweedfs/s3 :8333 + egress to kube-apiserver (kiwigrid/k8s-sidecar LIST/WATCH ConfigMaps).
  - `app/kustomization.yaml` — the three resources above.
- `kubernetes/cluster0/apps/monitoring/kustomization.yaml` — added `./loki/ks.yaml`.
- `kubernetes/cluster0/apps/monitoring/grafana/app/helm-release.yaml` — added Loki datasource at `http://loki.monitoring.svc:3100` alongside the existing Prometheus entry.
- `kubernetes/cluster0/apps/monitoring/grafana/app/network-policy.yaml` — new `grafana-allow-loki-egress` on :3100 so the new datasource actually works.
- `kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/s3-config.sops.yaml` — added a `loki` identity (`Read:loki`, `Write:loki`, `List:loki`, `Tagging:loki`, `Admin:loki` — Admin needed so SeaweedFS auto-creates the bucket on first write). Existing `anvAdmin` / `anvReadOnly` / `cnpg` identities preserved verbatim.
- `kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/network-policy.yaml` — new `seaweedfs-s3-allow-loki-ingress` mirroring the existing `seaweedfs-s3-allow-cnpg-ingress`.

## Acceptance-criteria verification

Static verification done in this branch:

- ✅ **[security]** Both credential surfaces are SOPS-encrypted. `git grep` for the plaintext keys returns nothing. Verified round-trip encryption (encryption only requires the public age recipients from `.sops.yaml`).
- ✅ **[functional] TSDB schema v13 + S3 storage** — verified by rendering the HelmRelease values through `helm template grafana/loki --version 6.55.0`. The rendered `config.yaml` ConfigMap contains `schema_config.configs[0].{store: tsdb, object_store: s3, schema: v13}`, `common.storage.s3.endpoint: http://seaweedfs-s3.seaweedfs.svc:8333`, `s3forcepathstyle: true`, `bucketnames: loki`. No Longhorn PVC for chunks — the only PVC is a 10Gi `/var/loki` volume for WAL/cache.
- ✅ **[functional] Compactor + retention** — rendered config contains `compactor.retention_enabled: true`, `compactor.delete_request_store: s3`, `compactor.retention_delete_delay: 2h`, `limits_config.retention_period: 168h`. All within the AC's 7-14d bound.
- ✅ **[functional] Grafana datasource registered in git-managed config** — added under `datasources.datasources.yaml.datasources` in the Grafana HelmRelease.
- ⏳ **[functional] HelmRelease Ready=True** — can only be confirmed post-reconcile; the manifests render cleanly (`flux build kustomization cluster-apps-loki`, `kubectl kustomize`) and the ks.yaml `dependsOn` chain is correct.
- ⏳ **[functional] Datasource healthy + empty query returns empty result** — post-reconcile check via the Grafana datasources API.
- ⏳ **[edge-case] Pre-ingest label/query request returns empty rather than error** — same, post-reconcile.

Pending items are the ones the AC block itself flags as only fully confirmable in-cluster. Nothing gated on a runtime check invalidates the static verification.

## Follow-up notes

- The SeaweedFS `s3` pod does not have a Reloader annotation, so it won't auto-restart on the `seaweedfs-s3-config` secret change. When merging, either bounce the seaweedfs s3 pod once so it picks up the new `loki` identity, or add a Reloader annotation in a follow-up.
- Phase 2 (Alloy DaemonSet) will need a matching `loki-allow-alloy-ingress` NetworkPolicy on port 3100.
- This is Tier 2 monitoring infra, so no auto-merge is expected.