### PR TITLE
fix: add writable HOME/tmp mount to bootstrap-s3-bucket initContainer

### DIFF
--- a/kubernetes/cluster0/apps/monitoring/loki/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/monitoring/loki/app/helm-release.yaml
@@ -126,6 +126,8 @@ spec:
           envFrom:
             - secretRef:
                 name: loki-s3-credentials
+          # Mount the chart's built-in tmp emptyDir so mc can write config to /tmp/.mc
+          # (chart v6.55.0 defines tmp as an emptyDir in the StatefulSet spec.volumes)
           volumeMounts:
             - name: tmp
               mountPath: /tmp

--- a/kubernetes/cluster0/apps/monitoring/loki/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/monitoring/loki/app/helm-release.yaml
@@ -121,9 +121,14 @@ spec:
           env:
             - name: MC_HOST_URL
               value: http://seaweedfs-s3.seaweedfs.svc:8333
+            - name: HOME
+              value: /tmp
           envFrom:
             - secretRef:
                 name: loki-s3-credentials
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
       persistence:
         enabled: true
         size: 10Gi


### PR DESCRIPTION
Refs #3347

This is a minimal P1 fix for the stalled Loki HelmRelease.

The bootstrap-s3-bucket initContainer was failing with:
```
mc: <ERROR> Unable to save new mc config. mkdir /.mc: permission denied
```

**Root cause:** The Loki pod runs as non-root (UID 10001). The mc tool writes its config to `$HOME/.mc`, and since HOME was unset, it defaulted to `/` — which UID 10001 cannot write to.

**Fix:** 
1. Set `HOME=/tmp` so mc writes config to /tmp/.mc
2. Mount the chart's existing `tmp` emptyDir volume at /tmp in the initContainer

This allows mc to complete the bucket creation, breaking the prior deadlock where Loki would never issue the PUT request that would auto-create the bucket (because it was failing on startup).

**Verification:**
- `helm template` renders the initContainer with HOME=/tmp and the volumeMount
- The command remains idempotent (`--ignore-existing`)
- No new secret introduced — reuses existing loki-s3-credentials