### PR TITLE
Fix Prometheus scraping of Loki and Alloy

### DIFF
--- a/kubernetes/cluster0/apps/monitoring/kube-prometheus-stack/app/network-policy.yaml
+++ b/kubernetes/cluster0/apps/monitoring/kube-prometheus-stack/app/network-policy.yaml
@@ -683,6 +683,52 @@ spec:
           podSelector:
             matchLabels:
               app.kubernetes.io/name: blocky-secondary
+---
+# Allow Prometheus egress to scrape intra-ns Loki on :3100 (metrics via ServiceMonitor)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: prometheus-allow-loki-scrape-egress
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 3100
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: loki
+---
+# Allow Prometheus egress to scrape intra-ns Alloy on :12345 (metrics via ServiceMonitor)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: prometheus-allow-alloy-scrape-egress
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 12345
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: alloy
 
 # =============================================================================
 # Alertmanager — Phase 3b (#2945)


### PR DESCRIPTION
Refs #3347

Adds two missing NetworkPolicy resources to allow Prometheus egress to Loki and Alloy for metrics scraping.

**Root Cause**

Prometheus has a default-deny egress policy in place. Every scrape target has reciprocal allow policies, but Loki and Alloy were missing the Prometheus *egress* half of the rule (the ingress half was present).

**Changes**

- `prometheus-allow-loki-scrape-egress`: Allow Prometheus pod egress to monitoring/loki on TCP 3100
- `prometheus-allow-alloy-scrape-egress`: Allow Prometheus pod egress to monitoring/alloy on TCP 12345

Both policies:
- Select pods with `app.kubernetes.io/name: prometheus` (StatefulSet)
- Use `policyTypes: [Egress]`
- Match the existing `prometheus-allow-*-scrape-egress` pattern in the file
- Verified with `kubectl kustomize`

**Verification**

Static verification with `kubectl kustomize` passes. Post-reconcile, Prometheus metrics collection should resume:
- `up{job="monitoring/loki"}=1`
- `up{job="monitoring/alloy"}=1`
- `loki_*` and `alloy_*` metrics appear in Prometheus