### PR TITLE
feat(monitoring): Alloy DaemonSet log collection (Phase 2 of #3347)

### DIFF
--- a/kubernetes/cluster0/apps/monitoring/alloy/app/cilium-network-policy.yaml
+++ b/kubernetes/cluster0/apps/monitoring/alloy/app/cilium-network-policy.yaml
@@ -1,0 +1,27 @@
+---
+# CiliumNetworkPolicy: allow Alloy egress to the K8s API server.
+#
+# Standard K8s NetworkPolicy ipBlock rules are silently bypassed by Cilium when
+# kubeProxyReplacement=true because the k3s API server runs in the host network
+# namespace and Cilium assigns it the 'kube-apiserver' entity identity rather
+# than a pod identity or IP. The companion ipBlock NetworkPolicy
+# (alloy-allow-k8s-api in network-policy.yaml) is kept for defence-in-depth,
+# but this CiliumNetworkPolicy is what actually enforces the allow in practice.
+#
+# Required by both `discovery.kubernetes` (LIST/WATCH pods) and
+# `loki.source.kubernetes` (GET pods/log stream) — without this the DaemonSet
+# starts up, discovers nothing, and silently ships no logs. Mirrors
+# grafana-allow-kube-apiserver / loki-allow-kube-apiserver; see #2829, #2947,
+# #3062 for prior precedent of the silent-failure mode.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: alloy-allow-kube-apiserver
+  namespace: monitoring
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: alloy
+  egress:
+    - toEntities:
+        - kube-apiserver

--- a/kubernetes/cluster0/apps/monitoring/alloy/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/monitoring/alloy/app/helm-release.yaml
@@ -1,0 +1,227 @@
+---
+# Grafana Alloy — DaemonSet log collector for Loki (Phase 2 of #3347).
+#
+# One pod per node tails container logs under /var/log/pods, normalises the
+# level field, and pushes to the in-cluster Loki SingleBinary
+# (http://loki.monitoring.svc:3100) that landed in Phase 1 (#3348).
+#
+# Label-cardinality strategy (the whole point of Phase 2 — see #3347 comment):
+# stream/index labels are limited to {namespace, app, container, level}.
+# `pod` and `node` are attached as structured metadata (Loki 3.x) so they
+# stay queryable/filterable in Grafana without exploding the stream count.
+# `pod` in particular is unbounded (~300+ values, churns on every restart)
+# and was the classic cardinality killer for the old loki-stack deployment.
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: alloy
+  namespace: monitoring
+spec:
+  interval: 15m
+  chart:
+    spec:
+      chart: alloy
+      version: 1.11.0
+      sourceRef:
+        kind: HelmRepository
+        name: grafana-charts
+        namespace: flux-system
+      interval: 15m
+  install:
+    remediation:
+      retries: 5
+  upgrade:
+    remediation:
+      retries: 5
+  values:
+    controller:
+      # DaemonSet: one Alloy per node, tailing that node's pod logs only.
+      type: daemonset
+      # Tolerate control-plane taints so system pods on the CP node also ship logs.
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
+
+    # Least-privilege RBAC. The chart's default rules grant get/list/watch on
+    # ConfigMaps, Secrets, PrometheusRules, AlertmanagerConfigs, ReplicaSets,
+    # etc. — none of which are needed for pod-log discovery. Override to the
+    # minimum for `discovery.kubernetes` (role=pod) and `loki.source.kubernetes`.
+    rbac:
+      create: true
+      # Rules are split across `rules` and `clusterRules` only to work around a
+      # chart-template quirk: if either list is empty/null the chart emits an
+      # invalid `[]` / `null` token into the ClusterRole `rules:` block
+      # (upstream `templates/rbac.yaml` unconditionally toYaml's both). Both
+      # lists get concatenated into the ClusterRole — verify with
+      # `helm template`. The union is exactly the pod + log discovery set we
+      # need; the default clusterRules (nodes, nodes/pods, nodes/metrics,
+      # /metrics, ConfigMaps, Secrets, PrometheusRules, ...) is dropped.
+      rules:
+        - apiGroups: [""]
+          resources: ["pods", "pods/log"]
+          verbs: ["get", "list", "watch"]
+      clusterRules:
+        - apiGroups: [""]
+          resources: ["namespaces"]
+          verbs: ["get", "list", "watch"]
+
+    # Chart-shipped ServiceMonitor — kube-prometheus-stack runs with nil
+    # selectors so it picks this up cluster-wide (see the repo convention).
+    serviceMonitor:
+      enabled: true
+
+    alloy:
+      # /var/log/pods is a symlink chain into /var/log/containers → the
+      # kubelet-managed container log files. loki.source.kubernetes streams
+      # via the API but we also mount /var/log for the file-tailer path.
+      mounts:
+        varlog: true
+      # Anonymous usage stats — opt out.
+      enableReporting: false
+      configMap:
+        create: true
+        # Alloy config (river/alloy syntax). Pipeline:
+        #   discovery.kubernetes (pods on this node)
+        #     -> discovery.relabel (derive namespace/app/container/pod/node)
+        #     -> loki.source.kubernetes (tail via K8s API)
+        #     -> loki.process (normalise level, enforce label set)
+        #     -> loki.write (push to in-cluster Loki)
+        content: |
+          logging {
+            level  = "info"
+            format = "logfmt"
+          }
+
+          // Discover only pods running on this node — Alloy runs as a
+          // DaemonSet, so each pod scopes discovery via the K8S_NODE_NAME
+          // env var the chart injects (spec.nodeName).
+          discovery.kubernetes "pods" {
+            role = "pod"
+            selectors {
+              role  = "pod"
+              field = "spec.nodeName=" + sys.env("K8S_NODE_NAME")
+            }
+          }
+
+          // Derive our target label set from pod metadata.
+          //   namespace <- __meta_kubernetes_namespace
+          //   app       <- pod label app.kubernetes.io/name (fallback: `app`)
+          //   container <- __meta_kubernetes_pod_container_name
+          //   pod       <- __meta_kubernetes_pod_name  (structured metadata)
+          //   node      <- __meta_kubernetes_pod_node_name (structured metadata)
+          discovery.relabel "pod_logs" {
+            targets = discovery.kubernetes.pods.targets
+
+            rule {
+              source_labels = ["__meta_kubernetes_namespace"]
+              target_label  = "namespace"
+            }
+            // Preferred workload label.
+            rule {
+              source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+              target_label  = "app"
+            }
+            // Fallback: bare `app` label (older charts / hand-written manifests).
+            rule {
+              source_labels = ["app", "__meta_kubernetes_pod_label_app"]
+              separator     = ";"
+              regex         = "^;(.+)$"
+              target_label  = "app"
+              replacement   = "$1"
+            }
+            rule {
+              source_labels = ["__meta_kubernetes_pod_container_name"]
+              target_label  = "container"
+            }
+            rule {
+              source_labels = ["__meta_kubernetes_pod_name"]
+              target_label  = "pod"
+            }
+            rule {
+              source_labels = ["__meta_kubernetes_pod_node_name"]
+              target_label  = "node"
+            }
+          }
+
+          // Tail container logs for the discovered pods via the K8s API.
+          // Requires pods/log RBAC (granted above).
+          loki.source.kubernetes "pods" {
+            targets    = discovery.relabel.pod_logs.output
+            forward_to = [loki.process.normalise.receiver]
+          }
+
+          // Normalise the level field and enforce the approved label set.
+          // See #3347 comment ("label cardinality strategy") for the rules:
+          //   * stream/index labels: namespace, app, container, level
+          //   * structured metadata: pod, node
+          //   * unmatched level -> "unknown" (never drop the line)
+          loki.process "normalise" {
+            // Extract a level token from the log line if present. Best-effort;
+            // structured JSON logs, klog-style prefixes (I0101 ...), and plain
+            // words are all common. Missing/unmatched -> handled below.
+            stage.regex {
+              expression = "(?i)(?:^|[^A-Za-z])(?P<level>trace|debug|info|warn(?:ing)?|err(?:or)?|fatal|critical|panic)(?:[^A-Za-z]|$)"
+            }
+
+            // klog-style single-letter prefixes at line start (I0101 ..., W0101 ...).
+            stage.regex {
+              expression = "^(?P<level>[IWED])[0-9]{4}"
+            }
+
+            // Canonicalise to lowercase {info, warn, error, debug}. Anchored
+            // so partial matches don't collide.
+            stage.replace { source = "level" expression = "^(?i)I(nfo)?$"           replace = "info"  }
+            stage.replace { source = "level" expression = "^(?i)W(arn(ing)?)?$"     replace = "warn"  }
+            stage.replace { source = "level" expression = "^(?i)E(rr(or)?)?$"       replace = "error" }
+            stage.replace { source = "level" expression = "^(?i)D(ebug)?$"          replace = "debug" }
+            stage.replace { source = "level" expression = "^(?i)(fatal|critical|panic)$" replace = "error" }
+            stage.replace { source = "level" expression = "^(?i)trace$"             replace = "debug" }
+
+            // Soft-enforce required fields: missing/empty -> "unknown" so the
+            // line is still ingested and queryable, per the edge-case AC.
+            stage.template { source = "level"     template = "{{ if .Value }}{{ .Value }}{{ else }}unknown{{ end }}" }
+            stage.template { source = "namespace" template = "{{ if .Value }}{{ .Value }}{{ else }}unknown{{ end }}" }
+            stage.template { source = "app"       template = "{{ if .Value }}{{ .Value }}{{ else }}unknown{{ end }}" }
+
+            // Promote the four approved keys to stream labels.
+            stage.labels {
+              values = {
+                namespace = "",
+                app       = "",
+                container = "",
+                level     = "",
+              }
+            }
+
+            // Attach pod + node as structured metadata (Loki 3.x). NOT stream
+            // labels — see the cardinality decision in #3347.
+            stage.structured_metadata {
+              values = {
+                pod  = "",
+                node = "",
+              }
+            }
+
+            // Final gate: drop everything else from the stream index.
+            // Exact list per the Phase 2 spec.
+            stage.label_keep {
+              values = ["app", "container", "level", "namespace"]
+            }
+
+            forward_to = [loki.write.default.receiver]
+          }
+
+          // Push to the in-cluster Loki. auth_enabled=false on the Loki side,
+          // so no tenant header / credential is required for intra-cluster
+          // pushes.
+          loki.write "default" {
+            endpoint {
+              url = "http://loki.monitoring.svc:3100/loki/api/v1/push"
+            }
+          }
+      resources:
+        requests:
+          cpu: 50m
+          memory: 128Mi
+        limits:
+          memory: 512Mi

--- a/kubernetes/cluster0/apps/monitoring/alloy/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/monitoring/alloy/app/helm-release.yaml
@@ -178,19 +178,53 @@ spec:
             }
 
             // Canonicalise to lowercase {info, warn, error, debug}. Anchored
-            // so partial matches don't collide.
-            stage.replace { source = "level" expression = "^(?i)I(nfo)?$"           replace = "info"  }
-            stage.replace { source = "level" expression = "^(?i)W(arn(ing)?)?$"     replace = "warn"  }
-            stage.replace { source = "level" expression = "^(?i)E(rr(or)?)?$"       replace = "error" }
-            stage.replace { source = "level" expression = "^(?i)D(ebug)?$"          replace = "debug" }
-            stage.replace { source = "level" expression = "^(?i)(fatal|critical|panic)$" replace = "error" }
-            stage.replace { source = "level" expression = "^(?i)trace$"             replace = "debug" }
+            // so partial matches don't collide. River requires each attribute
+            // on its own line (or comma-separated) inside a block.
+            stage.replace {
+              source     = "level"
+              expression = "^(?i)I(nfo)?$"
+              replace    = "info"
+            }
+            stage.replace {
+              source     = "level"
+              expression = "^(?i)W(arn(ing)?)?$"
+              replace    = "warn"
+            }
+            stage.replace {
+              source     = "level"
+              expression = "^(?i)E(rr(or)?)?$"
+              replace    = "error"
+            }
+            stage.replace {
+              source     = "level"
+              expression = "^(?i)D(ebug)?$"
+              replace    = "debug"
+            }
+            stage.replace {
+              source     = "level"
+              expression = "^(?i)(fatal|critical|panic)$"
+              replace    = "error"
+            }
+            stage.replace {
+              source     = "level"
+              expression = "^(?i)trace$"
+              replace    = "debug"
+            }
 
             // Soft-enforce required fields: missing/empty -> "unknown" so the
             // line is still ingested and queryable, per the edge-case AC.
-            stage.template { source = "level"     template = "{{ if .Value }}{{ .Value }}{{ else }}unknown{{ end }}" }
-            stage.template { source = "namespace" template = "{{ if .Value }}{{ .Value }}{{ else }}unknown{{ end }}" }
-            stage.template { source = "app"       template = "{{ if .Value }}{{ .Value }}{{ else }}unknown{{ end }}" }
+            stage.template {
+              source   = "level"
+              template = "{{ if .Value }}{{ .Value }}{{ else }}unknown{{ end }}"
+            }
+            stage.template {
+              source   = "namespace"
+              template = "{{ if .Value }}{{ .Value }}{{ else }}unknown{{ end }}"
+            }
+            stage.template {
+              source   = "app"
+              template = "{{ if .Value }}{{ .Value }}{{ else }}unknown{{ end }}"
+            }
 
             // Promote the four approved keys to stream labels.
             stage.labels {

--- a/kubernetes/cluster0/apps/monitoring/alloy/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/monitoring/alloy/app/helm-release.yaml
@@ -150,6 +150,15 @@ spec:
             forward_to = [loki.process.normalise.receiver]
           }
 
+          // NOTE: loki.process copies incoming stream labels (set by
+          // discovery.relabel above) into the per-entry extracted map at
+          // pipeline entry, so the stage.template soft-enforcement,
+          // stage.labels promotion, and stage.structured_metadata stages
+          // below can all read namespace/app/container/pod/node. Ref:
+          // grafana/alloy internal/component/loki/process/stages/pipeline.go
+          // (extracted-map seeding from e.Labels) + the loki.process docs
+          // ("stages have access to ... a shared map of extracted values").
+          //
           // Normalise the level field and enforce the approved label set.
           // See #3347 comment ("label cardinality strategy") for the rules:
           //   * stream/index labels: namespace, app, container, level

--- a/kubernetes/cluster0/apps/monitoring/alloy/app/kustomization.yaml
+++ b/kubernetes/cluster0/apps/monitoring/alloy/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helm-release.yaml
+  - ./network-policy.yaml
+  - ./cilium-network-policy.yaml

--- a/kubernetes/cluster0/apps/monitoring/alloy/app/network-policy.yaml
+++ b/kubernetes/cluster0/apps/monitoring/alloy/app/network-policy.yaml
@@ -1,0 +1,124 @@
+---
+# =============================================================================
+# Alloy NetworkPolicy — Phase 2 (#3347)
+# Pod label: app.kubernetes.io/name=alloy
+# Listens on:
+#   :12345 (HTTP — Alloy UI + /metrics for the ServiceMonitor scrape)
+# Egress to:
+#   loki.monitoring.svc :3100          (log push)
+#   kube-apiserver      :443 / :6443   (discovery.kubernetes + loki.source.kubernetes)
+# Note: kube-apiserver egress needs the companion CiliumNetworkPolicy in
+# cilium-network-policy.yaml — the same silent-bypass caveat as loki applies
+# here (kubeProxyReplacement + kube-apiserver entity identity).
+# =============================================================================
+
+# Default deny-all for alloy
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: alloy-default-deny
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: alloy
+  policyTypes: [Ingress, Egress]
+---
+# Allow DNS resolution
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: alloy-allow-dns
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: alloy
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+---
+# Allow egress to Loki :3100 for log push.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: alloy-allow-loki-egress
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: alloy
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 3100
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: loki
+---
+# Allow ingress from Prometheus (ServiceMonitor scrape) on the metrics port.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: alloy-allow-prometheus-scrape
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: alloy
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+      ports:
+        - port: 12345
+          protocol: TCP
+---
+# Allow egress to the K8s API server for pod discovery + log tailing
+# (discovery.kubernetes + loki.source.kubernetes). Mirrors the loki-allow-k8s-api
+# pattern — ipBlock is the enforcement path for non-Cilium fallbacks; the
+# CiliumNetworkPolicy alongside is what actually enforces the allow when
+# kubeProxyReplacement is on (see the CNP file for the full explanation).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: alloy-allow-k8s-api
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: alloy
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.43.0.0/16  # Service CIDR (kubernetes.default.svc)
+    - ports:
+        - port: 443
+          protocol: TCP
+        - port: 6443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.87.42.2/32  # control plane node

--- a/kubernetes/cluster0/apps/monitoring/alloy/ks.yaml
+++ b/kubernetes/cluster0/apps/monitoring/alloy/ks.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-apps-alloy
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: cluster-apps-loki
+  path: ./kubernetes/cluster0/apps/monitoring/alloy/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-cluster0
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: alloy
+      namespace: monitoring
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/cluster0/apps/monitoring/kustomization.yaml
+++ b/kubernetes/cluster0/apps/monitoring/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   # Pre Flux-Kustomizations
   - ./namespace.yaml
   # Flux-Kustomizations
+  - ./alloy/ks.yaml
   - ./blackbox-exporter/ks.yaml
   - ./changedetection-io/ks.yaml
   - ./grafana/ks.yaml

--- a/kubernetes/cluster0/apps/monitoring/loki/app/network-policy.yaml
+++ b/kubernetes/cluster0/apps/monitoring/loki/app/network-policy.yaml
@@ -70,6 +70,29 @@ spec:
         - port: 3100
           protocol: TCP
 ---
+# Allow ingress from Alloy (log push) on :3100 — Phase 2 (#3347).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: loki-allow-alloy-ingress
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: loki
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: alloy
+      ports:
+        - port: 3100
+          protocol: TCP
+---
 # Allow ingress from Prometheus (metrics scrape via ServiceMonitor) on :3100
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/helm-release.yaml
@@ -74,6 +74,11 @@ spec:
         storageClass: longhorn
       logs:
         type: emptyDir
+      # Auto-restart the filer StatefulSet on seaweedfs-s3-config secret
+      # rotation — avoids the manual bounce Phase 1 (#3348) needed when the
+      # `loki` S3 identity was added. See Phase 2 note on #3347.
+      podAnnotations:
+        reloader.stakater.com/auto: "true"
       s3:
         enabled: true
         enableAuth: true
@@ -86,3 +91,7 @@ spec:
       replicas: 1
       logs:
         type: emptyDir
+      # Same as filer.podAnnotations above — auto-restart the s3 Deployment
+      # on seaweedfs-s3-config secret rotation.
+      podAnnotations:
+        reloader.stakater.com/auto: "true"


### PR DESCRIPTION
Phase 2 of #3347. Deploys **Grafana Alloy** as a DaemonSet that tails pod logs on every node and ships them to the in-cluster Loki that landed in Phase 1 (#3348).

## What lands

- **`kubernetes/cluster0/apps/monitoring/alloy/`** — new HelmRelease (`grafana/alloy` 1.11.0, `controller.type: daemonset`), tolerates control-plane taints so system pods on the CP node also ship logs. ServiceMonitor enabled (kube-prometheus-stack discovers it via nil selectors).
- **`alloy/app/network-policy.yaml`** — default-deny + DNS + Loki :3100 egress + Prometheus :12345 ingress + kube-apiserver ipBlock egress (mirrors the Loki pattern).
- **`alloy/app/cilium-network-policy.yaml`** — `toEntities: [kube-apiserver]` (same silent-bypass caveat that Loki + Grafana already have).
- **`loki/app/network-policy.yaml`** — appends `loki-allow-alloy-ingress` permitting `monitoring/alloy -> loki:3100`.
- **`seaweedfs/seaweedfs/app/helm-release.yaml`** — `reloader.stakater.com/auto: "true"` added to `s3.podAnnotations` and `filer.podAnnotations`, so future `seaweedfs-s3-config` rotations no longer need the manual bounce Phase 1 required.
- **`monitoring/kustomization.yaml`** — wires in `./alloy/ks.yaml` (Flux Kustomization `cluster-apps-alloy`, `dependsOn: cluster-apps-loki`).

## Label-cardinality strategy

Per the audit called out on the Phase 2 comment in #3347:

- **Stream/index labels:** `namespace`, `app`, `container`, `level` (exactly these, enforced by `stage.label_keep`).
- **Structured metadata:** `pod`, `node` (Loki 3.x `stage.structured_metadata` — filterable in Grafana, doesn't blow up the stream count).
- **`level` normalisation:** anchored `stage.replace` rules canonicalise to `info` / `warn` / `error` / `debug`. `trace` folds to `debug`, `fatal` / `critical` / `panic` fold to `error`. Both a generic word-boundary regex and a klog-style `I0101 ...` regex feed the extraction.
- **Unmatched -> `unknown`:** `stage.template` soft-enforces `level`, `namespace`, `app` — missing fields become `"unknown"` rather than dropping the line (edge-case AC).

## RBAC

The chart's default rules grant get/list/watch on ConfigMaps, Secrets, PrometheusRules, AlertmanagerConfigs, ReplicaSets, Nodes, nodes/pods, nodes/metrics — none of which pod-log discovery needs. Trimmed to `pods`, `pods/log`, `namespaces` only.

(Rules are split across `rbac.rules` and `rbac.clusterRules` purely to work around a chart-template bug: if either list is empty/null the chart emits an invalid `[]` / `null` token into the ClusterRole. Comment in the HelmRelease explains this.)

## Static verification (this PR)

- ✅ `helm template grafana/alloy` with the HelmRelease values renders the correct Alloy config: `stage.label_keep { values = [\"app\", \"container\", \"level\", \"namespace\"] }` and `stage.structured_metadata { values = { pod = \"\", node = \"\" } }` are both present verbatim.
- ✅ Rendered ClusterRole contains only `pods`, `pods/log`, `namespaces` (get/list/watch). No ConfigMaps/Secrets/nodes/etc.
- ✅ Rendered ServiceMonitor + DaemonSet present.
- ✅ `helm template seaweedfs/seaweedfs`: `seaweedfs-s3` Deployment and `seaweedfs-filer` StatefulSet carry `reloader.stakater.com/auto: \"true\"` on the pod template; `seaweedfs-master` and `seaweedfs-volume` do not (intentional).
- ✅ `kubectl kustomize` builds cleanly for `alloy/app`, `loki/app`, `monitoring/`, and `seaweedfs/seaweedfs/app`.

## Pending post-reconcile

These ACs can only be confirmed once Flux reconciles:

- Alloy pod Running on every schedulable node.
- Chatty-namespace logs queryable in Grafana Explore within 5 min of rollout.
- `pod` / `node` visible as structured metadata (not labels) on ingested streams.

## Not this PR

- **Phase 3** (`limits_config` ingestion caps, PrometheusRule for bucket growth, retention validation) is a separate PR that `Closes` #3347.

Refs #3347