### PR TITLE
fix(headscale): set unix_socket to writable PVC path

### DIFF
--- a/kubernetes/cluster0/apps/networking/headscale/app/config.yaml
+++ b/kubernetes/cluster0/apps/networking/headscale/app/config.yaml
@@ -8,6 +8,7 @@ data:
     ---
     server_url: https://hs.${SECRET_PUBLIC_DOMAIN}
     listen_addr: 0.0.0.0:8080
+    unix_socket: /var/lib/headscale/headscale.sock
     metrics_listen_addr: 0.0.0.0:9091
 
     noise:


### PR DESCRIPTION
Refs #3352

headscale defaults its CLI socket to /var/run/headscale/headscale.sock, but the pod runs non-root and cannot create that directory. This causes the pod to crash with a permission error at startup.

The pod already has a writable Longhorn PVC mounted at /var/lib/headscale with fsGroup=1000 permissions. This fix sets the unix_socket config to point to the writable PVC path instead.

Validated: config renders cleanly via `kubectl kustomize`, embedded YAML is valid.