### PR TITLE
networking: fix headscale router registration + hardening (#3370)

### DIFF
--- a/kubernetes/cluster0/apps/networking/headscale/app/policy.yaml
+++ b/kubernetes/cluster0/apps/networking/headscale/app/policy.yaml
@@ -67,22 +67,13 @@ data:
         },
       ],
 
-      // Static assertions that get evaluated on every `headscale policy set`
-      // / file-mode reload. If any accept fails or any deny succeeds, the
-      // policy write is rejected and the previous good policy stays live.
-      // See hscontrol/policy/v2/test.go in juanfont/headscale.
-      "tests": [
-        {
-          "src": "tag:nixos",
-          "accept": [
-            "prometheus:9090",
-            "loki:3100",
-          ],
-          "deny": [
-            "prometheus:22",         // no SSH to prometheus
-            "loki:9095",             // no gRPC to loki
-            "tag:k8s-router:22",     // no SSH to the router pod
-          ],
-        },
-      ],
+      // NOTE: no `tests` block here on purpose. headscale evaluates `tests`
+      // by resolving each `src` tag to actual registered node IPs -- with
+      // zero tag:nixos nodes currently registered, "tag:nixos" resolves to
+      // no IP addresses and the assertion fails at every policy load/boot
+      // ("policy tests failed at boot ... resolved to no IP addresses").
+      // It's only a warning (the policy still applies), but it actively
+      // misled a live investigation (#3370). Re-add a tests block once at
+      // least one tag:nixos node is actually registered, so the accept/deny
+      // assertions have real IPs to resolve against.
     }

--- a/kubernetes/cluster0/apps/networking/headscale/app/statefulset.yaml
+++ b/kubernetes/cluster0/apps/networking/headscale/app/statefulset.yaml
@@ -13,6 +13,12 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: headscale
+      annotations:
+        # headscale-config / headscale-policy are mounted via subPath, which
+        # Kubernetes never updates in place -- without Reloader, edits to
+        # either ConfigMap silently no-op until someone manually restarts
+        # the pod. See #3370.
+        reloader.stakater.com/auto: "true"
     spec:
       securityContext:
         fsGroup: 1000

--- a/kubernetes/cluster0/apps/networking/headscale/app/tailscale-router-deployment.yaml
+++ b/kubernetes/cluster0/apps/networking/headscale/app/tailscale-router-deployment.yaml
@@ -48,6 +48,31 @@ spec:
       # (blocky -> upstream) for the login-server URL; the pod's own
       # /etc/resolv.conf points at CoreDNS rather than the node resolver.
       dnsPolicy: ClusterFirstWithHostNet
+      # Because this pod is hostNetwork, a crash (as opposed to a graceful
+      # termination) leaves the tailscale0 tun interface behind in the node
+      # netns -- preStop never runs on a crash, so cleanup has to happen on
+      # the way *up*, not the way down. Delete any stale tailscale0 before
+      # tailscaled starts. `|| true` makes this a no-op when there is no
+      # stale interface (e.g. first-ever start, or a clean prior exit).
+      initContainers:
+        - name: cleanup-stale-tun
+          image: ghcr.io/tailscale/tailscale:v1.98.9@sha256:f15d5d3f4a68773a853180b72496f70ba614b64de0878c43fe3da39fe0afba47
+          imagePullPolicy: IfNotPresent
+          command:
+            - sh
+            - -c
+            - ip link delete tailscale0 || true
+          securityContext:
+            capabilities:
+              add: [NET_ADMIN]
+              drop: [ALL]
+            allowPrivilegeEscalation: true
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              memory: 32Mi
       containers:
         - name: tailscale
           image: ghcr.io/tailscale/tailscale:v1.98.9@sha256:f15d5d3f4a68773a853180b72496f70ba614b64de0878c43fe3da39fe0afba47
@@ -79,10 +104,18 @@ spec:
             # allocated ClusterIPs live in 10.43.x.x).
             - name: TS_ROUTES
               value: "10.43.0.0/16"
+            # NOTE: do NOT add --advertise-tags here. The preauth key used
+            # for TS_AUTHKEY is already tagged tag:k8s-router, and headscale
+            # 0.28+ hard-rejects registration when a PreAuthKey-authenticated
+            # node ALSO passes --advertise-tags (hscontrol/state/state.go:
+            # 1820-1829; CHANGELOG 0.28.0, juanfont/headscale#2931). Tags
+            # must come from the tagged key OR --advertise-tags, never both.
+            # The tag already rides on the key -- re-adding this flag will
+            # break registration with a misleading "requested tags ... invalid
+            # or not permitted" error. See #3370.
             - name: TS_EXTRA_ARGS
               value: >-
                 --login-server=https://hs.${SECRET_PUBLIC_DOMAIN}
-                --advertise-tags=tag:k8s-router
                 --hostname=k8s-router
             # We publish routes, not DNS; don't let the router try to
             # rewrite the node's resolv.conf.


### PR DESCRIPTION
Closes #3370

## Root cause

headscale 0.28+ (`hscontrol/state/state.go:1820-1829`) hard-rejects registration when a **PreAuthKey-authenticated** node also passes `--advertise-tags`. The `tailscale-router` preauth key is already tagged `tag:k8s-router`, and `TS_EXTRA_ARGS` also passed `--advertise-tags=tag:k8s-router` — tripping the guard before policy evaluation and producing the misleading error `requested tags [tag:k8s-router] are invalid or not permitted`. Confirmed intentional per the 0.28.0 CHANGELOG (juanfont/headscale#2931).

## Changes

1. **The fix** — removed `--advertise-tags=tag:k8s-router` from the router's `TS_EXTRA_ARGS` in `tailscale-router-deployment.yaml`. Added a comment citing `state.go:1820-1829` / CHANGELOG #2931 so it isn't re-added. No policy, key, or tagOwners change — the tag rides on the already-tagged preauth key.

2. **Stale TUN cleanup at startup** — added an `initContainer` (`cleanup-stale-tun`, same `ghcr.io/tailscale/tailscale` image, `NET_ADMIN` only) running `ip link delete tailscale0 || true` before `tailscaled` starts. The router is `hostNetwork: true`, so a crashed pod orphans `tailscale0` in the node netns; the next pod then fails with `TUN device tailscale0 is busy`. `preStop` doesn't help here — it never runs on a crash — so cleanup happens on the way up instead. `|| true` makes it a no-op when there's nothing to clean up. Confirmed the upstream `tailscale/tailscale` image Dockerfile installs `iproute2` on Alpine, so `ip` is present in the init container.

3. **Reloader on headscale** — added `reloader.stakater.com/auto: "true"` to the headscale StatefulSet pod template annotations (mirrors the `authelia` convention). `headscale-config`/`headscale-policy` are mounted via `subPath`, which Kubernetes never updates in place, so policy edits previously silently no-op'd until a manual restart.

4. **Removed the self-failing `tests` block** — `policy.hujson`'s `tests` block asserted `tag:nixos` reachability, but with zero `tag:nixos` nodes currently registered it failed at every boot (`policy tests failed at boot; ... resolved to no IP addresses`). It was only a warning but actively misled the incident investigation. Removed with a comment explaining why, and a note to re-add once a `tag:nixos` node is actually registered. `tagOwners`, `hosts`, `grants`, and `autoApprovers` are all unchanged.

## Verification

- `kubectl kustomize kubernetes/cluster0/apps/networking/headscale/app/` renders cleanly (verified locally against this cluster's kubeconfig).
- Manually re-parsed the rendered `headscale-policy` ConfigMap's `policy.hujson` (comments/trailing commas stripped) to confirm it's still valid JSON after removing the `tests` block.
- Confirmed via the upstream `tailscale/tailscale` Dockerfile that the `ghcr.io/tailscale/tailscale` image is Alpine-based with `iproute2` installed, so the init container's `ip link delete` command is available.
- **Deferred to post-merge (needs live cluster access to verify)**:
  - Router registers with headscale as `tag:k8s-router` with 0 restarts over 10 minutes.
  - `10.43.0.0/16` route auto-approves with no manual `headscale nodes approve-routes`.
  - TUN cleanup actually resolves a real `TUN device tailscale0 is busy` crash-loop when reproduced live.
  - Reloader triggers a rollout on a live policy ConfigMap edit.
  - No "policy tests failed at boot" warning in headscale logs after redeploy.

## AC mapping

| AC | Status |
|---|---|
| `TS_EXTRA_ARGS` no longer has `--advertise-tags`, comment references the guard | Done, static-verified |
| Router registers as `tag:k8s-router`, 0 restarts over 10 min | Deferred to post-merge |
| `10.43.0.0/16` auto-approved, no manual approval | Deferred to post-merge (policy `autoApprovers` unchanged, static-verified) |
| headscale StatefulSet has `reloader.stakater.com/auto: "true"` | Done, static-verified |
| Stale `tailscale0` cleaned up at startup, not `preStop` | Done, static-verified (initContainer); live crash-loop behaviour deferred to post-merge |
| Startup cleanup is a no-op when no stale interface | Done, static-verified (`|| true`) |
| `tests` block reworked/removed, no boot warning, `policy.hujson` still parses | Done, static-verified |
| Tailnet access not broadened (`tagOwners`/`grants`/`autoApprovers` unchanged, route still `10.43.0.0/16`) | Done, static-verified |
| `kubectl kustomize` / `flux build` render cleanly | Done, static-verified |
