### PR TITLE
feat(networking): stand up Headscale control server (Child A of #3352)

### DIFF
--- a/kubernetes/cluster0/apps/networking/headscale/app/config.yaml
+++ b/kubernetes/cluster0/apps/networking/headscale/app/config.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: headscale-config
+  namespace: networking
+data:
+  config.yaml: |-
+    ---
+    server_url: https://hs.${SECRET_PUBLIC_DOMAIN}
+    listen_addr: 0.0.0.0:8080
+    metrics_listen_addr: 0.0.0.0:9091
+
+    noise:
+      private_key_path: /var/lib/headscale/noise_private.key
+
+    derp:
+      server:
+        enabled: false
+      urls:
+        - https://controlplane.tailscale.com/derpmap/default
+      auto_update_enabled: true
+      update_frequency: 24h
+
+    database:
+      type: sqlite
+      sqlite:
+        path: /var/lib/headscale/db.sqlite
+
+    log:
+      level: info
+
+    policy:
+      mode: file
+      path: /etc/headscale/policy.hujson

--- a/kubernetes/cluster0/apps/networking/headscale/app/httproute.yaml
+++ b/kubernetes/cluster0/apps/networking/headscale/app/httproute.yaml
@@ -1,0 +1,29 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: headscale
+  namespace: networking
+spec:
+  hostnames:
+    - hs.${SECRET_PUBLIC_DOMAIN}
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: traefik-gateway
+      namespace: networking
+      sectionName: websecure
+  rules:
+    # NOTE: no forwardauth-authelia filter here - headscale clients
+    # (tailscale/headscale nodes) need to reach the noise/TS2021 protocol
+    # un-proxied by forward-auth. Traefik terminates TLS; the WebSocket
+    # upgrade for the noise protocol passes straight through.
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: headscale
+          namespace: networking
+          port: 8080
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/kubernetes/cluster0/apps/networking/headscale/app/kustomization.yaml
+++ b/kubernetes/cluster0/apps/networking/headscale/app/kustomization.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./config.yaml
+  - ./policy.yaml
+  - ./statefulset.yaml
+  - ./service.yaml
+  - ./httproute.yaml
+  - ./servicemonitor.yaml
+  - ./network-policy.yaml
+labels:
+  - pairs:
+      app.kubernetes.io/name: headscale
+      app.kubernetes.io/instance: headscale

--- a/kubernetes/cluster0/apps/networking/headscale/app/network-policy.yaml
+++ b/kubernetes/cluster0/apps/networking/headscale/app/network-policy.yaml
@@ -1,0 +1,115 @@
+---
+# -----------------------------------------------------------------------------
+# Default-deny — applies to the headscale pod.
+# -----------------------------------------------------------------------------
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: headscale-default-deny
+  namespace: networking
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: headscale
+  policyTypes: [Ingress, Egress]
+---
+# -----------------------------------------------------------------------------
+# Traefik ingress on :8080 - the noise/TS2021 control-plane API that
+# headscale clients talk to via the HTTPRoute (un-proxied, no forward-auth).
+# -----------------------------------------------------------------------------
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: headscale-allow-traefik-ingress
+  namespace: networking
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: headscale
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: traefik
+      ports:
+        - port: 8080
+          protocol: TCP
+---
+# -----------------------------------------------------------------------------
+# Prometheus scrape ingress on :9091.
+# -----------------------------------------------------------------------------
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: headscale-allow-prometheus-scrape
+  namespace: networking
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: headscale
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+      ports:
+        - port: 9091
+          protocol: TCP
+---
+# -----------------------------------------------------------------------------
+# Internet egress on :443 - headscale fetches the public DERP map from
+# https://controlplane.tailscale.com/derpmap/default (auto_update_enabled).
+# -----------------------------------------------------------------------------
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: headscale-allow-internet-egress
+  namespace: networking
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: headscale
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+---
+# -----------------------------------------------------------------------------
+# DNS egress to CoreDNS in kube-system.
+# -----------------------------------------------------------------------------
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: headscale-allow-dns
+  namespace: networking
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: headscale
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns

--- a/kubernetes/cluster0/apps/networking/headscale/app/policy.yaml
+++ b/kubernetes/cluster0/apps/networking/headscale/app/policy.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: headscale-policy
+  namespace: networking
+data:
+  # Minimal policy for this PR: only declares tag ownership so nodes can be
+  # tagged at registration time. The actual grants/autoApprovers land with
+  # the subnet router (child issue, see #3352).
+  policy.hujson: |-
+    {
+      "tagOwners": {
+        "tag:k8s-router": ["homeops@"],
+        "tag:nixos": ["homeops@"],
+      },
+    }

--- a/kubernetes/cluster0/apps/networking/headscale/app/service.yaml
+++ b/kubernetes/cluster0/apps/networking/headscale/app/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: headscale
+  namespace: networking
+  labels:
+    app.kubernetes.io/name: headscale
+spec:
+  selector:
+    app.kubernetes.io/name: headscale
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+      protocol: TCP
+    - name: metrics
+      port: 9091
+      targetPort: metrics
+      protocol: TCP

--- a/kubernetes/cluster0/apps/networking/headscale/app/servicemonitor.yaml
+++ b/kubernetes/cluster0/apps/networking/headscale/app/servicemonitor.yaml
@@ -1,0 +1,15 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: headscale
+  namespace: networking
+  labels:
+    app.kubernetes.io/name: headscale
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: headscale
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s

--- a/kubernetes/cluster0/apps/networking/headscale/app/statefulset.yaml
+++ b/kubernetes/cluster0/apps/networking/headscale/app/statefulset.yaml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: headscale
+  namespace: networking
+spec:
+  serviceName: headscale
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: headscale
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: headscale
+    spec:
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+        - name: headscale
+          image: ghcr.io/juanfont/headscale:0.29.2
+          args: ["serve"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
+            seccompProfile:
+              type: RuntimeDefault
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+            - name: metrics
+              containerPort: 9091
+              protocol: TCP
+          volumeMounts:
+            - name: config
+              mountPath: /etc/headscale/config.yaml
+              subPath: config.yaml
+              readOnly: true
+            - name: policy
+              mountPath: /etc/headscale/policy.hujson
+              subPath: policy.hujson
+              readOnly: true
+            - name: data
+              mountPath: /var/lib/headscale
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+      volumes:
+        - name: config
+          configMap:
+            name: headscale-config
+        - name: policy
+          configMap:
+            name: headscale-policy
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: longhorn
+        resources:
+          requests:
+            storage: 1Gi

--- a/kubernetes/cluster0/apps/networking/headscale/ks.yaml
+++ b/kubernetes/cluster0/apps/networking/headscale/ks.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-apps-headscale
+  namespace: flux-system
+spec:
+  path: ./kubernetes/cluster0/apps/networking/headscale/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-cluster0
+  dependsOn:
+    - name: cluster-apps-longhorn
+  healthChecks:
+    - apiVersion: apps/v1
+      kind: StatefulSet
+      name: headscale
+      namespace: networking
+  interval: 30m
+  retryInterval: 1m
+  timeout: 3m

--- a/kubernetes/cluster0/apps/networking/kustomization.yaml
+++ b/kubernetes/cluster0/apps/networking/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   - ./gateway-api/ks.yaml
   - ./traefik/ks.yaml
   - ./cloudflared/ks.yaml
+  - ./headscale/ks.yaml


### PR DESCRIPTION
Refs #3352

Child A of #3352 (read the design doc first). Stands up the Headscale control server so a tailnet exists and nodes can register. Foundation for the subnet router (Child B) and the nixos-config client (Child C).

## What's here

New app under `kubernetes/cluster0/apps/networking/headscale/` using bare manifests (no community Helm chart - small surface, avoids chart lag), mirroring the app/ks layout used elsewhere in `networking/`.

- **StatefulSet** `ghcr.io/juanfont/headscale:0.29.2`, single replica. SQLite DB + noise private key on a 1Gi Longhorn-backed PVC (`volumeClaimTemplates`) mounted at `/var/lib/headscale` - survives pod restarts.
- **config ConfigMap** mounted at `/etc/headscale/config.yaml`: `server_url: https://hs.${SECRET_PUBLIC_DOMAIN}`, `listen_addr: 0.0.0.0:8080`, `metrics_listen_addr: 0.0.0.0:9091`, `database.type: sqlite`, `policy.mode: file` + `policy.path`, `noise.private_key_path`. Consumes the default public derpmap; embedded DERP server explicitly disabled.
- **policy ConfigMap** (hujson): minimal `tagOwners` for `tag:k8s-router` and `tag:nixos` (owner `homeops@`). Grants/autoApprovers land in Child B.
- **Service** (ClusterIP) exposing :8080 and :9091.
- **HTTPRoute** at `hs.${SECRET_PUBLIC_DOMAIN}` via `traefik-gateway`/`websecure`, mirroring the Longhorn HTTPRoute. Deliberately **no `forwardauth-authelia` filter** - headscale clients need unproxied noise/TS2021 (WebSocket upgrade over TLS; Traefik terminates TLS).
- **ServiceMonitor** for :9091 (kube-prometheus-stack has nil selectors, so this is auto-discovered).
- Wired `./headscale/ks.yaml` into the `networking` apps kustomization; `ks.yaml` `dependsOn: cluster-apps-longhorn`.
- Default-deny NetworkPolicy for the headscale pod, plus scoped allows: Traefik ingress on :8080, Prometheus ingress on :9091, DNS egress, and internet egress on :443 (needed for the DERP map fetch - `auto_update_enabled: true` against `https://controlplane.tailscale.com/derpmap/default`).

## Verification

- Static: `kustomize build kubernetes/cluster0/apps/networking/headscale/app` renders cleanly, and `kubectl apply --dry-run=client` accepts every resource against this cluster's installed CRDs (HTTPRoute, ServiceMonitor).
- Static: confirmed the PVC is a real `volumeClaimTemplates` entry (Longhorn storage class), not `emptyDir`.
- **Not run**: `flux-local test` (the CI check) - podman is non-functional in this sandbox (`Error: no such file or directory` on any `podman run`/`podman info`, pre-existing environment issue unrelated to this change). CI will run it on the PR.
- **Pending reconcile** (can't verify outside the live cluster): StatefulSet actually reaching Ready, PVC binding, node registration against the running Headscale instance.

Closes: N/A (Child B closes the parent per the design doc)