### PR TITLE
feat(loki): Phase 3 guardrails - ingestion limits + growth alerting

### DIFF
--- a/kubernetes/cluster0/apps/monitoring/loki/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/monitoring/loki/app/helm-release.yaml
@@ -82,7 +82,7 @@ spec:
         delete_request_store: s3
 
       limits_config:
-        # Bounded retention — 7 days (168h). Phase 3 will tighten limits further.
+        # Bounded retention -- 7 days (168h).
         retention_period: 168h
         reject_old_samples: true
         reject_old_samples_max_age: 168h
@@ -90,6 +90,42 @@ spec:
         split_queries_by_interval: 15m
         query_timeout: 300s
         volume_enabled: true
+
+        # --- Phase 3 guardrails (#3347) ---
+        # Bound per-stream and total ingestion so a single misbehaving
+        # stream (e.g. a chatty pod with an unstable label, or a log-line
+        # loop) cannot exhaust the SeaweedFS bucket before anyone notices.
+        # These are deliberately generous for a single homelab node running
+        # Alloy on ~a dozen namespaces, not defaults copied from a
+        # multi-tenant SaaS deployment -- the point is a ceiling, not a
+        # tight budget.
+        #
+        # ingestion_rate_mb / ingestion_burst_size_mb: sustained/burst
+        # ingest rate across the whole tenant. 8 MB/s sustained, 16 MB/s
+        # burst is generous headroom over current usage (~477MB received
+        # total since deploy) while still capping a runaway logger well
+        # below "fill the disk".
+        ingestion_rate_mb: 8
+        ingestion_burst_size_mb: 16
+
+        # per_stream_rate_limit(_burst): caps a single stream (unique
+        # label set) so one noisy pod can't monopolise the tenant-wide
+        # budget above. 4 MB/s per stream is half the tenant budget --
+        # generous for any one workload's normal log volume, but low
+        # enough that a single crash-looping pod hits discards (visible in
+        # loki_discarded_bytes_total) instead of silently consuming all
+        # ingestion headroom.
+        per_stream_rate_limit: 4MB
+        per_stream_rate_limit_burst: 8MB
+
+        # max_global_streams_per_user: with the curated Alloy label set
+        # (namespace/app/pod/container/level), stream count is roughly
+        # (running pods) x (containers) x (log levels seen) -- low
+        # hundreds for this cluster. 5000 gives headroom for redeploys /
+        # rolling restarts (old + new pod streams coexist briefly) without
+        # allowing unbounded label-cardinality blowup to create endless
+        # new streams.
+        max_global_streams_per_user: 5000
 
     singleBinary:
       replicas: 1
@@ -135,6 +171,16 @@ spec:
         enabled: true
         size: 10Gi
         storageClass: longhorn
+      # Phase 3 (#3347): bounded envelope for a single-binary Loki on
+      # homelab log volume. Requests are sized for steady-state (WAL
+      # flush + TSDB index writes + occasional Explore queries); the
+      # memory limit gives headroom above steady-state for query bursts
+      # and compactor runs without leaving so much slack that a genuine
+      # leak/runaway goes unnoticed. No CPU limit -- CPU is throttled
+      # (compressible), so limiting it only slows query/compaction bursts
+      # for no OOM-prevention benefit; the memory limit is the guardrail
+      # that matters here. Coordinator validates via a 24h soak (no
+      # OOMKills) post-merge.
       resources:
         requests:
           cpu: 100m

--- a/kubernetes/cluster0/apps/monitoring/loki/app/kustomization.yaml
+++ b/kubernetes/cluster0/apps/monitoring/loki/app/kustomization.yaml
@@ -3,6 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helm-release.yaml
+  - ./prometheusrule.yaml
   - ./secret.sops.yaml
   - ./network-policy.yaml
   - ./cilium-network-policy.yaml

--- a/kubernetes/cluster0/apps/monitoring/loki/app/prometheusrule.yaml
+++ b/kubernetes/cluster0/apps/monitoring/loki/app/prometheusrule.yaml
@@ -1,0 +1,60 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: loki
+  namespace: monitoring
+spec:
+  groups:
+    - name: loki.guardrails
+      rules:
+        # Phase 3 guardrail (#3347): the previous loki-stack failure mode was
+        # unbounded growth going unnoticed until a Longhorn PVC filled up.
+        # Loki now lives on SeaweedFS S3 with retention_period: 168h enforced
+        # by the compactor, so the bucket should plateau -- steady growth
+        # past that point means either retention/the compactor stopped
+        # working, or ingestion has outgrown the 7-day retention budget.
+        # Threshold is a soft early-warning, not a hard cluster capacity
+        # limit; adjust as the SeaweedFS cluster's total capacity is known.
+        - alert: LokiS3BucketUsageHigh
+          expr: |
+            SeaweedFS_s3_bucket_size_bytes{bucket="loki"} > 20 * 1024 * 1024 * 1024
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Loki S3 bucket usage is above 20GiB"
+            description: "The 'loki' SeaweedFS S3 bucket has held more than 20GiB for over 30 minutes ({{ $value | humanize1024 }}B). With a 168h (7d) retention_period this should plateau -- sustained growth past this point suggests the compactor has stopped deleting old chunks, or ingestion volume has outgrown the retention budget."
+
+        # Guards the same failure mode from the ingestion side: a
+        # misbehaving stream sustaining high ingest for an extended period
+        # will fill the bucket well before the 20GiB alert above fires.
+        # 6 MB/s sustained for 15m sits below the tenant-wide
+        # ingestion_rate_mb: 8 ceiling in limits_config, so it fires before
+        # Loki starts discarding samples -- an early warning, not a
+        # duplicate of the discard-driven alert below.
+        - alert: LokiIngestionRateHigh
+          expr: |
+            sum(rate(loki_distributor_bytes_received_total[15m])) > 6 * 1024 * 1024
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Loki ingestion rate is unusually high"
+            description: "Loki has received log data at over 6MB/s for 15 minutes ({{ $value | humanize1024 }}B/s), approaching the tenant-wide ingestion_rate_mb: 8 limit. Check for a misbehaving/log-looping pod before Loki starts discarding samples."
+
+        # Direct signal that limits_config guardrails are actively rejecting
+        # data -- i.e. a stream or the tenant has hit the caps configured
+        # above. This is expected occasionally under a genuine burst, but
+        # sustained discards for 15m mean something is stuck emitting logs
+        # far above normal volume.
+        - alert: LokiIngestionDiscardsHigh
+          expr: |
+            sum(rate(loki_discarded_samples_total[15m])) > 0
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Loki is discarding ingested log samples"
+            description: "Loki has discarded log samples over the last 15 minutes (reason={{ $labels.reason }}, tenant={{ $labels.tenant }}). This means a stream or the tenant has hit the per_stream_rate_limit / ingestion_rate_mb guardrails in limits_config -- investigate the source pod/namespace before increasing limits."


### PR DESCRIPTION
## Summary

Implements Phase 3 (Guardrails) of #3347. Phases 1 & 2 (Loki on SeaweedFS S3, Alloy DaemonSet) are already merged. This PR bounds ingestion so a single misbehaving stream cannot exhaust storage, and adds alerting on bucket growth / ingestion rate so the runaway-volume failure that killed the previous Loki deployment cannot recur silently.

Closes #3347

## Changes

### `limits_config` guardrails (`helm-release.yaml`)

Added to the existing `limits_config` block (retention/reject-old-samples/query settings untouched):

- `ingestion_rate_mb: 8` / `ingestion_burst_size_mb: 16` -- tenant-wide sustained/burst ingest cap. Current total received since deploy is ~477MB, so 8MB/s gives generous headroom while still capping a runaway logger well below "fill the disk".
- `per_stream_rate_limit: 4MB` / `per_stream_rate_limit_burst: 8MB` -- caps a single stream (unique label set) at half the tenant budget, so one noisy pod can't monopolise ingestion for everyone else. Breaches surface as discards in `loki_discarded_bytes_total`/`loki_discarded_samples_total` rather than silent resource exhaustion.
- `max_global_streams_per_user: 5000` -- with the curated Alloy label set (namespace/app/pod/container/level), expected stream count is low hundreds; 5000 gives headroom for rolling restarts without permitting unbounded cardinality blowup.

Rationale for each value is inline as a comment in the config.

### PrometheusRule (`loki/app/prometheusrule.yaml`, new)

Added a Loki-scoped `PrometheusRule` in the loki app directory (kept separate from the seaweedfs app's own rule, since these are Loki-specific concerns even though one queries a SeaweedFS metric) with three `severity: warning` alerts:

- `LokiS3BucketUsageHigh` -- `SeaweedFS_s3_bucket_size_bytes{bucket="loki"} > 20GiB` for 30m. With `retention_period: 168h` enforced by the compactor the bucket should plateau; sustained growth past 20GiB means retention/the compactor stopped working or ingestion has outgrown the retention budget.
- `LokiIngestionRateHigh` -- sustained ingest > 6MB/s for 15m, an early warning below the 8MB/s `ingestion_rate_mb` ceiling so it fires before Loki starts discarding.
- `LokiIngestionDiscardsHigh` -- any sustained `loki_discarded_samples_total` rate for 15m, a direct signal that the new `limits_config` guardrails are actively rejecting data somewhere.

All three PromQL expressions were validated by executing them as instant queries against the live Prometheus datasource (empty results are expected -- values are currently well under threshold and there are no discards).

### Resources (`helm-release.yaml`)

Left `requests`/`limits` (100m/256Mi request, 1Gi memory limit) unchanged -- already sane for the current homelab log volume -- and added a comment documenting the rationale (steady-state sizing, headroom for query/compaction bursts, no CPU limit since CPU is compressible and doesn't need an OOM-style guardrail). The 24h soak (no OOMKills) is coordinator-validated post-merge per the AC.

## Retention validation (AC: temporarily short retention_period)

Per the AC, this is a **runtime check the coordinator validates post-reconcile**, not something to merge with a permanently-short retention. Statically:

- `compactor.retention_enabled: true`, `delete_request_store: s3`, `retention_delete_delay: 2h`, `retention_delete_worker_count: 150` are already in place from Phase 1 and untouched here.
- `limits_config.retention_period: 168h` (7d) is the enforced bound, matched by `reject_old_samples_max_age: 168h`.

Suggested runtime validation steps for the coordinator:
1. Temporarily set `retention_period` to something short (e.g. `1h`) and push to a throwaway branch/manual test -- do not merge a short value to `main`.
2. Wait for the compactor's retention pass to run (check `loki_compactor_*` metrics / logs, or `SeaweedFS_s3_bucket_size_bytes{bucket="loki"}` for a drop).
3. Confirm via `mc ls seaweedfs/loki` (or the SeaweedFS filer UI) that chunk objects older than the test window are gone.
4. Revert to `168h` and confirm the bucket stabilizes at the real retention window.

## Validation performed

- `kubectl kustomize kubernetes/cluster0/apps/monitoring/loki/app` renders cleanly, including the new PrometheusRule.
- All three alert PromQL expressions executed successfully as instant queries against the live Prometheus datasource (no query errors; empty results as expected given current low volume/zero discards).
- Metrics used (`SeaweedFS_s3_bucket_size_bytes`, `loki_distributor_bytes_received_total`, `loki_discarded_samples_total`) confirmed present and correctly labelled (`bucket="loki"`) in the live instance.