### PR TITLE
fix(loki): idempotently bootstrap missing SeaweedFS bucket

### DIFF
--- a/kubernetes/cluster0/apps/monitoring/loki/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/monitoring/loki/app/helm-release.yaml
@@ -99,6 +99,31 @@ spec:
       extraEnvFrom:
         - secretRef:
             name: loki-s3-credentials
+      # Hotfix (#3347 Phase 1 follow-up): the "loki" S3 bucket does not
+      # exist in SeaweedFS. Loki's startup/readiness GETs/lists the bucket
+      # before it ever writes, so it hits 404 NoSuchBucket and never becomes
+      # Ready -- which means it never issues the PUT that would otherwise
+      # let SeaweedFS auto-create the bucket. This initContainer breaks that
+      # deadlock by idempotently creating the bucket first. `mc mb
+      # --ignore-existing` is a no-op when the bucket already exists, so
+      # restarts/reschedules never crash-loop on it. Reuses the existing
+      # loki-s3-credentials secret -- no new credentials introduced.
+      initContainers:
+        - name: bootstrap-s3-bucket
+          image: minio/mc:RELEASE.2024-11-21T17-21-54Z
+          command:
+            - sh
+            - -c
+            - |
+              set -eu
+              mc alias set seaweedfs "$MC_HOST_URL" "$AWS_ACCESS_KEY_ID" "$AWS_SECRET_ACCESS_KEY"
+              mc mb --ignore-existing seaweedfs/loki
+          env:
+            - name: MC_HOST_URL
+              value: http://seaweedfs-s3.seaweedfs.svc:8333
+          envFrom:
+            - secretRef:
+                name: loki-s3-credentials
       persistence:
         enabled: true
         size: 10Gi

--- a/kubernetes/cluster0/apps/monitoring/loki/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/monitoring/loki/app/helm-release.yaml
@@ -110,7 +110,7 @@ spec:
       # loki-s3-credentials secret -- no new credentials introduced.
       initContainers:
         - name: bootstrap-s3-bucket
-          image: minio/mc:RELEASE.2024-11-21T17-21-54Z
+          image: minio/mc:RELEASE.2024-11-21T17-21-54Z@sha256:993e8c454a7ec632923f7e3e61adf1d473261da6354cefd641aedd33a2cfe112
           command:
             - sh
             - -c


### PR DESCRIPTION
## Refs #3347

Hotfix for Loki, currently broken in-cluster and firing 4 alerts (Phase 1
follow-up; PR #3348 already merged).

### Root cause (already diagnosed by coordinator)

`loki-0` is NotReady. The `loki` S3 bucket does not exist in SeaweedFS
(confirmed: `SeaweedFS_s3_bucket_object_count` shows only the `postgresql`
bucket; `SeaweedFS_s3_request_total{bucket="loki",code="404",type="GET"}` is
incrementing). Loki's startup/readiness does a GET/list against the object
store before it ever writes, so it hits `404 NoSuchBucket` and never becomes
Ready -- which means it never issues the PUT that SeaweedFS would auto-create
the bucket on. Deadlock. Credentials are fine (404, not 403).

This cascades into 4 firing alerts that clear once Loki is Ready:
`KubePodNotReady` (loki-0), `SeaweedFSS3RequestErrorsHigh`, `TargetDown`
(monitoring/loki), `KubeStatefulSetReplicasMismatch` (loki).

### Fix

Added a `singleBinary.initContainers` entry to the Loki HelmRelease using
`minio/mc`, pinned to `RELEASE.2024-11-21T17-21-54Z`, which runs:

```sh
mc alias set seaweedfs "$MC_HOST_URL" "$AWS_ACCESS_KEY_ID" "$AWS_SECRET_ACCESS_KEY"
mc mb --ignore-existing seaweedfs/loki
```

against `http://seaweedfs-s3.seaweedfs.svc:8333` (path-style addressing via
`mc alias`), before the main Loki container starts. This self-heals on every
pod start/reschedule.

- The grafana/loki chart (v6.55.0) exposes a clean `singleBinary.initContainers`
  list -- no fallback Job was needed.
- Credentials come from the existing `loki-s3-credentials` SOPS secret via
  `envFrom` -- no new secret, no plaintext creds.
- `mc mb --ignore-existing` is a no-op when the bucket already exists, so
  restarts/reschedules never crash-loop on it.
- No new NetworkPolicy required: the pod already has the
  `loki-allow-seaweedfs-s3-egress` egress rule (:8333) from Phase 1, and DNS
  egress is already allowed.

### Acceptance criteria

- [x] **static-verified** An idempotent bucket-bootstrap (Loki pod
      initContainer) ensures the `loki` bucket exists in SeaweedFS before
      Loki's main container starts.
- [x] **static-verified** The bootstrap targets
      `http://seaweedfs-s3.seaweedfs.svc:8333` with path-style addressing and
      reuses the existing `loki-s3-credentials` secret for auth.
- [x] **static-verified** Idempotent: `mc mb --ignore-existing` exits 0 as a
      no-op when the `loki` bucket already exists.
- [x] **static-verified** `helm template` of the Loki HelmRelease renders the
      initContainer with the create-bucket command and credential env wired
      from the secret (confirmed via `helm template ... --version 6.55.0`).
- [x] **static-verified** No new plaintext credentials introduced; reuses
      only the existing SOPS-encrypted `loki-s3-credentials` secret.

`kubectl kustomize` of the app dir also builds cleanly with the change.

### Pending reconcile (coordinator to verify)

- `loki-0` goes Ready after Flux reconciles.
- The 4 firing alerts (`KubePodNotReady`, `SeaweedFSS3RequestErrorsHigh`,
  `TargetDown`, `KubeStatefulSetReplicasMismatch`) clear.