### PR TITLE
transfer tag:nixos ownership from homeops@ to ben@

### DIFF
--- a/kubernetes/cluster0/apps/networking/headscale/app/policy.yaml
+++ b/kubernetes/cluster0/apps/networking/headscale/app/policy.yaml
@@ -9,9 +9,9 @@ data:
   # newer shape and what we standardise on going forward).
   #
   # Access story:
-  #   tag:nixos    - remote NixOS observability consumers
+  #   tag:nixos    - remote NixOS observability consumers (owned by ben@)
   #                  ONLY reach prometheus:9090 and loki:3100
-  #   tag:k8s-router - the in-cluster tailscale-router pod
+  #   tag:k8s-router - the in-cluster tailscale-router pod (owned by homeops@)
   #                    auto-approves its own 10.43.0.0/16 route advertisement
   #                    so an operator doesn't have to run
   #                    `headscale nodes approve-routes` on every redeploy
@@ -29,7 +29,7 @@ data:
     {
       "tagOwners": {
         "tag:k8s-router": ["homeops@"],
-        "tag:nixos":      ["homeops@"],
+        "tag:nixos":      ["ben@"],
       },
 
       // Named hosts referenced from `grants` and `tests`. /32s pin to the


### PR DESCRIPTION
## Summary

Transfer tailscale policy ownership of `tag:nixos` from `homeops@` to `ben@` to enable ben to enrol NixOS machines onto the tailnet.

## Context

Currently, attempting to enrol a NixOS machine under the ben@ user with `tailscale up --advertise-tags=tag:nixos` fails:
```
requested tags [tag:nixos] are invalid or not permitted
```

This is because `tag:nixos` ownership is restricted to `homeops@` in the policy, while the machines are being enrolled under `ben@`.

## Changes

Modified `kubernetes/cluster0/apps/networking/headscale/app/policy.yaml`:

**Before:**
```hujson
"tagOwners": {
  "tag:k8s-router": ["homeops@"],
  "tag:nixos":      ["homeops@"],
},
```

**After:**
```hujson
"tagOwners": {
  "tag:k8s-router": ["homeops@"],
  "tag:nixos":      ["ben@"],
},
```

### Ownership Split

- **Config/infra tags** (`tag:k8s-router`): Owned by homeops@
- **Machine tags** (`tag:nixos`): Owned by ben@

### Preserved

- Access grants remain unchanged (tag:nixos peers still reach only prometheus:9090 and loki:3100)
- Auto-approvers unchanged
- All network policies remain in place
- No impact on k8s-router or any other infrastructure

## Validation

- ✓ hujson syntax validated (balanced braces, trailing commas preserved)
- ✓ `kubectl kustomize` build succeeds; ConfigMap renders cleanly

Relates to #3372 (monitoring for tag:nixos nodes once enrolled).