### PR TITLE
fix: add required headscale 0.29 prefixes and dns config blocks

### DIFF
--- a/kubernetes/cluster0/apps/networking/headscale/app/config.yaml
+++ b/kubernetes/cluster0/apps/networking/headscale/app/config.yaml
@@ -29,6 +29,19 @@ data:
     log:
       level: info
 
+    prefixes:
+      v4: 100.64.0.0/10
+      v6: fd7a:115c:a1e0::/48
+
+    dns:
+      magic_dns: true
+      base_domain: tailnet.internal
+      override_local_dns: false
+      nameservers:
+        global:
+          - 1.1.1.1
+          - 8.8.8.8
+
     policy:
       mode: file
       path: /etc/headscale/policy.hujson


### PR DESCRIPTION
Refs #3352

P1 hotfix: add missing  and  config blocks to headscale 0.29 configuration.

**Root cause:** headscale-0 was CrashLoopBackOff due to validation errors:
1. `dns.nameservers.global` must be set when `dns.override_local_dns` is true (default)
2. At least one IPv4 or IPv6 prefix is required

**Changes:**
- Added standard Tailscale CGNAT ranges: `100.64.0.0/10` (v4) and `fd7a:115c:a1e0::/48` (v6)
- Added DNS config with `override_local_dns: false` and sensible nameservers

**Validation:** Config passes `headscale configtest` against headscale:0.29.2

Static validation: `kubectl kustomize` renders cleanly with valid ConfigMap YAML.