### PR TITLE
Fix Longhorn backup alert false positives; exclude loki cache

### DIFF
--- a/kubernetes/cluster0/apps/longhorn-system/longhorn/app/prometheusrule.yaml
+++ b/kubernetes/cluster0/apps/longhorn-system/longhorn/app/prometheusrule.yaml
@@ -69,6 +69,14 @@ spec:
 
     - name: longhorn.backups
       rules:
+        # Loki is SingleBinary on SeaweedFS S3; storage-loki-0 is local cache/WAL,
+        # intentionally not backed up. Excluded here (rather than per-alert) so every
+        # backup alert below inherits the exclusion consistently.
+        - record: longhorn:volume_last_backup_at:alertable
+          expr: |
+            longhorn_volume_last_backup_at
+            unless on (pvc, pvc_namespace) longhorn_volume_last_backup_at{pvc="storage-loki-0", pvc_namespace="monitoring"}
+
         - alert: LonghornBackupFailed
           expr: longhorn_backup_state == 4
           for: 1m
@@ -78,9 +86,15 @@ spec:
             summary: "Longhorn backup {{ $labels.backup }} failed"
             description: "Backup {{ $labels.backup }} for volume {{ $labels.volume }} is in a failed state."
 
+        # Guarded with `> 0` so a volume that has NEVER been backed up (last_backup_at == 0,
+        # epoch) does not instantly compute as a ~56 year staleness and trip these. Genuinely
+        # never-backed-up volumes are instead covered by LonghornVolumeNeverBackedUp below,
+        # which has its own grace period. Volumes that WERE backed up and then went stale are
+        # unaffected by this guard and still fire as before.
         - alert: LonghornBackupMissed
           expr: |
-            time() - max by (volume) (longhorn_volume_last_backup_at) > (9 * 24 * 3600)
+            time() - max by (volume) (longhorn:volume_last_backup_at:alertable) > (9 * 24 * 3600)
+            and max by (volume) (longhorn:volume_last_backup_at:alertable) > 0
           for: 1h
           labels:
             severity: warning
@@ -90,10 +104,35 @@ spec:
 
         - alert: LonghornBackupCritical
           expr: |
-            time() - max by (volume) (longhorn_volume_last_backup_at) > (14 * 24 * 3600)
+            time() - max by (volume) (longhorn:volume_last_backup_at:alertable) > (14 * 24 * 3600)
+            and max by (volume) (longhorn:volume_last_backup_at:alertable) > 0
           for: 1h
           labels:
             severity: critical
           annotations:
             summary: "Longhorn volume {{ $labels.volume }} has not been backed up in over 14 days"
             description: "Most recent successful backup for {{ $labels.volume }} is {{ $value | humanizeDuration }} old. At least two consecutive weekly backups have been missed."
+
+        # Catches volumes that have NEVER been backed up (last_backup_at == 0) once they
+        # are older than the weekly backup interval, so a volume created minutes ago (e.g.
+        # a fresh data-headscale-0 or storage-loki-0 before it existed) doesn't instantly
+        # fire, but a genuinely unprotected volume is still surfaced rather than hidden
+        # forever. Age is derived by joining to kube_persistentvolumeclaim_created (PVC
+        # creation timestamp, confirmed present via kube-state-metrics) on the matching
+        # pvc/pvc_namespace labels, since longhorn_volume_last_backup_at has no volume-age
+        # signal of its own when it is still 0.
+        - alert: LonghornVolumeNeverBackedUp
+          expr: |
+            max by (volume, pvc, pvc_namespace) (longhorn:volume_last_backup_at:alertable) == 0
+            and on (pvc, pvc_namespace) (
+              time() - label_replace(
+                label_replace(kube_persistentvolumeclaim_created, "pvc", "$1", "persistentvolumeclaim", "(.+)"),
+                "pvc_namespace", "$1", "namespace", "(.+)"
+              ) > (9 * 24 * 3600)
+            )
+          for: 1h
+          labels:
+            severity: warning
+          annotations:
+            summary: "Longhorn volume {{ $labels.volume }} has never been backed up"
+            description: "PVC {{ $labels.pvc }} in {{ $labels.pvc_namespace }} is older than the weekly backup interval but has no successful backup on record."


### PR DESCRIPTION
## Root cause

`LonghornBackupMissed` / `LonghornBackupCritical` compute
`time() - max by (volume)(longhorn_volume_last_backup_at) > threshold`.
For a never-backed-up volume `last_backup_at == 0` (epoch), so the
expression evaluates to ~56 years and instantly trips **both** the 9-day
warning and 14-day critical thresholds, even for a volume created minutes
ago. This is currently firing for `networking/data-headscale-0` and
`monitoring/storage-loki-0`, both new volumes.

## Design (verified live against `localhost:9090`)

Probed `longhorn_volume_last_backup_at` (has `pvc` / `pvc_namespace` labels)
and confirmed `kube_persistentvolumeclaim_created` is present and scraped
by kube-state-metrics with matching PVC name/namespace. Chose **shape (b)**
from the issue (join to PVC creation time) over a long `for:` window,
since a `for:` grace period resets on Prometheus restart and is less
robust.

1. **Guard the existing stale alerts** (`LonghornBackupMissed` /
   `LonghornBackupCritical`) with `and ... > 0`, so `last_backup_at == 0`
   can no longer satisfy the staleness threshold. Volumes that were
   previously backed up and then went stale are unaffected -- still fire
   exactly as before.
2. **Add `LonghornVolumeNeverBackedUp`** -- a dedicated alert for volumes
   that have genuinely never backed up. It joins
   `longhorn_volume_last_backup_at == 0` to `kube_persistentvolumeclaim_created`
   (renamed via `label_replace` to match `pvc`/`pvc_namespace` labels) so
   it only fires once the PVC is older than the weekly backup interval
   (9d grace, same as the existing warning threshold). Confirmed live:
   both `data-headscale-0` and `storage-loki-0` are ~13h old right now and
   correctly produce **no** alert under this design; the join expression
   evaluates to an empty result set for both.
3. **Exclude `storage-loki-0`** from all three backup alerts via a shared
   recording rule `longhorn:volume_last_backup_at:alertable` (an `unless`
   against the specific `pvc="storage-loki-0", pvc_namespace="monitoring"`
   series), with an inline comment explaining Loki is SingleBinary on
   SeaweedFS S3 and this PVC is local cache/WAL, intentionally not backed
   up. Using one shared recording rule means the exclusion is applied
   consistently to `LonghornBackupMissed`, `LonghornBackupCritical`, and
   `LonghornVolumeNeverBackedUp` rather than repeated per-alert.
   `data-headscale-0` is **not** touched by this exclusion and remains
   enrolled/alerting.

### RecurringJob group exclusion (nice-to-have) -- not attempted

Did not remove `storage-loki-0` from the `default` RecurringJob group.
Longhorn's StorageClass `recurringJobSelector` only applies group
membership at PVC creation time -- changing the StorageClass would not
retroactively affect the already-existing `storage-loki-0` PVC. The only
way to change group membership on an existing volume is to label the live
Longhorn `Volume` CR directly, which is an imperative, non-declarative
change outside git (not GitOps-native) and was explicitly flagged in the
issue as something to avoid if risky/non-declarative. Kept this PR to the
alert-exclusion only, which is the must-have.

## Verification

- `promtool check rules` (Prometheus v2.55.1, downloaded fresh since no
  package manager access in this sandbox) against the rendered
  PrometheusRule spec extracted from `kubectl kustomize`: **SUCCESS, 11
  rules found** (was 9; +1 recording rule, +1 alert).
- `kubectl kustomize kubernetes/cluster0/apps/longhorn-system/longhorn/app/`
  renders cleanly (exit 0).
- Live-queried `localhost:9090` for every new/changed expression:
  - `longhorn:volume_last_backup_at:alertable` correctly returns 27 series
    excluding `storage-loki-0`, retaining `data-headscale-0`.
  - Guarded `LonghornBackupMissed`/`Critical` expression returns empty
    (no false positive) for the current never-backed-up volumes.
  - `LonghornVolumeNeverBackedUp` expression returns empty for both
    `data-headscale-0` and `storage-loki-0` (both ~13h old, well under
    the 9d grace).
  - Live kubectl checks against the cluster were not otherwise performed
    (kubeconfig-based `kubectl` not available/permitted in this sandbox);
    only the Prometheus HTTP API (already port-forwarded) and static
    render/lint checks were used. `promtool`/`kustomize` output above is
    the closest available substitute -- flagging as deferred/post-merge
    per the note in prior PRs #3369/#3371.

## AC status

- [x] Never-backed-up volume within the weekly interval does not fire
  `LonghornBackupCritical`/`LonghornBackupMissed` -- verified live.
- [x] Previously-backed-up volume that goes stale still fires -- verified
  by inspection of the guard logic (`and > 0` only excludes the `== 0`
  case; unaffected otherwise). No live stale volume exists to reproduce
  today, so this is a static/logical verification, not live-reproduced.
- [x] Genuinely never-backed-up volume beyond grace period still alerts
  -- via `LonghornVolumeNeverBackedUp`; logic verified live, though no
  volume in the cluster is currently old enough to trigger it (both
  candidates are ~13h old).
- [x] `storage-loki-0` produces no alert, with inline comment -- verified
  live + present in the rule file.
- [x] `data-headscale-0` is NOT excluded -- verified live (still present
  in the alertable recording rule's result set).
- [x] Grace-period mechanism uses metrics actually present -- verified
  via direct query of `kube_persistentvolumeclaim_created`.
- [x] `promtool check rules` / `kubectl kustomize` -- both pass.
- [x] No broadened access, backup target, or credential changes -- diff
  is limited to `prometheusrule.yaml` alerting rules only.

Closes #3373
