### PR TITLE
fix(coredns): allow hostNetwork DNS ingress for tailscale-router

### DIFF
--- a/kubernetes/cluster0/apps/kube-system/coredns/policy/cilium-network-policy.yaml
+++ b/kubernetes/cluster0/apps/kube-system/coredns/policy/cilium-network-policy.yaml
@@ -14,3 +14,32 @@ spec:
   egress:
     - toEntities:
         - kube-apiserver
+---
+# hostNetwork/reserved:host caveat (see #3367): the tailscale-router pod runs
+# with hostNetwork: true, so its DNS queries to CoreDNS carry the Cilium
+# identity `reserved:host` (same node) or `remote-node` (different node),
+# not the pod's endpoint identity. Standard NetworkPolicy pod/namespace
+# selectors -- including the wildcard `coredns-allow-dns-ingress` in
+# network-policy.yaml -- do not match host-entity traffic, so it was being
+# dropped by coredns-default-deny. Mirrors the fromEntities pattern used for
+# prometheus/loki ingress from the router in
+# networking/headscale/app/tailscale-router-network-policy.yaml (#3365).
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: coredns-allow-hostnetwork-dns-ingress
+  namespace: kube-system
+spec:
+  endpointSelector:
+    matchLabels:
+      k8s-app: kube-dns
+  ingress:
+    - fromEntities:
+        - host
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP


### PR DESCRIPTION
## Summary

Closes #3367

The in-cluster tailscale subnet router (`networking/tailscale-router`, `hostNetwork: true`) flap-restarted because its DNS queries to CoreDNS were being dropped. Because the pod runs with `hostNetwork: true`, Cilium classifies its traffic as `reserved:host` (same node) or `remote-node` (different node) rather than the pod's own endpoint identity. Standard `NetworkPolicy` pod/namespace selectors -- including the existing wildcard `coredns-allow-dns-ingress` (`namespaceSelector: {}`) -- only match pod-identified traffic, so `coredns-default-deny` silently dropped the router's queries. Without DNS, `kubernetes.default.svc` never resolved, so the router's in-cluster API calls (reading/writing its `tailscale-state` Secret) deadlined and the pod restarted.

## Fix

Add a `CiliumNetworkPolicy` (`coredns-allow-hostnetwork-dns-ingress`) in `kube-system`, alongside the existing `coredns-allow-kube-apiserver` CNP, admitting ingress to CoreDNS (`k8s-app: kube-dns`) on port 53 UDP+TCP from `fromEntities: [host, remote-node]`. This mirrors the pattern #3365 already established for prometheus/loki ingress from the router (`prometheus-allow-tailscale-router-ingress` / `loki-allow-tailscale-router-ingress` in `networking/headscale/app/tailscale-router-network-policy.yaml`).

No other files needed changes -- `coredns/policy/kustomization.yaml` already references `cilium-network-policy.yaml`, and `coredns-default-deny` plus the existing pod-selector allowances are left untouched.

## kube-apiserver hop

No additional CNP is needed for the apiserver hop. Every existing CNP in this repo that talks to the apiserver (`coredns-allow-kube-apiserver`, `metrics-server-allow-kube-apiserver`, `reloader-allow-kube-apiserver`, etc.) uses Cilium's special `kube-apiserver` `toEntities`/`fromEntities` reserved identity -- never an `endpointSelector` matching apiserver pod labels. This confirms the k3s-embedded apiserver isn't a Cilium-managed endpoint with its own default-deny to route around, so once DNS resolves the router's apiserver calls should proceed unblocked. (I don't have cluster access in this environment to verify this at runtime -- flagging for confirmation post-merge per the AC.)

## Verification

- `kubectl kustomize kubernetes/cluster0/apps/kube-system/coredns/policy/` renders cleanly.
- New/existing YAML in the touched file parses correctly (PyYAML `safe_load_all`).
- `scripts/lint-prometheus-scrape-netpol.py` (the #3361 guardrail) still passes: `Prometheus scrape NetworkPolicy lint: OK (23 target(s), 22 egress rule(s) checked).`
- I do not have live cluster access (`kubectl` in this sandbox can't load the kubeconfig), so the runtime ACs (router boot with 0 restarts over 10 minutes, headscale registration, route auto-approval, apiserver reachability) need to be confirmed post-merge/reconcile by whoever has cluster access.

## Acceptance criteria status

- [x] CiliumNetworkPolicy in `kube-system` admits ingress to CoreDNS on port 53 TCP+UDP from `fromEntities: [host, remote-node]`.
- [ ] Router resolves `kubernetes.default.svc`, reads/writes `tailscale-state`, 0 restarts over 10 min -- **needs runtime verification post-merge**.
- [ ] Router registers with headscale, route auto-approved -- **needs runtime verification post-merge**.
- [x] Policy opens only port 53 UDP/TCP for host/remote-node to CoreDNS; `coredns-default-deny` and existing pod-selector allowances unchanged.
- [x] `remote-node` (not just `host`) is included, covering cross-node scheduling.
- [x] kube-apiserver hop: no CNP needed (see reasoning above); noted here in lieu of an added policy.
- [x] `flux build`/`kubectl kustomize` render cleanly; #3361 lint still passes.