### PR TITLE
feat(networking): tailscale subnet router + ACL policy (Child B of #3352)

### DIFF
--- a/kubernetes/cluster0/apps/networking/headscale/app/kustomization.yaml
+++ b/kubernetes/cluster0/apps/networking/headscale/app/kustomization.yaml
@@ -9,6 +9,10 @@ resources:
   - ./httproute.yaml
   - ./servicemonitor.yaml
   - ./network-policy.yaml
+  - ./tailscale-router-rbac.yaml
+  - ./tailscale-router-secret.sops.yaml
+  - ./tailscale-router-deployment.yaml
+  - ./tailscale-router-network-policy.yaml
 labels:
   - pairs:
       app.kubernetes.io/name: headscale

--- a/kubernetes/cluster0/apps/networking/headscale/app/policy.yaml
+++ b/kubernetes/cluster0/apps/networking/headscale/app/policy.yaml
@@ -4,13 +4,85 @@ metadata:
   name: headscale-policy
   namespace: networking
 data:
-  # Minimal policy for this PR: only declares tag ownership so nodes can be
-  # tagged at registration time. The actual grants/autoApprovers land with
-  # the subnet router (child issue, see #3352).
+  # Headscale v0.29 policy manager (policy v2). Uses the modern `grants`
+  # form (headscale supports both `acls` and `grants`; grants is Tailscale's
+  # newer shape and what we standardise on going forward).
+  #
+  # Access story:
+  #   tag:nixos    - remote NixOS observability consumers
+  #                  ONLY reach prometheus:9090 and loki:3100
+  #   tag:k8s-router - the in-cluster tailscale-router pod
+  #                    auto-approves its own 10.43.0.0/16 route advertisement
+  #                    so an operator doesn't have to run
+  #                    `headscale nodes approve-routes` on every redeploy
+  #
+  # Hosts are pinned to current ClusterIPs (as /32). Tradeoff: if the
+  # prometheus or loki Service is deleted and recreated, its ClusterIP may
+  # change and this file has to be updated. Alternatives considered:
+  #   - broad CIDR (10.43.0.0/16) - defeats the ACL: peers could reach
+  #     any Service, not just prom/loki.
+  #   - pod-IP CIDR (10.42.0.0/16) - would need TS_ROUTES adjusted too,
+  #     and pod IPs churn faster than ClusterIPs.
+  #   ClusterIP /32 wins: services must be reconstituted deliberately
+  #   (rare), and the policy update is a one-line change.
   policy.hujson: |-
     {
       "tagOwners": {
         "tag:k8s-router": ["homeops@"],
-        "tag:nixos": ["homeops@"],
+        "tag:nixos":      ["homeops@"],
       },
+
+      // Named hosts referenced from `grants` and `tests`. /32s pin to the
+      // current in-cluster Service ClusterIPs; update if the Service is
+      // recreated.
+      "hosts": {
+        "prometheus": "10.43.180.44/32", // prometheus-kube-prometheus-prometheus.monitoring
+        "loki":       "10.43.108.90/32", // loki.monitoring
+      },
+
+      // The in-cluster router advertises the k3s service CIDR. Without
+      // autoApprovers, an operator would have to run
+      // `headscale nodes approve-routes ...` after every re-registration.
+      "autoApprovers": {
+        "routes": {
+          "10.43.0.0/16": ["tag:k8s-router"],
+        },
+      },
+
+      // Least-privilege access: tag:nixos peers may reach ONLY
+      //   prometheus tcp/9090 and loki tcp/3100.
+      // Everything else (SSH, other ports on the same hosts, the router
+      // itself, other cluster services) is denied by the default-deny
+      // posture of the tailnet: absence of a grant is a deny.
+      "grants": [
+        {
+          "src": ["tag:nixos"],
+          "dst": ["prometheus"],
+          "ip":  ["tcp:9090"],
+        },
+        {
+          "src": ["tag:nixos"],
+          "dst": ["loki"],
+          "ip":  ["tcp:3100"],
+        },
+      ],
+
+      // Static assertions that get evaluated on every `headscale policy set`
+      // / file-mode reload. If any accept fails or any deny succeeds, the
+      // policy write is rejected and the previous good policy stays live.
+      // See hscontrol/policy/v2/test.go in juanfont/headscale.
+      "tests": [
+        {
+          "src": "tag:nixos",
+          "accept": [
+            "prometheus:9090",
+            "loki:3100",
+          ],
+          "deny": [
+            "prometheus:22",         // no SSH to prometheus
+            "loki:9095",             // no gRPC to loki
+            "tag:k8s-router:22",     // no SSH to the router pod
+          ],
+        },
+      ],
     }

--- a/kubernetes/cluster0/apps/networking/headscale/app/tailscale-router-deployment.yaml
+++ b/kubernetes/cluster0/apps/networking/headscale/app/tailscale-router-deployment.yaml
@@ -1,0 +1,115 @@
+---
+# =============================================================================
+# tailscale-router
+#
+# In-cluster Tailscale subnet router advertising the k3s service CIDR
+# (10.43.0.0/16) into the headscale-hosted tailnet, so tag:nixos peers can
+# reach in-cluster Services by their ClusterIPs. See design doc #3352.
+#
+# hostNetwork: true is a REQUIREMENT, not a preference:
+#   Cilium runs with kubeProxyReplacement=true. Its socket-LB DNATs
+#   ClusterIP -> pod IP at the *origin socket*, not on the wire. Packets
+#   the router receives on its tun interface from a tailnet peer and then
+#   *forwards* to a ClusterIP arrive as routed traffic, so socket-LB never
+#   sees the origin socket and the ClusterIP is not translated. Running
+#   the router in the node netns (hostNetwork) puts the destination lookup
+#   in the host's routing stack where Cilium *does* apply ClusterIP DNAT
+#   for routed packets. This is the same mitigation the upstream Tailscale
+#   Kubernetes operator uses. Full rationale + fallbacks in #3352.
+#
+# TS_USERSPACE=false so we get the kernel tun device (userspace mode does
+# NAT in-process and would defeat the point of putting us in host netns).
+# That requires /dev/net/tun access, hence the hostPath device mount and
+# NET_ADMIN.
+# =============================================================================
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tailscale-router
+  namespace: networking
+spec:
+  replicas: 1
+  strategy:
+    # Recreate rather than RollingUpdate: two subnet routers advertising
+    # the same prefix simultaneously would confuse peer route tables.
+    # A brief gap on redeploy is acceptable for the observability use case.
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tailscale-router
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tailscale-router
+    spec:
+      serviceAccountName: tailscale-router
+      hostNetwork: true
+      # ClusterFirstWithHostNet so the router still resolves cluster DNS
+      # (blocky -> upstream) for the login-server URL; the pod's own
+      # /etc/resolv.conf points at CoreDNS rather than the node resolver.
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+        - name: tailscale
+          image: ghcr.io/tailscale/tailscale:v1.98.9@sha256:f15d5d3f4a68773a853180b72496f70ba614b64de0878c43fe3da39fe0afba47
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            # Not privileged: tailscaled just needs NET_ADMIN + /dev/net/tun
+            # for the kernel-mode subnet router. NET_RAW is required for
+            # tailscale's netfilter/nftables programming.
+            capabilities:
+              add: [NET_ADMIN, NET_RAW]
+              drop: [ALL]
+            allowPrivilegeEscalation: true
+          env:
+            # Persist tailnet node state (machine key, node key, ...) into
+            # this Secret. The RBAC in tailscale-router-rbac.yaml pins
+            # get/update/patch to exactly this name.
+            - name: TS_KUBE_SECRET
+              value: tailscale-state
+            - name: TS_USERSPACE
+              value: "false"
+            - name: TS_AUTHKEY
+              valueFrom:
+                secretKeyRef:
+                  name: tailscale-router-auth
+                  key: TS_AUTHKEY
+            # k3s default service CIDR (verified: every existing
+            # network-policy.yaml in this cluster references 10.43.0.0/16
+            # as "Service CIDR", and kubectl -n monitoring get svc confirms
+            # allocated ClusterIPs live in 10.43.x.x).
+            - name: TS_ROUTES
+              value: "10.43.0.0/16"
+            - name: TS_EXTRA_ARGS
+              value: >-
+                --login-server=https://hs.${SECRET_PUBLIC_DOMAIN}
+                --advertise-tags=tag:k8s-router
+                --hostname=k8s-router
+            # We publish routes, not DNS; don't let the router try to
+            # rewrite the node's resolv.conf.
+            - name: TS_ACCEPT_DNS
+              value: "false"
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+          volumeMounts:
+            - name: dev-net-tun
+              mountPath: /dev/net/tun
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 128Mi
+      volumes:
+        # tailscaled with TS_USERSPACE=false opens /dev/net/tun to create
+        # the tun interface. Kubelet doesn't expose /dev/net/tun to a
+        # non-privileged container by default, even on hostNetwork.
+        - name: dev-net-tun
+          hostPath:
+            path: /dev/net/tun
+            type: CharDevice

--- a/kubernetes/cluster0/apps/networking/headscale/app/tailscale-router-network-policy.yaml
+++ b/kubernetes/cluster0/apps/networking/headscale/app/tailscale-router-network-policy.yaml
@@ -1,0 +1,214 @@
+---
+# =============================================================================
+# tailscale-router network policy
+#
+# CAVEAT — hostNetwork enforcement:
+#   The tailscale-router pod runs with hostNetwork: true. Cilium treats
+#   traffic from hostNetwork pods as originating from the `reserved:host`
+#   identity, not the pod's endpoint identity. Standard K8s NetworkPolicy
+#   podSelector rules (this file) and CiliumNetworkPolicy endpointSelector
+#   rules matching the pod's labels are therefore NOT enforced against the
+#   router's forwarded traffic — that would require enabling Cilium's
+#   host-firewall feature cluster-wide (invasive).
+#
+#   This policy is retained for two reasons:
+#     1. Documentation — the ONLY egress the router should ever need.
+#     2. Defence-in-depth if host-firewall is later enabled.
+#
+#   The router's *actual* runtime blast radius is bounded elsewhere:
+#     - the tailnet ACL in policy.yaml (only tag:nixos -> prom/loki:9090/3100)
+#     - node-level firewall / kernel routing (host has its own posture)
+#
+#   The peer-side ACL enforcement is where the security guarantee lives.
+# =============================================================================
+---
+# Default deny-all on the router pod. Documents intent; not enforced against
+# host-netns traffic (see caveat above).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: tailscale-router-default-deny
+  namespace: networking
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: tailscale-router
+  policyTypes: [Ingress, Egress]
+---
+# DNS resolution to cluster CoreDNS. Router uses ClusterFirstWithHostNet
+# to resolve the login-server URL.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: tailscale-router-allow-dns
+  namespace: networking
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: tailscale-router
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+---
+# Internet egress on :443 (TCP) - the headscale control endpoint at
+# hs.${SECRET_PUBLIC_DOMAIN} and Tailscale's public DERP relay pool.
+# DERP uses TCP 443; tailscaled falls back to it when direct WireGuard
+# NAT-traversal fails. Private ranges excluded so the router can't
+# accidentally scan the internal network on 443.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: tailscale-router-allow-internet-egress
+  namespace: networking
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: tailscale-router
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+---
+# Direct WireGuard: tailscaled binds a random UDP port and sends/receives
+# WireGuard datagrams peer-to-peer. Destination ports are peer-chosen,
+# so we allow the full high-port UDP range to any public IP. This is
+# defence-in-depth documentation only (see file header caveat).
+#
+# Also covers STUN (UDP 3478) for NAT discovery.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: tailscale-router-allow-wireguard-egress
+  namespace: networking
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: tailscale-router
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - protocol: UDP
+      to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+---
+# Egress to prometheus (monitoring ns) on :9090.
+#
+# This rule is what makes the "grant tag:nixos access to prometheus" story
+# actually work at the packet layer: a tailnet peer's scrape request lands
+# on the router's tun interface and gets *forwarded* to the prometheus
+# ClusterIP. From the pod-network policy engine's perspective, that
+# forwarded traffic originates at the router pod, hits Cilium's host-netns
+# routing (because hostNetwork), then reaches the prometheus pod. If
+# host-firewall is enabled later, this is the rule that keeps the router
+# reachable to its ACL-approved destinations.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: tailscale-router-allow-prometheus-egress
+  namespace: networking
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: tailscale-router
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 9090
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+---
+# Egress to loki (monitoring ns) on :3100.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: tailscale-router-allow-loki-egress
+  namespace: networking
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: tailscale-router
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 3100
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: loki
+---
+# Cilium companion: since the router runs in the host netns, its forwarded
+# traffic is identified as `reserved:host` at policy time. Allow prometheus
+# and loki ingress from `host` and `remote-node` so the peer-forwarded
+# packets aren't dropped by their respective default-deny policies.
+# Mirrors the pattern from kube-system/cilium/app/cilium-network-policy.yaml
+# (hubble-relay -> host-networked cilium-agent) and Prometheus's
+# host-networked scrape targets.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: prometheus-allow-tailscale-router-ingress
+  namespace: monitoring
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+  ingress:
+    - fromEntities:
+        - host
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "9090"
+              protocol: TCP
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: loki-allow-tailscale-router-ingress
+  namespace: monitoring
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: loki
+  ingress:
+    - fromEntities:
+        - host
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "3100"
+              protocol: TCP

--- a/kubernetes/cluster0/apps/networking/headscale/app/tailscale-router-rbac.yaml
+++ b/kubernetes/cluster0/apps/networking/headscale/app/tailscale-router-rbac.yaml
@@ -1,0 +1,48 @@
+---
+# ServiceAccount for the tailscale-router pod. The pod stores its tailnet
+# node state (machine key, node key, etc.) into the `tailscale-state` Secret
+# via the kube-secret mode of tailscaled (TS_KUBE_SECRET=tailscale-state).
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tailscale-router
+  namespace: networking
+---
+# RBAC scoped to the single Secret the router persists into
+# (`tailscale-state`). The `create` verb has to be granted on the
+# whole `secrets` resource because Kubernetes RBAC does not allow
+# resourceNames on create - the resource does not exist yet at
+# create time, so no name to match. Get/update/patch are pinned
+# to the single resource name.
+#
+# This exactly matches the tailscale.com/v1.98/docs/k8s/role.yaml
+# reference minus the `events` verbs, which the operator only needs
+# when publishing operator-managed events for its CRDs. A bare
+# subnet router does not.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: tailscale-router
+  namespace: networking
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["tailscale-state"]
+    verbs: ["get", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tailscale-router
+  namespace: networking
+subjects:
+  - kind: ServiceAccount
+    name: tailscale-router
+    namespace: networking
+roleRef:
+  kind: Role
+  name: tailscale-router
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes/cluster0/apps/networking/headscale/app/tailscale-router-secret.sops.yaml
+++ b/kubernetes/cluster0/apps/networking/headscale/app/tailscale-router-secret.sops.yaml
@@ -1,49 +1,32 @@
-# ---------------------------------------------------------------------------
-# tailscale-router preauth key.
-#
-# TS_AUTHKEY is a headscale preauth key that the router pod uses to register
-# itself into the tailnet on first boot (and re-register if `tailscale-state`
-# is lost). Mint via:
-#
-#   kubectl -n networking exec -it headscale-0 -- \
-#     headscale preauthkeys create --user homeops \
-#       --reusable --tags tag:k8s-router --expiration 8760h
-#
-# Replace REPLACE_ME_WITH_HEADSCALE_PREAUTH_KEY below, then encrypt in place:
-#
-#   sops encrypt --in-place kubernetes/cluster0/apps/networking/headscale/app/tailscale-router-secret.sops.yaml
-#
-# (Or `sops edit` to unseal/edit/reseal in one step once already encrypted.)
-# ---------------------------------------------------------------------------
 apiVersion: v1
 kind: Secret
 metadata:
-    name: tailscale-router-auth
-    namespace: networking
+  name: tailscale-router-auth
+  namespace: networking
 type: Opaque
 stringData:
-    TS_AUTHKEY: ENC[AES256_GCM,data:YDx1Wvbj+d2egH3pf4/zZdOysigMYlBauQoIWwf9EmEXOyU51g==,iv:pMGqedSSzEbr8c5GgToCUTG2wrbwFITie2KhV1XBsFM=,tag:OuzBC35vkL9SGMJYfFXdpg==,type:str]
+  TS_AUTHKEY: ENC[AES256_GCM,data:u69+idhoW3oHLpABVwrL+BjvZ4Nd/F5Ur1RNvo5OBi/XEuBAfrb4izVR76LzIFG8ATUSQktCtMVS+CRAA1DzsDiRCdYHuJ71LKjWavJ9B7WrLpLAs5ResA==,iv:PuM08UDhJ8sxMppoFqxxoz4VIv++wFdy3cSXDnIOV44=,tag:v/IoJsLR90thjCsTwveuyg==,type:str]
 sops:
-    age:
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1WVNwNDExdk41UTIyQktw
-            c0JHOHQzYkhiUWhOZVJ3WjFVZWVqWXhKbDJJCllWSzNKY0tOYzYwNlFMbWt3dkxC
-            TXNWbGJqQ01wWGJXQlVNdGxhR3hodkkKLS0tIHRMUC9nVnM4dytobkVLQUpIbWhC
-            bmUzcWg1VDZyUHVXUnVOVFVCamNyaUEKm0xDZE4WxfQXLC5MwcnrLQItbRUKGY8s
-            gp/JDI6PckH0FqWrCCZUvBxcG46+uFCjFglXBymsCPcjKMSzAE4Tng==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1582vh25trj6w7klwt38d44n5nr8njr8rrxxx5kcfu3y2ezx9ss3s6j24ex
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQV3hnWm5BYmloS21ZejA2
-            KzVVNFphV3lybFd3MnJJYkQ5U2Nld0xCRzFRCkVsT1NzakZvVG5BQ3RoalhnaUNj
-            L044akNmcGwxM0UzV25xZ3AyZzdCbnMKLS0tIGU5YlpoaHlqbEgxb0RtTlVzU2Rn
-            Z0dhaXBXSkNCUkVuWXJVRWpVZ3pOMjQKOL3Ve9tpgymPVg3ASMNgp+g8JQs+FDtj
-            Fxkk6apC4kdSk022WoaWvYW6QoaIydsTLZg4NEWAl+WDNAZN9t/25A==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age185kanaq3uw2gjx5enu2v69nk9ner3lamdevrfgx3wqucsl9ewa2qlt2gf7
-    encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-07-28T19:20:09Z"
-    mac: ENC[AES256_GCM,data:7CP3Ub/1f39cNqeC1U3WdgHFZrHcKgEl74MNZRaqAOTx53/pD5kAAkqELiolE5/4rGT2H4UEGykgXkyPhfpQgCijBcQZooD2hMHvsSyXPdJdp6Pil0THoGxdETAZqDQGBVK28RK1H0G2p3PSzzJJbclWuWLeACN8tGFCFUQDXy8=,iv:GRkQ1lplZtKTHbeXPwrurBA3VI/fq3i1hXWdTThIhZk=,tag:UPZmrhKLQG8BA8DCw0ymJg==,type:str]
-    version: 3.13.3
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6WTZ2Y2lrVWcybVB6WDZW
+        VnZieS9raVpnY3dxUjluL0VnK3NnTkRpS3hJCjB2V2lvam43R0hHMkJzeWViOGRl
+        OVdyWTFKb1R2SGpRL2svTlRWT1lsM0UKLS0tIGNmZ083RXd6WVVpdDB2Q2s3SFp3
+        Rjc3QzRZQU9DTmpZTEZsczlCU1cySFkKUEVNu/OWZt88b+6vyZ+sFIgJAW+rxc2Z
+        I2GwLmBrIRWP0whE4Fkv40tgtf8AIgJiBPE3KEJPGgZVumHLFg1CdQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1582vh25trj6w7klwt38d44n5nr8njr8rrxxx5kcfu3y2ezx9ss3s6j24ex
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBLMXhkRmJ3NW9NQmVOb2Z6
+        YjBVL2NEY1RqVWRXOHg1SEtlUlNxTmNETW5RCmxzM0luVlJSblJHRVRGSzVyTWlU
+        UnVKQ1pibWxVdktlSHcxUlNyZmtkckkKLS0tIFVsZFlHWk5GcXNpT3B4M1BxdVRG
+        eXNibTBuZDlXWUZkUmo2ek1heGt4THcK4vkvuYpMSF1PAVRyJTgR/BLfgzvXXYZe
+        yU0BYVAvn1RXM22ltn326h0WbcHQJnemsu8CtgbdxQ1edhYTDrzbXg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age185kanaq3uw2gjx5enu2v69nk9ner3lamdevrfgx3wqucsl9ewa2qlt2gf7
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-07-28T19:44:07Z"
+  mac: ENC[AES256_GCM,data:0OW2+oN/fTSycqxJVsLLh8u2VdjO4OLVaW4ab0061WxTmWELahb5wnZXkXg3OCdgnxYBdCrviov+Bykz5D9HZbk64JI9aw0n5Vqz3OPWzxxVhBBLlwRG9fPS2+6/uL5q5Juacv9ZWG1EX831GnijKq1IDPo4/TC1t4ZaCieuOqY=,iv:jJuZe9JgZzFBB3zZtKoJ7dhw++j4WECMNyQXODR6rW8=,tag:BpbWF0RAV01LX5SatW3G9w==,type:str]
+  version: 3.13.3

--- a/kubernetes/cluster0/apps/networking/headscale/app/tailscale-router-secret.sops.yaml
+++ b/kubernetes/cluster0/apps/networking/headscale/app/tailscale-router-secret.sops.yaml
@@ -1,0 +1,49 @@
+# ---------------------------------------------------------------------------
+# tailscale-router preauth key.
+#
+# TS_AUTHKEY is a headscale preauth key that the router pod uses to register
+# itself into the tailnet on first boot (and re-register if `tailscale-state`
+# is lost). Mint via:
+#
+#   kubectl -n networking exec -it headscale-0 -- \
+#     headscale preauthkeys create --user homeops \
+#       --reusable --tags tag:k8s-router --expiration 8760h
+#
+# Replace REPLACE_ME_WITH_HEADSCALE_PREAUTH_KEY below, then encrypt in place:
+#
+#   sops encrypt --in-place kubernetes/cluster0/apps/networking/headscale/app/tailscale-router-secret.sops.yaml
+#
+# (Or `sops edit` to unseal/edit/reseal in one step once already encrypted.)
+# ---------------------------------------------------------------------------
+apiVersion: v1
+kind: Secret
+metadata:
+    name: tailscale-router-auth
+    namespace: networking
+type: Opaque
+stringData:
+    TS_AUTHKEY: ENC[AES256_GCM,data:YDx1Wvbj+d2egH3pf4/zZdOysigMYlBauQoIWwf9EmEXOyU51g==,iv:pMGqedSSzEbr8c5GgToCUTG2wrbwFITie2KhV1XBsFM=,tag:OuzBC35vkL9SGMJYfFXdpg==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1WVNwNDExdk41UTIyQktw
+            c0JHOHQzYkhiUWhOZVJ3WjFVZWVqWXhKbDJJCllWSzNKY0tOYzYwNlFMbWt3dkxC
+            TXNWbGJqQ01wWGJXQlVNdGxhR3hodkkKLS0tIHRMUC9nVnM4dytobkVLQUpIbWhC
+            bmUzcWg1VDZyUHVXUnVOVFVCamNyaUEKm0xDZE4WxfQXLC5MwcnrLQItbRUKGY8s
+            gp/JDI6PckH0FqWrCCZUvBxcG46+uFCjFglXBymsCPcjKMSzAE4Tng==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1582vh25trj6w7klwt38d44n5nr8njr8rrxxx5kcfu3y2ezx9ss3s6j24ex
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQV3hnWm5BYmloS21ZejA2
+            KzVVNFphV3lybFd3MnJJYkQ5U2Nld0xCRzFRCkVsT1NzakZvVG5BQ3RoalhnaUNj
+            L044akNmcGwxM0UzV25xZ3AyZzdCbnMKLS0tIGU5YlpoaHlqbEgxb0RtTlVzU2Rn
+            Z0dhaXBXSkNCUkVuWXJVRWpVZ3pOMjQKOL3Ve9tpgymPVg3ASMNgp+g8JQs+FDtj
+            Fxkk6apC4kdSk022WoaWvYW6QoaIydsTLZg4NEWAl+WDNAZN9t/25A==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age185kanaq3uw2gjx5enu2v69nk9ner3lamdevrfgx3wqucsl9ewa2qlt2gf7
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-07-28T19:20:09Z"
+    mac: ENC[AES256_GCM,data:7CP3Ub/1f39cNqeC1U3WdgHFZrHcKgEl74MNZRaqAOTx53/pD5kAAkqELiolE5/4rGT2H4UEGykgXkyPhfpQgCijBcQZooD2hMHvsSyXPdJdp6Pil0THoGxdETAZqDQGBVK28RK1H0G2p3PSzzJJbclWuWLeACN8tGFCFUQDXy8=,iv:GRkQ1lplZtKTHbeXPwrurBA3VI/fq3i1hXWdTThIhZk=,tag:UPZmrhKLQG8BA8DCw0ymJg==,type:str]
+    version: 3.13.3


### PR DESCRIPTION
<!-- markdownlint-disable MD013 -->

Closes #3352 — implements Child B (#3354) of the private-observability
tailnet design. Child A (headscale control server) landed in #3355 with
fixes #3357/#3358. This PR is the final home-ops piece; the tailscale
client half on the NixOS boxes (Child C) is delegated to the `nixos-config`
repo.

## What lands

All under `kubernetes/cluster0/apps/networking/headscale/app/`:

| File | Purpose |
| --- | --- |
| `tailscale-router-deployment.yaml` | Subnet router Deployment (`hostNetwork: true`, `NET_ADMIN`+`NET_RAW`, tailscale `v1.98.9`@sha256), advertises `10.43.0.0/16` and `tag:k8s-router` to headscale. |
| `tailscale-router-rbac.yaml` | ServiceAccount + Role + RoleBinding scoped to `secrets/tailscale-state` (get/update/patch) + `create` on secrets in `networking`. |
| `tailscale-router-secret.sops.yaml` | SOPS-encrypted `TS_AUTHKEY` placeholder. Operator fills in the real preauth key and re-seals — see mint instructions below. |
| `tailscale-router-network-policy.yaml` | Default-deny + explicit allow for the router pod (headscale/DNS/prom/loki/internet + WireGuard UDP) + companion `CiliumNetworkPolicy`s on prom/loki so their default-deny lets `reserved:host` ingress through. |
| `policy.yaml` (updated) | `hosts` (prom/loki as ClusterIP /32), `grants` (`tag:nixos` → `prometheus:9090` + `loki:3100` **only**), `autoApprovers` (`10.43.0.0/16` for `tag:k8s-router`), and a `tests` block encoding the allow/deny expectations. |

## `hostNetwork: true` is required, not optional

Cilium runs with `kubeProxyReplacement=true`. Its socket-LB DNATs
ClusterIP → pod IP at the *origin socket*, not on the wire. Packets the
router receives on its tun interface from a tailnet peer and then
**forwards** to a ClusterIP arrive as routed traffic, so socket-LB never
sees the origin socket and the ClusterIP is never translated — a curl
from a peer to a ClusterIP hangs. Running the router in the node netns
puts the destination lookup in the host's routing stack where Cilium
does apply ClusterIP DNAT for routed packets. This is the same
mitigation the upstream Tailscale Kubernetes operator uses. Full
rationale + fallbacks in the design doc (#3352).

## hostNetwork network-policy caveat (documented in-file)

Cilium identifies hostNetwork-pod traffic as `reserved:host`, not the
pod's endpoint identity. Standard K8s NetworkPolicy `podSelector` rules
matching the router pod are therefore **not enforced against the
router's forwarded traffic** without cluster-wide `hostFirewall`
enablement (invasive; out of scope for this PR).

The router's runtime blast radius is bounded elsewhere:

1. The tailnet ACL in `policy.yaml` (only `tag:nixos` → prom/loki:9090/3100).
2. Node-level firewall / kernel routing on the host.

The pod-selected policy is retained as documentation + defence-in-depth
for a possible future host-firewall rollout. The prom/loki ingress side
uses CNPs with `fromEntities: [host, remote-node]` so their default-deny
does accept the forwarded packets today — that half **is** enforced.

## ACL surface

```
tag:nixos    - remote NixOS observability consumers
               allowed: prometheus:9090, loki:3100
               denied:  everything else (implicit)

tag:k8s-router - the in-cluster router
                 autoApprover for 10.43.0.0/16
```

`tests` asserts:

- Accept: `prometheus:9090`, `loki:3100`
- Deny: `prometheus:22`, `loki:9095`, `tag:k8s-router:22`

## Minting the preauth key

Once this PR is merged and Flux has applied the manifests, on the cluster:

```sh
kubectl -n networking exec -it headscale-0 -- \
  headscale preauthkeys create \
    --user homeops \
    --reusable \
    --tags tag:k8s-router \
    --expiration 8760h
```

Then locally:

```sh
sops kubernetes/cluster0/apps/networking/headscale/app/tailscale-router-secret.sops.yaml
# replace REPLACE_ME_WITH_HEADSCALE_PREAUTH_KEY with the key from above
# save + close; sops re-encrypts in place
git add -p kubernetes/cluster0/apps/networking/headscale/app/tailscale-router-secret.sops.yaml
git commit -m "chore(networking): seal tailscale-router preauth key"
git push
```

Note that the initial rollout will see the tailscale-router pod
`CrashLoopBackoff` until the placeholder value is replaced — that's
deliberate (a real preauth key is the operator's to mint).

## Static verification (pre-rollout)

- `kubectl kustomize` renders 24 resources cleanly (11 NetworkPolicies,
  2 CiliumNetworkPolicies, 2 ConfigMaps, Deployment, StatefulSet, RBAC
  trio, Service, ServiceMonitor, HTTPRoute, Secret).
- Deployment renders with `hostNetwork: true`, `NET_ADMIN`+`NET_RAW`,
  `TS_ROUTES=10.43.0.0/16`, `TS_AUTHKEY` sourced from
  `tailscale-router-auth` Secret, `--login-server=https://hs.${SECRET_PUBLIC_DOMAIN}`.
- `policy.hujson` parses + validates against `github.com/juanfont/headscale@v0.29.2`'s
  `hscontrol/policy/v2.NewPolicyManager` (tested locally with two
  fabricated tagged nodes so the `tests` block actually evaluates —
  0 test failures, 1 compiled filter rule from the two grants).
- SOPS envelope round-trips against the two recipients declared in
  `.sops.yaml` (`age1582vh…` + `age185ka…`).

## Coordinator-validated (post-rollout)

- Router registers with headscale, `10.43.0.0/16` route auto-approves.
- From a registered `tag:nixos` peer:
  - `curl http://<prometheus-clusterip>:9090/-/ready` succeeds.
  - `curl http://<loki-clusterip>:3100/ready` succeeds.
  - `curl http://<prometheus-clusterip>:22` refused/blocked.
  - `curl http://<loki-clusterip>:9095` refused/blocked.

## De-confliction with #3361

#3361 lands a `prometheus-allow-networking-headscale-scrape-egress`
rule in `kube-prometheus-stack/app/network-policy.yaml` (fixing a
pre-existing gap on **prometheus's egress** to headscale:9091 for
scraping). This PR touches only `networking/headscale/` and adds
**ingress** CNPs on prom/loki pods (in `monitoring`) — different
direction, different pods, no file overlap.

## No auto-merge

New networking service touching ACL policy and tailnet auth surface —
coordinator merges after review + a Ben-driven preauth-key seal.
