### PR TITLE
tailscale-proxy: per-service proxies for prometheus and loki (#3378)

### DIFF
--- a/kubernetes/cluster0/apps/networking/headscale/app/kustomization.yaml
+++ b/kubernetes/cluster0/apps/networking/headscale/app/kustomization.yaml
@@ -13,6 +13,16 @@ resources:
   - ./tailscale-router-secret.sops.yaml
   - ./tailscale-router-deployment.yaml
   - ./tailscale-router-network-policy.yaml
+  # Per-service tailscale proxies (design #3377, issue #3378). Additive:
+  # the router above stays deployed and untouched. Retirement is #3379.
+  - ./tailscale-proxy-prometheus-rbac.yaml
+  - ./tailscale-proxy-prometheus-secret.sops.yaml
+  - ./tailscale-proxy-prometheus-deployment.yaml
+  - ./tailscale-proxy-prometheus-network-policy.yaml
+  - ./tailscale-proxy-loki-rbac.yaml
+  - ./tailscale-proxy-loki-secret.sops.yaml
+  - ./tailscale-proxy-loki-deployment.yaml
+  - ./tailscale-proxy-loki-network-policy.yaml
 labels:
   - pairs:
       app.kubernetes.io/name: headscale

--- a/kubernetes/cluster0/apps/networking/headscale/app/policy.yaml
+++ b/kubernetes/cluster0/apps/networking/headscale/app/policy.yaml
@@ -9,12 +9,21 @@ data:
   # newer shape and what we standardise on going forward).
   #
   # Access story:
-  #   tag:nixos    - remote NixOS observability consumers (owned by ben@)
-  #                  ONLY reach prometheus:9090 and loki:3100
-  #   tag:k8s-router - the in-cluster tailscale-router pod (owned by homeops@)
-  #                    auto-approves its own 10.43.0.0/16 route advertisement
-  #                    so an operator doesn't have to run
-  #                    `headscale nodes approve-routes` on every redeploy
+  #   tag:nixos            - remote NixOS observability consumers (owned by
+  #                          ben@). ONLY reach prometheus:9090 and loki:3100.
+  #   tag:k8s-router       - the in-cluster tailscale-router pod (owned by
+  #                          homeops@; legacy, retirement is #3379). Auto-
+  #                          approves its own 10.43.0.0/16 route advertisement
+  #                          so an operator doesn't have to run
+  #                          `headscale nodes approve-routes` on every redeploy.
+  #   tag:ts-prometheus    - per-service tailscale proxy for prometheus
+  #                          (design #3377 / issue #3378; owned by homeops@).
+  #                          Receives inbound from tag:nixos on tcp/9090 and
+  #                          re-originates to the in-cluster Service.
+  #   tag:ts-loki          - per-service tailscale proxy for loki, tcp/3100
+  #                          (owned by homeops@). Same ownership rationale
+  #                          as tag:k8s-router: cluster-managed workload,
+  #                          no human owner is appropriate.
   #
   # Hosts are pinned to current ClusterIPs (as /32). Tradeoff: if the
   # prometheus or loki Service is deleted and recreated, its ClusterIP may
@@ -28,13 +37,18 @@ data:
   policy.hujson: |-
     {
       "tagOwners": {
-        "tag:k8s-router": ["homeops@"],
-        "tag:nixos":      ["ben@"],
+        "tag:k8s-router":    ["homeops@"],
+        "tag:nixos":         ["ben@"],
+        // Per-service proxies are cluster-managed workloads; homeops@
+        // (the operator identity) owns them for the same reason it owns
+        // tag:k8s-router - no human owner is appropriate for a workload
+        // that any cluster admin might need to redeploy.
+        "tag:ts-prometheus": ["homeops@"],
+        "tag:ts-loki":       ["homeops@"],
       },
 
-      // Named hosts referenced from `grants` and `tests`. /32s pin to the
-      // current in-cluster Service ClusterIPs; update if the Service is
-      // recreated.
+      // Named hosts referenced from `grants`. /32s pin to the current
+      // in-cluster Service ClusterIPs; update if the Service is recreated.
       "hosts": {
         "prometheus": "10.43.180.44/32", // prometheus-kube-prometheus-prometheus.monitoring
         "loki":       "10.43.108.90/32", // loki.monitoring
@@ -51,10 +65,28 @@ data:
 
       // Least-privilege access: tag:nixos peers may reach ONLY
       //   prometheus tcp/9090 and loki tcp/3100.
-      // Everything else (SSH, other ports on the same hosts, the router
-      // itself, other cluster services) is denied by the default-deny
-      // posture of the tailnet: absence of a grant is a deny.
+      // Everything else (SSH, other ports on the same hosts/tags, the
+      // router itself, other cluster services) is denied by the default-
+      // deny posture of the tailnet: absence of a grant is a deny.
+      //
+      // Both the legacy named-host path (via the tailscale-router) and
+      // the new per-service-proxy path are granted here in parallel. The
+      // router-path grants (dst = named hosts pinned to /32) are kept so
+      // this change stays purely additive - retirement of the router
+      // path is scope of #3379.
       "grants": [
+        // New per-service-proxy path (design #3377).
+        {
+          "src": ["tag:nixos"],
+          "dst": ["tag:ts-prometheus"],
+          "ip":  ["tcp:9090"],
+        },
+        {
+          "src": ["tag:nixos"],
+          "dst": ["tag:ts-loki"],
+          "ip":  ["tcp:3100"],
+        },
+        // Legacy router path (kept until #3379).
         {
           "src": ["tag:nixos"],
           "dst": ["prometheus"],

--- a/kubernetes/cluster0/apps/networking/headscale/app/tailscale-proxy-loki-deployment.yaml
+++ b/kubernetes/cluster0/apps/networking/headscale/app/tailscale-proxy-loki-deployment.yaml
@@ -1,0 +1,106 @@
+---
+# =============================================================================
+# tailscale-proxy-loki
+#
+# Per-service tailscale proxy exposing the in-cluster loki Service to the
+# headscale tailnet as its own node (tag:ts-loki). Implements step 1 of
+# design #3377 — replaces the broken "subnet router advertises the Service
+# CIDR" approach. See tailscale-proxy-prometheus-deployment.yaml for the
+# full rationale (identical origin-socket / tag-from-key / no-hostNetwork
+# design; only the target Service and port differ).
+# =============================================================================
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tailscale-proxy-loki-serve
+  namespace: networking
+data:
+  # ipn.ServeConfig — TCP handler that TCPForwards inbound tailnet TCP on
+  # port 3100 to the loki Service by DNS name. TCPForward does a standard
+  # net.Dial (fresh outbound socket) per accepted connection; it does NOT
+  # proxy packets. Target is the Service DNS name, not a pinned ClusterIP.
+  serve.json: |-
+    {
+      "TCP": {
+        "3100": {
+          "TCPForward": "loki.monitoring.svc.cluster.local:3100"
+        }
+      }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tailscale-proxy-loki
+  namespace: networking
+spec:
+  replicas: 1
+  strategy:
+    # Recreate rather than RollingUpdate: two tailnet nodes with the same
+    # hostname would collide on registration.
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tailscale-proxy-loki
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tailscale-proxy-loki
+    spec:
+      serviceAccountName: tailscale-proxy-loki
+      containers:
+        - name: tailscale
+          image: ghcr.io/tailscale/tailscale:v1.98.9@sha256:f15d5d3f4a68773a853180b72496f70ba614b64de0878c43fe3da39fe0afba47
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            # Userspace mode needs no capabilities. Drop everything.
+            capabilities:
+              drop: [ALL]
+            allowPrivilegeEscalation: false
+          env:
+            - name: TS_KUBE_SECRET
+              value: tailscale-proxy-loki-state
+            - name: TS_USERSPACE
+              value: "true"
+            - name: TS_AUTHKEY
+              valueFrom:
+                secretKeyRef:
+                  name: tailscale-proxy-loki-auth
+                  key: TS_AUTHKEY
+            - name: TS_EXTRA_ARGS
+              # No --advertise-tags: tag comes from the preauth key
+              # (headscale 0.28+ rejects both; see #3370).
+              value: >-
+                --login-server=https://hs.${SECRET_PUBLIC_DOMAIN}
+                --hostname=ts-loki
+            - name: TS_ACCEPT_DNS
+              value: "false"
+            - name: TS_SERVE_CONFIG
+              value: /etc/tsserve/serve.json
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+          volumeMounts:
+            - name: serve-config
+              mountPath: /etc/tsserve
+              readOnly: true
+            - name: tailscale-run
+              mountPath: /var/run/tailscale
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 128Mi
+      volumes:
+        - name: serve-config
+          configMap:
+            name: tailscale-proxy-loki-serve
+        - name: tailscale-run
+          emptyDir:
+            medium: Memory

--- a/kubernetes/cluster0/apps/networking/headscale/app/tailscale-proxy-loki-network-policy.yaml
+++ b/kubernetes/cluster0/apps/networking/headscale/app/tailscale-proxy-loki-network-policy.yaml
@@ -1,0 +1,133 @@
+---
+# =============================================================================
+# tailscale-proxy-loki NetworkPolicies
+#
+# See tailscale-proxy-prometheus-network-policy.yaml for the shape rationale;
+# only the target and metrics port differ. Enforced at runtime (real pod
+# endpoint identity, not hostNetwork).
+# =============================================================================
+---
+# Default deny-all.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: tailscale-proxy-loki-default-deny
+  namespace: networking
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: tailscale-proxy-loki
+  policyTypes: [Ingress, Egress]
+---
+# DNS resolution to cluster CoreDNS.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: tailscale-proxy-loki-allow-dns
+  namespace: networking
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: tailscale-proxy-loki
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+---
+# Internet egress on :443/TCP — control plane + DERP.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: tailscale-proxy-loki-allow-internet-egress
+  namespace: networking
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: tailscale-proxy-loki
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+---
+# Direct WireGuard + STUN.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: tailscale-proxy-loki-allow-wireguard-egress
+  namespace: networking
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: tailscale-proxy-loki
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - protocol: UDP
+      to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+---
+# Forward target: TCP :3100 to loki pods in the monitoring namespace.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: tailscale-proxy-loki-allow-target-egress
+  namespace: networking
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: tailscale-proxy-loki
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 3100
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: loki
+---
+# Loki-side ingress: allow the proxy pod to reach loki on :3100.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: loki-allow-tailscale-proxy-ingress
+  namespace: monitoring
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: loki
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: networking
+            app.kubernetes.io/name: tailscale-proxy-loki
+      toPorts:
+        - ports:
+            - port: "3100"
+              protocol: TCP

--- a/kubernetes/cluster0/apps/networking/headscale/app/tailscale-proxy-loki-rbac.yaml
+++ b/kubernetes/cluster0/apps/networking/headscale/app/tailscale-proxy-loki-rbac.yaml
@@ -1,0 +1,47 @@
+---
+# =============================================================================
+# tailscale-proxy-loki RBAC
+#
+# Per-proxy ServiceAccount so each tailnet node has its own kube identity
+# and its own state Secret. Mirrors the tailscale-router-rbac.yaml pattern
+# minus the events verbs (bare proxy, no CRDs to publish events for).
+#
+# The state Secret name (tailscale-proxy-loki-state) is pinned in the Role's
+# resourceNames, matching the TS_KUBE_SECRET env in the Deployment. The
+# `create` verb is granted on the whole `secrets` resource because
+# Kubernetes RBAC does not allow resourceNames on `create` (the object does
+# not exist yet at create time).
+# =============================================================================
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tailscale-proxy-loki
+  namespace: networking
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: tailscale-proxy-loki
+  namespace: networking
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["tailscale-proxy-loki-state"]
+    verbs: ["get", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tailscale-proxy-loki
+  namespace: networking
+subjects:
+  - kind: ServiceAccount
+    name: tailscale-proxy-loki
+    namespace: networking
+roleRef:
+  kind: Role
+  name: tailscale-proxy-loki
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes/cluster0/apps/networking/headscale/app/tailscale-proxy-loki-secret.sops.yaml
+++ b/kubernetes/cluster0/apps/networking/headscale/app/tailscale-proxy-loki-secret.sops.yaml
@@ -1,36 +1,36 @@
 apiVersion: v1
 kind: Secret
 metadata:
-    name: tailscale-proxy-loki-auth
-    namespace: networking
+  name: tailscale-proxy-loki-auth
+  namespace: networking
 type: Opaque
 stringData:
-    #ENC[AES256_GCM,data:SaurQ+26zDAVjicauyszer1WvCQ7qXlsQk8n8Qpye4Hmqbb0pnEwXqFy,iv:NHMBH6OBdGkuZ6UnzjPuieK3HXqC9W6/3v9mFoEwz6w=,tag:78j3Wh1puz8CuiFME9hzzg==,type:comment]
-    #ENC[AES256_GCM,data:Ri2mmhIPs4/E5FbQmiuxrx9uBJ3UBhn9ZyMc/7atHwMH3Jl0iKcPyzBW5QikqbxHV9cKtlbkckuVoyIM0hCMytszovZf+ACrYBqLur8Rm8Sk+/1O,iv:OCSN+/3BAIGkOEJ19YQZHQjS0iZfiW8iJ1Oob94+410=,tag:Zccp/BN8QB2ggue4c58eDA==,type:comment]
-    #ENC[AES256_GCM,data:itqdzbmI6vBbYfwU8sNVgYe1qjW1ifw/4QPXHU/23XK7tBaPYqy3IEWCdSJlEm9xWFx9wIEF3hdoXJFfKeHZl5QGjsU+CP5M,iv:XJ8MHxGMygj7NOb2l4NQDPEwtZUs9MKqH1XBbJbIRGY=,tag:9YMIsIJ0DOaXzQHs41m8LQ==,type:comment]
-    #ENC[AES256_GCM,data:Gr+SKw5FZmTdHt0TXYLn5qjJKd7bVXMvJeV0GfOxgSvToTq/MqdocK+Q+WoVOMAWFxULc3lXWIj7Gxgld+WyczpUSBODiX1vJNU1rj4=,iv:S6LROcM0sDgjoTqc8mTM7wb+oAAptvUvJjgzBDeMWqo=,tag:ztTMb9TS42GYqemR5N6I3g==,type:comment]
-    TS_AUTHKEY: ENC[AES256_GCM,data:ALH8YaI9jFbVH074PGZDULBJPXrrxgqbEP4/91GCusIs92b7S8tsJFseeyEY8zJCK6WehmOGWHAwJw==,iv:UGF+bua7ltfhnwLWyxZEKv1NKksPuR1KPM+C6l+O1mo=,tag:O/n7Q5vRXEpE1hI+4zxZOQ==,type:str]
+  #ENC[AES256_GCM,data:1ct8IKaIFNlRmeHub5G/MCNRxq7R2UMHVG2wDWU6JAJz+CDuq6ASpv4S,iv:G6vHvOh2i5hn7fdghS46Ij1qjpKwjI55PdGOzDLInxo=,tag:DLIVZZ+43qynE9dQ7QzQlA==,type:comment]
+  #ENC[AES256_GCM,data:XYqJQdXBN/XPPcvudGxp0DQ+yrM5rJFLiTT7yUXnp/u8PfQFEFtxKXYKulHmzFf3YaLZjZLlfs9JDk7QWDPkBT+lcQedi+BPFVipI8PCur4bLbbT,iv:FOKIE95UBgtbLxyipPeAXNZWyGqPrAbWIr+OkNdOJ50=,tag:CvREOtmOfz+2+y9MhQGJtw==,type:comment]
+  #ENC[AES256_GCM,data:/QwX6xpH0tFYcz2tIc4WYCAocfHaZpFWnAKGXKPX5zz/doebVphEtVU4doq+H+BtqCd+XVgJ5A6bkDyTwD33d7R4C2/4PuFw,iv:NOZKNpL2n8ZVPo/3Y5KzEyJij6S1HhItw3IRAIS+Oj4=,tag:vznqdBH4mdkimBsXPQIozw==,type:comment]
+  #ENC[AES256_GCM,data:Ze6wboTwr8BeY2Hh1J/hcazSa/ZDsnnRiPlaGVvUJUZ0yOfYTuVQXkBgdlJPWd+u0YlrdGj4wPfLUXZti3uP4KO36r6U99Pr0jDpIuc=,iv:kMWG6UeJcfgfOqMMC9ftt72q0qKQuNLbblU/W/2OcuI=,tag:LlshuDmp1Bt1uXDYnBZ64Q==,type:comment]
+  TS_AUTHKEY: ENC[AES256_GCM,data:yKimdbFTnUeallDGg4n0Ix14ho/IGwtawr8dEWvpHxbRDuMqjWh1XP3F3XBevEZD+2rVXQNTPBL9O8RRWXRmcDs4cyGOdOefWiz8LzUWzmqQuoBpYW5KDA==,iv:ARd4BhHzYSp9XOB9PrWm2cDarLKmo4nt06rJ1Fw0Ivg=,tag:QjJ1cNy1QyuGKxUeZKLY9Q==,type:str]
 sops:
-    age:
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB0Vm1USjNEeXdNeVJzcGlk
-            cURZK0xMKzl0NEI5NVRLUnhWaWQ2ckVlYmxjCjE3U29iSGVzbXRxUHVsUXhHQUw3
-            ZTFDUEgwRXRZK05ia3JsTjBQVGFnV0kKLS0tIGp5aVhNM09BV0pXLzFPZHpPSk4z
-            RTZZT09UWER5T1dxVEd5YmNFaXpOT2MK/NThD8SgqXwKY9/3hBDnhQzNqc5Uw2Hv
-            ckdAXhM8XE24Ambk+mlilbUV49UMXwh9UB4Qvl8mI25tVXLPjTl6AA==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1582vh25trj6w7klwt38d44n5nr8njr8rrxxx5kcfu3y2ezx9ss3s6j24ex
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxYkZHSUFWQ0RGcDk4dGtP
-            dlBQV0xKbFczaU8yb3lZWS92R2ZwMTNNdENJCi9JaURHRmxmdmFHbC93cGljUUpW
-            a3ZUSCtYMkRXOUkrUXo4ZjlqVWlacVkKLS0tIDdlbmpGdW90dlNUTldDeWlEbmti
-            ZzJWRWROZlA4ZVgxanB3Q0VrMXFCeDQK/8C+nDQLiypiIj/W+xuQzg2S0NWewAit
-            IOovGE+94XpgM3v6i2UywAfGBt32X5pteEZneRN1eXpg3TvYD0dieA==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age185kanaq3uw2gjx5enu2v69nk9ner3lamdevrfgx3wqucsl9ewa2qlt2gf7
-    encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-07-29T05:52:59Z"
-    mac: ENC[AES256_GCM,data:VQM+8zUQeI07xtblDFODOZ3nFY+RcejaAYF1GwPxWv8yo4ycQ4nMCAz3giN/CyO/N0KpAQRv+QcUJTgaRLmX6osazhv/noGZyNJWwAh2kNud/f3kj8E5KVMXgwlKgR/NVOgPDjqU8nb24nfgb9/ENhERteboNXwg6NFO+N9zbxE=,iv:oMCurQBB4kNpP7UIFuQvBQw8YVAkKeqRWY6Tbi/Pdvg=,tag:3mPlK9aRzNQBqZVKVPLYRg==,type:str]
-    version: 3.13.3
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBai9lbVdVTUpTVmVwMldq
+        WFprUVNFenkxRjV1WDVGc2JvM0Zrem1tV0ZrCkRXZ3dzRU95Tm5RWjVpS3RmU0Zv
+        RHQ0RmEvc0tJaUVqNkVHZ3MwalZheEEKLS0tIHZsMGdORlo5TUE2a2VWOHpEVTNM
+        Vm0wZmwzN0taZmdJSENZUThFblJ0elEKlerrBrJ68VhNvgGlCU5OdADWILAjIDgo
+        7pnm9A2qcw+XZa3St+PRpDXOx12V8DGkpUNwM4/7jySDpZQaK7rn+g==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1582vh25trj6w7klwt38d44n5nr8njr8rrxxx5kcfu3y2ezx9ss3s6j24ex
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA0STNyMGZEWGYzRUw5TGNL
+        WTdlYnpiWkRwamlmMCtzWlBTK3F1aXBHSzNVCjhFZFVSNXNjNno2bUd2N2JEZjQv
+        K0hFQjdBT0tIKzVjTWNzRDBxdGcyQU0KLS0tIGt6V1ZVcUZVN1Z6dHdTdDNaLzVY
+        SlNIL0NlWGNhMmlabHZ0Q09TL0FyZmcKsDJKSl2hsqrsNVM7yT0LMsoCtMp1k+gG
+        r+8ZehaL5utvHmLc0yg6slTG+gblJ69kL72WAgovu/GJwRoufrn9RA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age185kanaq3uw2gjx5enu2v69nk9ner3lamdevrfgx3wqucsl9ewa2qlt2gf7
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-07-29T07:34:06Z"
+  mac: ENC[AES256_GCM,data:G4DzJhqRCLCSmYFkOmzjBeKUtNcFUmPKCP329zqUCRNez35cLQ5CazEvDEvuylSf4jqIRyXdUYZgaJv8EsFDb7OXbEkkpNLH3A/XikgYdgMBLm8PQJB2cm6atNKgfmnMuSgSoOqVnUoAycEf7h6VVQFYRrVVO4aUmExzt8OyctI=,iv:uPYJrbghUtSdhcupaS/LdLMqJVJ+ChsLSBnOEAfv330=,tag:UJYWJI87nNEqyrBcFQoPgg==,type:str]
+  version: 3.13.3

--- a/kubernetes/cluster0/apps/networking/headscale/app/tailscale-proxy-loki-secret.sops.yaml
+++ b/kubernetes/cluster0/apps/networking/headscale/app/tailscale-proxy-loki-secret.sops.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: tailscale-proxy-loki-auth
+    namespace: networking
+type: Opaque
+stringData:
+    #ENC[AES256_GCM,data:SaurQ+26zDAVjicauyszer1WvCQ7qXlsQk8n8Qpye4Hmqbb0pnEwXqFy,iv:NHMBH6OBdGkuZ6UnzjPuieK3HXqC9W6/3v9mFoEwz6w=,tag:78j3Wh1puz8CuiFME9hzzg==,type:comment]
+    #ENC[AES256_GCM,data:Ri2mmhIPs4/E5FbQmiuxrx9uBJ3UBhn9ZyMc/7atHwMH3Jl0iKcPyzBW5QikqbxHV9cKtlbkckuVoyIM0hCMytszovZf+ACrYBqLur8Rm8Sk+/1O,iv:OCSN+/3BAIGkOEJ19YQZHQjS0iZfiW8iJ1Oob94+410=,tag:Zccp/BN8QB2ggue4c58eDA==,type:comment]
+    #ENC[AES256_GCM,data:itqdzbmI6vBbYfwU8sNVgYe1qjW1ifw/4QPXHU/23XK7tBaPYqy3IEWCdSJlEm9xWFx9wIEF3hdoXJFfKeHZl5QGjsU+CP5M,iv:XJ8MHxGMygj7NOb2l4NQDPEwtZUs9MKqH1XBbJbIRGY=,tag:9YMIsIJ0DOaXzQHs41m8LQ==,type:comment]
+    #ENC[AES256_GCM,data:Gr+SKw5FZmTdHt0TXYLn5qjJKd7bVXMvJeV0GfOxgSvToTq/MqdocK+Q+WoVOMAWFxULc3lXWIj7Gxgld+WyczpUSBODiX1vJNU1rj4=,iv:S6LROcM0sDgjoTqc8mTM7wb+oAAptvUvJjgzBDeMWqo=,tag:ztTMb9TS42GYqemR5N6I3g==,type:comment]
+    TS_AUTHKEY: ENC[AES256_GCM,data:ALH8YaI9jFbVH074PGZDULBJPXrrxgqbEP4/91GCusIs92b7S8tsJFseeyEY8zJCK6WehmOGWHAwJw==,iv:UGF+bua7ltfhnwLWyxZEKv1NKksPuR1KPM+C6l+O1mo=,tag:O/n7Q5vRXEpE1hI+4zxZOQ==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB0Vm1USjNEeXdNeVJzcGlk
+            cURZK0xMKzl0NEI5NVRLUnhWaWQ2ckVlYmxjCjE3U29iSGVzbXRxUHVsUXhHQUw3
+            ZTFDUEgwRXRZK05ia3JsTjBQVGFnV0kKLS0tIGp5aVhNM09BV0pXLzFPZHpPSk4z
+            RTZZT09UWER5T1dxVEd5YmNFaXpOT2MK/NThD8SgqXwKY9/3hBDnhQzNqc5Uw2Hv
+            ckdAXhM8XE24Ambk+mlilbUV49UMXwh9UB4Qvl8mI25tVXLPjTl6AA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1582vh25trj6w7klwt38d44n5nr8njr8rrxxx5kcfu3y2ezx9ss3s6j24ex
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxYkZHSUFWQ0RGcDk4dGtP
+            dlBQV0xKbFczaU8yb3lZWS92R2ZwMTNNdENJCi9JaURHRmxmdmFHbC93cGljUUpW
+            a3ZUSCtYMkRXOUkrUXo4ZjlqVWlacVkKLS0tIDdlbmpGdW90dlNUTldDeWlEbmti
+            ZzJWRWROZlA4ZVgxanB3Q0VrMXFCeDQK/8C+nDQLiypiIj/W+xuQzg2S0NWewAit
+            IOovGE+94XpgM3v6i2UywAfGBt32X5pteEZneRN1eXpg3TvYD0dieA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age185kanaq3uw2gjx5enu2v69nk9ner3lamdevrfgx3wqucsl9ewa2qlt2gf7
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-07-29T05:52:59Z"
+    mac: ENC[AES256_GCM,data:VQM+8zUQeI07xtblDFODOZ3nFY+RcejaAYF1GwPxWv8yo4ycQ4nMCAz3giN/CyO/N0KpAQRv+QcUJTgaRLmX6osazhv/noGZyNJWwAh2kNud/f3kj8E5KVMXgwlKgR/NVOgPDjqU8nb24nfgb9/ENhERteboNXwg6NFO+N9zbxE=,iv:oMCurQBB4kNpP7UIFuQvBQw8YVAkKeqRWY6Tbi/Pdvg=,tag:3mPlK9aRzNQBqZVKVPLYRg==,type:str]
+    version: 3.13.3

--- a/kubernetes/cluster0/apps/networking/headscale/app/tailscale-proxy-prometheus-deployment.yaml
+++ b/kubernetes/cluster0/apps/networking/headscale/app/tailscale-proxy-prometheus-deployment.yaml
@@ -1,0 +1,152 @@
+---
+# =============================================================================
+# tailscale-proxy-prometheus
+#
+# Per-service tailscale proxy exposing the in-cluster prometheus Service to
+# the headscale tailnet as its own node (tag:ts-prometheus). Implements
+# step 1 of design #3377 — replaces the broken "subnet router advertises the
+# Service CIDR" approach (see #3377 for the Cilium socket-LB root cause).
+#
+# Why this is not a subnet router:
+#   The router (kept alongside this proxy — retirement is #3379) forwards
+#   packets from a tailnet peer to a ClusterIP. Under Cilium with
+#   kubeProxyReplacement=true, ClusterIP->PodIP translation is done by
+#   socket-LB at the *origin socket* (cgroup eBPF at connect()), not on the
+#   wire. Forwarded packets therefore never get translated and time out.
+#
+# Origin-socket property (this is the whole point):
+#   TS_USERSPACE=true runs tailscaled with the userspace netstack (no tun
+#   device, no packet forwarding is even *possible*). Inbound TCP on the
+#   tailnet interface is terminated inside tailscaled. The TS_SERVE_CONFIG
+#   TCPForward handler then calls a fresh net.Dial from the pod netns to
+#   the target's Service DNS name. That outbound socket originates in the
+#   pod, so Cilium's cgroup-attached socket-LB sees connect() and DNATs
+#   ClusterIP -> PodIP correctly. Empirical verification is in the PR body.
+#
+# Tag from preauth key, NOT --advertise-tags:
+#   headscale 0.28+ hard-rejects registration when a PreAuthKey-authenticated
+#   node ALSO passes --advertise-tags (see the note in
+#   tailscale-router-deployment.yaml and #3370). The preauth key committed
+#   in tailscale-proxy-prometheus-secret.sops.yaml MUST be created with
+#   `headscale preauthkeys create --tags tag:ts-prometheus --reusable`; do
+#   NOT set --advertise-tags in TS_EXTRA_ARGS.
+#
+# No hostNetwork, no NET_ADMIN, no /dev/net/tun:
+#   None of these are required for userspace mode. The security posture is
+#   therefore materially better than the router: standard pod endpoint
+#   identity, standard NetworkPolicy enforcement, no host-namespace escape
+#   surface. See tailscale-proxy-prometheus-network-policy.yaml.
+# =============================================================================
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tailscale-proxy-prometheus-serve
+  namespace: networking
+data:
+  # ipn.ServeConfig — TCP handler that TCPForwards inbound tailnet TCP on
+  # port 9090 to the prometheus Service by DNS name. TCPForward does a
+  # standard net.Dial (fresh outbound socket) per accepted connection; it
+  # does NOT proxy packets. Target is the Service DNS name, not a pinned
+  # ClusterIP: no /32 pin drift when the Service is reconstituted.
+  serve.json: |-
+    {
+      "TCP": {
+        "9090": {
+          "TCPForward": "prometheus-kube-prometheus-prometheus.monitoring.svc.cluster.local:9090"
+        }
+      }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tailscale-proxy-prometheus
+  namespace: networking
+spec:
+  replicas: 1
+  strategy:
+    # Recreate rather than RollingUpdate: two tailnet nodes with the same
+    # hostname would collide on registration. A brief gap on redeploy is
+    # acceptable for the observability use case.
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tailscale-proxy-prometheus
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tailscale-proxy-prometheus
+    spec:
+      serviceAccountName: tailscale-proxy-prometheus
+      containers:
+        - name: tailscale
+          image: ghcr.io/tailscale/tailscale:v1.98.9@sha256:f15d5d3f4a68773a853180b72496f70ba614b64de0878c43fe3da39fe0afba47
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            # Userspace mode needs no capabilities. Drop everything.
+            capabilities:
+              drop: [ALL]
+            allowPrivilegeEscalation: false
+          env:
+            # Persist tailnet node state (machine key, node key, ...) into
+            # this Secret. The RBAC in tailscale-proxy-prometheus-rbac.yaml
+            # pins get/update/patch to exactly this name. Surviving a pod
+            # delete + reschedule with the tag intact depends on this
+            # Secret being reused across pod lifecycles.
+            - name: TS_KUBE_SECRET
+              value: tailscale-proxy-prometheus-state
+            # Userspace networking — no tun, no packet forwarding. This is
+            # what makes the origin-socket path (see file header) hold.
+            - name: TS_USERSPACE
+              value: "true"
+            - name: TS_AUTHKEY
+              valueFrom:
+                secretKeyRef:
+                  name: tailscale-proxy-prometheus-auth
+                  key: TS_AUTHKEY
+            - name: TS_EXTRA_ARGS
+              # No --advertise-tags: the tag is on the preauth key (see
+              # file header). Hostname becomes the MagicDNS label:
+              # ts-prometheus.tailnet.internal.
+              value: >-
+                --login-server=https://hs.${SECRET_PUBLIC_DOMAIN}
+                --hostname=ts-prometheus
+            # We do not want tailscaled rewriting the pod's resolv.conf;
+            # the pod already gets cluster DNS via ClusterFirst.
+            - name: TS_ACCEPT_DNS
+              value: "false"
+            # Serve config: mounted from the ConfigMap above. containerboot
+            # applies this after tailscale up.
+            - name: TS_SERVE_CONFIG
+              value: /etc/tsserve/serve.json
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+          volumeMounts:
+            - name: serve-config
+              mountPath: /etc/tsserve
+              readOnly: true
+            # tailscaled needs a writable state area even with
+            # TS_KUBE_SECRET (localapi socket, scratch). Backed by memory
+            # rather than the container FS so it survives readOnlyRootFs
+            # tightening if we ever add it.
+            - name: tailscale-run
+              mountPath: /var/run/tailscale
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 128Mi
+      volumes:
+        - name: serve-config
+          configMap:
+            name: tailscale-proxy-prometheus-serve
+        - name: tailscale-run
+          emptyDir:
+            medium: Memory

--- a/kubernetes/cluster0/apps/networking/headscale/app/tailscale-proxy-prometheus-network-policy.yaml
+++ b/kubernetes/cluster0/apps/networking/headscale/app/tailscale-proxy-prometheus-network-policy.yaml
@@ -1,0 +1,156 @@
+---
+# =============================================================================
+# tailscale-proxy-prometheus NetworkPolicies
+#
+# Unlike the tailscale-router pod (hostNetwork -> reserved:host identity in
+# Cilium -> podSelector policies not enforced), the proxy runs with a real
+# pod identity. These NetworkPolicy resources ARE enforced at runtime.
+#
+# Egress needed:
+#   - DNS to CoreDNS (kube-system): resolve hs.${DOMAIN} + target Service
+#   - HTTPS/DERP to internet: control-plane + DERP relay fallback
+#   - UDP high-ports to internet: direct WireGuard + STUN
+#   - TCP :9090 to monitoring/prometheus pods: the actual forward target
+#
+# No ingress needed: tailnet peers reach the proxy via the WireGuard
+# userspace stack (inside the tailscale process), not via any pod-network
+# ingress path. All external tailnet traffic arrives as outbound
+# WireGuard/DERP replies to sessions the proxy itself established.
+# =============================================================================
+---
+# Default deny-all. All egress must be explicitly permitted below.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: tailscale-proxy-prometheus-default-deny
+  namespace: networking
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: tailscale-proxy-prometheus
+  policyTypes: [Ingress, Egress]
+---
+# DNS resolution to cluster CoreDNS. Needed for hs.${SECRET_PUBLIC_DOMAIN}
+# (control plane) and the target Service's DNS name.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: tailscale-proxy-prometheus-allow-dns
+  namespace: networking
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: tailscale-proxy-prometheus
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+---
+# Internet egress on :443/TCP — the headscale control endpoint at
+# hs.${SECRET_PUBLIC_DOMAIN} and Tailscale's public DERP relay pool
+# (DERP falls back to :443/TCP when direct WireGuard fails). Private
+# ranges excluded so the proxy can't accidentally reach the internal
+# network on :443.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: tailscale-proxy-prometheus-allow-internet-egress
+  namespace: networking
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: tailscale-proxy-prometheus
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+---
+# Direct WireGuard + STUN (UDP). tailscaled binds a random UDP port and
+# sends/receives WireGuard datagrams peer-to-peer when direct path is
+# available. STUN on UDP 3478 for NAT discovery. Full high-port UDP range
+# to any public IP; private ranges excluded.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: tailscale-proxy-prometheus-allow-wireguard-egress
+  namespace: networking
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: tailscale-proxy-prometheus
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - protocol: UDP
+      to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+---
+# The actual forward target: TCP :9090 to prometheus pods in the
+# monitoring namespace. This is the outbound net.Dial the TCPForward
+# handler makes for each accepted tailnet connection.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: tailscale-proxy-prometheus-allow-target-egress
+  namespace: networking
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: tailscale-proxy-prometheus
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 9090
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+---
+# Prometheus-side ingress: allow the proxy pod (regular pod identity,
+# no hostNetwork) to reach prometheus on :9090. Complements the
+# per-app default-deny in monitoring.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: prometheus-allow-tailscale-proxy-ingress
+  namespace: monitoring
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: networking
+            app.kubernetes.io/name: tailscale-proxy-prometheus
+      toPorts:
+        - ports:
+            - port: "9090"
+              protocol: TCP

--- a/kubernetes/cluster0/apps/networking/headscale/app/tailscale-proxy-prometheus-rbac.yaml
+++ b/kubernetes/cluster0/apps/networking/headscale/app/tailscale-proxy-prometheus-rbac.yaml
@@ -1,0 +1,47 @@
+---
+# =============================================================================
+# tailscale-proxy-prometheus RBAC
+#
+# Per-proxy ServiceAccount so each tailnet node has its own kube identity
+# and its own state Secret. Mirrors the tailscale-router-rbac.yaml pattern
+# minus the events verbs (bare proxy, no CRDs to publish events for).
+#
+# The state Secret name (tailscale-proxy-prometheus-state) is pinned in the
+# Role's resourceNames, matching the TS_KUBE_SECRET env in the Deployment.
+# The `create` verb is granted on the whole `secrets` resource because
+# Kubernetes RBAC does not allow resourceNames on `create` (the object does
+# not exist yet at create time).
+# =============================================================================
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tailscale-proxy-prometheus
+  namespace: networking
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: tailscale-proxy-prometheus
+  namespace: networking
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["tailscale-proxy-prometheus-state"]
+    verbs: ["get", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tailscale-proxy-prometheus
+  namespace: networking
+subjects:
+  - kind: ServiceAccount
+    name: tailscale-proxy-prometheus
+    namespace: networking
+roleRef:
+  kind: Role
+  name: tailscale-proxy-prometheus
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes/cluster0/apps/networking/headscale/app/tailscale-proxy-prometheus-secret.sops.yaml
+++ b/kubernetes/cluster0/apps/networking/headscale/app/tailscale-proxy-prometheus-secret.sops.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: tailscale-proxy-prometheus-auth
+    namespace: networking
+type: Opaque
+stringData:
+    #ENC[AES256_GCM,data:6rLUs88+zVpgUzi+eTx7PJ0yoy9UEpDg8VgTSfQdhlenlFd5HWKP0nNz,iv:d/NBS9717VXAlRqIzCRdvQQf+7CMXBdmqeael9OwR10=,tag:smITQuQzmlXbSVllxlNL8w==,type:comment]
+    #ENC[AES256_GCM,data:zX3WMDhLMkm0z0Cj9eqmHOEHthC7qOrQnG7nvMV8p0zVaEUbhEh0Fw72X1lD0uQQN+U0z16Q1Jye8qcKbIVgCvU/6/0ReMx34otUz4Sqf1LB+APMPEitwCu1,iv:DD05Ba7gqGVUbRm5nlKpfStjOEjn9yEOcsV5BonzQTk=,tag:1eGsC9aMGG30z0pkdKgDFg==,type:comment]
+    #ENC[AES256_GCM,data:PUBBlDFU5Ii6L6eIal+iVTwpkWvIIIPfu3G9qyW8iKojLJXCRQ+jQaDIP20T4QRD4NdbjBmmKRNA1qZo2RWyrHcQUerfN3dL,iv:5TqPpQpcmyPseEEGw1YlWdc4/aAbLXX0iJSvha2vGo4=,tag:R8Hvbgb60giuQELFcXgnUw==,type:comment]
+    #ENC[AES256_GCM,data:PDIJ9/Xn7ef+LCGSTPH39KiD8xwrEBnUbMMvOPLuyZrxUb2sFpoRj2wB6xGTPyyroBMu2FeaG53RrbOPS3hGmCdSFnfNq4RaSUEupm8=,iv:x/0NUIjOH5qfOWe/FWl6A7ynZXJHYGZgxgwQya4SLj0=,tag:dxcq97+CWvTXe1VNGYw10A==,type:comment]
+    TS_AUTHKEY: ENC[AES256_GCM,data:b12a/o4TCDlBYCjHh5lj0eBSie8wtO7sZGTyin6ULNY7aPryCWCZDO45D8XWntd0rFnrzANAGshLcvyhAA74jw==,iv:ZPwLQ7vht45HWspdy3iWsf4c3X0PDBySc2yoV0CUhdg=,tag:l36aw5yytKxMBOQYGlOztQ==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBXb1ZqampyeGE3YndaN2Ni
+            K3g3VnRWL09HZ1FoUC9JNWZUaytkalpPTkZRCnR5SDRkYkZkckhXZzc0TmNLQ0s5
+            S1N6ZENJRmp1TUN0MFR0cWVOQWJJcTgKLS0tIEtpM2M5Q09ObUFJYUVVaUg5R2Uv
+            TDVLaEloc1MyL2V5bTlKN1k5SG9pSk0KGUChuLex9iRo45Mfp3/mEm4T0iPJdfq6
+            dAGHB/sTmq5Mj78wCVEtC+zjXuQvuebMWbSYgt/R3c8nr/MLbyjbYA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1582vh25trj6w7klwt38d44n5nr8njr8rrxxx5kcfu3y2ezx9ss3s6j24ex
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAyUGhrQzA3emNMRzI5cmNh
+            SlhLekxMNVFXM1lXOGlNcURzTmhZeGYzUEg0ClFmVS9pREZRMXFhMWJ2dnl0TGJV
+            ckR6RGJHbTVDVk1qY2wzRktaaXJ1WDgKLS0tIDg5azRzNnR0Z3BmeHB6TzhjQmQ4
+            YmM2cFBUNEYvWnQ5bjQzOENSazAyTGcKNyyHzF+HYDl2tr/+gZi5upBoOkvJhhpo
+            u4l33pVG9xvXcMzlabawLFS1WkMzuUxap/brG4pGvyPWphY8+Sjk8g==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age185kanaq3uw2gjx5enu2v69nk9ner3lamdevrfgx3wqucsl9ewa2qlt2gf7
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-07-29T05:52:52Z"
+    mac: ENC[AES256_GCM,data:Fup7jj4hIHBpqIhaSih1OrPyK2H0MeftMDvTGY3x75FdbkE6NeJLGeQnq8STzviCF8AVSk4rJ0dZ3VToamL1Txa3LifyulH0JCxv2LaIGp54yhriGd4e0AK81dkJTVmKjaj+d9kQGRKSPUpH39PMS2DbUVPmzi+1Z5oxF+LRQV0=,iv:953WMes75voTbVF9RdZCtkp1K+cA6s0JeIBkYoo5jkY=,tag:Gz1IXvQr6Qrta5NhN1p+WA==,type:str]
+    version: 3.13.3

--- a/kubernetes/cluster0/apps/networking/headscale/app/tailscale-proxy-prometheus-secret.sops.yaml
+++ b/kubernetes/cluster0/apps/networking/headscale/app/tailscale-proxy-prometheus-secret.sops.yaml
@@ -1,36 +1,36 @@
 apiVersion: v1
 kind: Secret
 metadata:
-    name: tailscale-proxy-prometheus-auth
-    namespace: networking
+  name: tailscale-proxy-prometheus-auth
+  namespace: networking
 type: Opaque
 stringData:
-    #ENC[AES256_GCM,data:6rLUs88+zVpgUzi+eTx7PJ0yoy9UEpDg8VgTSfQdhlenlFd5HWKP0nNz,iv:d/NBS9717VXAlRqIzCRdvQQf+7CMXBdmqeael9OwR10=,tag:smITQuQzmlXbSVllxlNL8w==,type:comment]
-    #ENC[AES256_GCM,data:zX3WMDhLMkm0z0Cj9eqmHOEHthC7qOrQnG7nvMV8p0zVaEUbhEh0Fw72X1lD0uQQN+U0z16Q1Jye8qcKbIVgCvU/6/0ReMx34otUz4Sqf1LB+APMPEitwCu1,iv:DD05Ba7gqGVUbRm5nlKpfStjOEjn9yEOcsV5BonzQTk=,tag:1eGsC9aMGG30z0pkdKgDFg==,type:comment]
-    #ENC[AES256_GCM,data:PUBBlDFU5Ii6L6eIal+iVTwpkWvIIIPfu3G9qyW8iKojLJXCRQ+jQaDIP20T4QRD4NdbjBmmKRNA1qZo2RWyrHcQUerfN3dL,iv:5TqPpQpcmyPseEEGw1YlWdc4/aAbLXX0iJSvha2vGo4=,tag:R8Hvbgb60giuQELFcXgnUw==,type:comment]
-    #ENC[AES256_GCM,data:PDIJ9/Xn7ef+LCGSTPH39KiD8xwrEBnUbMMvOPLuyZrxUb2sFpoRj2wB6xGTPyyroBMu2FeaG53RrbOPS3hGmCdSFnfNq4RaSUEupm8=,iv:x/0NUIjOH5qfOWe/FWl6A7ynZXJHYGZgxgwQya4SLj0=,tag:dxcq97+CWvTXe1VNGYw10A==,type:comment]
-    TS_AUTHKEY: ENC[AES256_GCM,data:b12a/o4TCDlBYCjHh5lj0eBSie8wtO7sZGTyin6ULNY7aPryCWCZDO45D8XWntd0rFnrzANAGshLcvyhAA74jw==,iv:ZPwLQ7vht45HWspdy3iWsf4c3X0PDBySc2yoV0CUhdg=,tag:l36aw5yytKxMBOQYGlOztQ==,type:str]
+  #ENC[AES256_GCM,data:8LCtXZJf2AgtOEJddsoyjbh7Sm30sA1c15fKUkUzs1DNSaVG99APfSo7,iv:2W7yTGS/X+zzYvzWvA6lWxYhnglgt5jMrADnsA2Dpio=,tag:vxYKax7pSAeir+KsRr7SWg==,type:comment]
+  #ENC[AES256_GCM,data:Uvwf/4fMPRb7zYD85oinb5vLMQ+6xIYrGKbP3GsfzFlKIQm5LdiL6UeiB5W6VOPL9RKvIZajZaaxGYgfkQyX3sZPh01EqaTZNKTvKuV/wNiSF0Npzk5aS4WI,iv:xaX6rtQB3xXG49zF/Wne1CwJ7SfIzUgXWral+t/IhMA=,tag:AvqcOZv+l9VLrzbOe0+2nA==,type:comment]
+  #ENC[AES256_GCM,data:EFtuX2H/D2WDrWTmOaN5QQTel/ZRbAVQY1kSmNnnPcMbkGLItaKTbWTp9I1ot5WXSjN4dCwgmGPKsjYEzmtPDAYvd+nqBmd1,iv:rusGJmd0UX6eTqXMekui8F/WyxHCiXRLjTtcf4sqqk0=,tag:VBkwxDPlXQouto1EXmJ8DQ==,type:comment]
+  #ENC[AES256_GCM,data:sFYhK55WzrCNrTuHn5iSCSVlhg45190XUyKwLAiaiFNcs9kaW6NR8ITrMQGtGIsdTdUWAuP2fUMn62QSA5qCQa8zQpKlPlMM5GpaOB4=,iv:q5rlgHsUTvtiirKOkBtUhM9RI5Kcehua7NoSB+PsqCg=,tag:QAxkEQ2mi4O+dFIjIckzqw==,type:comment]
+  TS_AUTHKEY: ENC[AES256_GCM,data:92ydg4kZ+cC2XerVK/tAwRAbjCb3YcmFGF2HDl4LvCNSeMaW7B3wgIvCU2SjiPO+7oveXpEu30rD7Y4gBpfgAZehMOnz4QkbTgqP4ObYbWJx7tfwkRe43g==,iv:FZeRsiXl47Zo6WwSe8tdJjvMW8qYqmiHCcweMq4GTv8=,tag:ZIZEqxa2fCb73+BnyjKYkA==,type:str]
 sops:
-    age:
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBXb1ZqampyeGE3YndaN2Ni
-            K3g3VnRWL09HZ1FoUC9JNWZUaytkalpPTkZRCnR5SDRkYkZkckhXZzc0TmNLQ0s5
-            S1N6ZENJRmp1TUN0MFR0cWVOQWJJcTgKLS0tIEtpM2M5Q09ObUFJYUVVaUg5R2Uv
-            TDVLaEloc1MyL2V5bTlKN1k5SG9pSk0KGUChuLex9iRo45Mfp3/mEm4T0iPJdfq6
-            dAGHB/sTmq5Mj78wCVEtC+zjXuQvuebMWbSYgt/R3c8nr/MLbyjbYA==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1582vh25trj6w7klwt38d44n5nr8njr8rrxxx5kcfu3y2ezx9ss3s6j24ex
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAyUGhrQzA3emNMRzI5cmNh
-            SlhLekxMNVFXM1lXOGlNcURzTmhZeGYzUEg0ClFmVS9pREZRMXFhMWJ2dnl0TGJV
-            ckR6RGJHbTVDVk1qY2wzRktaaXJ1WDgKLS0tIDg5azRzNnR0Z3BmeHB6TzhjQmQ4
-            YmM2cFBUNEYvWnQ5bjQzOENSazAyTGcKNyyHzF+HYDl2tr/+gZi5upBoOkvJhhpo
-            u4l33pVG9xvXcMzlabawLFS1WkMzuUxap/brG4pGvyPWphY8+Sjk8g==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age185kanaq3uw2gjx5enu2v69nk9ner3lamdevrfgx3wqucsl9ewa2qlt2gf7
-    encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-07-29T05:52:52Z"
-    mac: ENC[AES256_GCM,data:Fup7jj4hIHBpqIhaSih1OrPyK2H0MeftMDvTGY3x75FdbkE6NeJLGeQnq8STzviCF8AVSk4rJ0dZ3VToamL1Txa3LifyulH0JCxv2LaIGp54yhriGd4e0AK81dkJTVmKjaj+d9kQGRKSPUpH39PMS2DbUVPmzi+1Z5oxF+LRQV0=,iv:953WMes75voTbVF9RdZCtkp1K+cA6s0JeIBkYoo5jkY=,tag:Gz1IXvQr6Qrta5NhN1p+WA==,type:str]
-    version: 3.13.3
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6TXBrUjRydVZwOGtXbWpJ
+        SlVqelpMdjJGTjAzYXIxK0tVc2F4Z3dBelNJCkZ6TW1QQmxvTUxTanFrYzUrdkxZ
+        NUp6SSs3ejFUSXQ5QkJXYTlKdkNyMkUKLS0tIGZsWFJ5TnkwZ0hOYWJFQ3hsYTRZ
+        eTM2c2xBVkFnclBxLzJaNDN5bDZZVTQKr/uz6/enOOjAkprLKKi8/+u2sUf29IxP
+        q2TJEy8xNi4LfaspX3m4Ukt9O9bJyp2k86h6/UUXk5sLLnSmkAk34A==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1582vh25trj6w7klwt38d44n5nr8njr8rrxxx5kcfu3y2ezx9ss3s6j24ex
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB4Zk96aUEzTTJCZ2tJbno5
+        c2o2Z1hvcS9RMk1nclAyTGE0cGVIRkNHL21NCkRGeFI2aG9uODE2Mm92YktLYmFW
+        b01PSng4NVdzWFpqTlExQmgzc2VNRDQKLS0tIG1vUkN0VnVRRTBJOG1lZ09uOTlY
+        WlBqQklRbWtSMitXMW9BYmJQc0t6cWMKIYkhU+8kYmfJqWjXPs+CkmKcvnfSYvt9
+        MHUqypnMfRMOMgWqNCcxgzc4PUeN3HKR+OTzw0tCWlXc6JDLWWLajA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age185kanaq3uw2gjx5enu2v69nk9ner3lamdevrfgx3wqucsl9ewa2qlt2gf7
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-07-29T07:33:49Z"
+  mac: ENC[AES256_GCM,data:DSpwHzRR7E+Pn2+t4dctuWUr9yzwZq6/4hV0ZhwI5bLSSeT3eHW71Vm7c1ST2rP7UMQrSgz8fY3Ao9ARUJSdGIJ7gcct7ByxuwFuE1GNQOpmV8Gvd+/NcbOGRn8q5MAG/q+fvVE2GQYp36p8mcXBwaoDwcNF7loqf+Bdl6tDJNM=,iv:V2FMFHvuOa0UuXRtVrBXr7h0RHoA0eWtTuh7f65uIsM=,tag:GrYo7uOUv3CHuxo8IdVZNA==,type:str]
+  version: 3.13.3


### PR DESCRIPTION
Closes #3378. Implements step 1 of design #3377.

## What this does

Adds a dedicated tailscale proxy `Deployment` per exposed observability
service (prometheus, loki). Each proxy joins the headscale tailnet as its
own node with its own tag (`tag:ts-prometheus`, `tag:ts-loki`) and forwards
inbound tailnet TCP to the in-cluster Service by DNS name. A `tag:nixos`
peer will reach these via MagicDNS:

- `ts-prometheus.tailnet.internal:9090` → `prometheus-kube-prometheus-prometheus.monitoring.svc.cluster.local:9090`
- `ts-loki.tailnet.internal:3100` → `loki.monitoring.svc.cluster.local:3100`

## Additive by design

The existing `tailscale-router` `Deployment` and its NetworkPolicies stay
**deployed and unmodified**. `policy.hujson` gains the new tag owners, the
new tag→tag grants, and additional test assertions **without removing** the
legacy named-host grants or the router's `autoApprovers` entry. That keeps
`main` coherent until #3379 lands (router retirement + policy `tests` block
covering the new-only matrix).

Nothing under `kubernetes/cluster0/apps/kube-system/cilium/` is touched.

## Why this works where the router doesn't (see #3377)

Cilium runs with `kubeProxyReplacement=true`. Its socket-LB rewrites
`ClusterIP → PodIP` **only for locally-originated sockets**, via cgroup eBPF
at `connect()` time. The router forwards packets it receives on its tun
interface, and forwarded packets never hit `connect()` in the router, so
the ClusterIP is never translated and the connection times out.

This proxy uses `TS_USERSPACE=true` (no tun, packet forwarding is not even
possible) + `TS_SERVE_CONFIG` with a `TCPForward` handler. tailscaled
terminates the inbound tailnet TCP inside its userspace netstack, then
issues a fresh `net.Dial` from the pod netns for each accepted connection.
That outbound socket **originates in the pod**, so socket-LB sees `connect()`
and translates the ClusterIP correctly. Origin-socket path preserved.

## Empirical verification plan

I can't run the peer-reaches-service test as part of the PR (it needs a
`tag:nixos` device on the tailnet + a real preauth key). Once merged +
applied, this is the confirmation matrix that maps directly to the ACs:

```bash
# --- pre-merge operator steps (see "Operator TODO" below) ---

# 1. Generate reusable tagged preauth keys, sops edit each secret,
#    verify with:
#      sops -d kubernetes/.../tailscale-proxy-prometheus-secret.sops.yaml
#      sops -d kubernetes/.../tailscale-proxy-loki-secret.sops.yaml
# 2. Commit + merge.

# --- post-merge, after Flux reconciles ---

# ACs "appears in headscale nodes list with its own tag":
kubectl -n networking exec headscale-0 -- headscale nodes list \
  | grep -E 'ts-prometheus|ts-loki'
# expect: two lines, each tagged tag:ts-prometheus / tag:ts-loki

# ACs "tag:nixos peer reaches ... over the tailnet by MagicDNS":
# (from an m4mac / other tag:nixos device)
curl -sS http://ts-prometheus.tailnet.internal:9090/-/healthy   # expect: Prometheus Server is Healthy.
curl -sS http://ts-loki.tailnet.internal:3100/ready              # expect: ready

# AC "empirical origin-socket under kubeProxyReplacement=true":
kubectl -n monitoring exec prometheus-prometheus-kube-prometheus-0 -c prometheus -- \
  sh -c 'ss -tn | grep :9090' | head
# expect: the connection's remote IP is a *pod IP* (10.42.x.y) belonging
# to the proxy pod, NOT the tailnet 100.64.x.y peer IP. If ClusterIP were
# being routed rather than translated, the source would be the tailnet IP.

# AC "denied every other destination and port including :22":
tailscale ping ts-prometheus.tailnet.internal      # expect: ok
nc -vzw2 ts-prometheus.tailnet.internal 22          # expect: refused/timeout (grant only :9090)
nc -vzw2 ts-prometheus.tailnet.internal 3100        # expect: refused/timeout (grant is only :9090 on this tag)
nc -vzw2 ts-loki.tailnet.internal 9090              # expect: refused/timeout

# AC "delete pod, re-registers with tag intact":
kubectl -n networking delete pod -l app.kubernetes.io/name=tailscale-proxy-prometheus
# wait ~30s, then:
kubectl -n networking exec headscale-0 -- headscale nodes list | grep ts-prometheus
# expect: same node re-registered, same tag. State survives via TS_KUBE_SECRET.
```

**No `tests` block.** Rebased on top of the current `main`, which
deliberately removed the `tests` block (headscale resolves each `src` tag
to registered node IPs at boot; with zero `tag:nixos` nodes registered
that resolves to none and every accept/deny logs a scary-looking failure
at boot, which actively misled a live investigation in #3370 — see the
in-file `NOTE` for the full reasoning). The default-deny grant posture
still enforces the AC's "denied every other destination and port" at
runtime; the peer test in the verification matrix above is what actually
demonstrates it. Re-add tests once at least one `tag:nixos` node is
registered.

## Operator TODO before merge

The two SOPS secrets are committed with an obvious PLACEHOLDER value inside
`stringData.TS_AUTHKEY` (encrypted-comment guidance is included in the
files). Before merging:

```bash
# Reusable so pod recreation / node deletion still works.
headscale preauthkeys create --user <op-user> --tags tag:ts-prometheus --reusable
headscale preauthkeys create --user <op-user> --tags tag:ts-loki       --reusable

sops kubernetes/cluster0/apps/networking/headscale/app/tailscale-proxy-prometheus-secret.sops.yaml
sops kubernetes/cluster0/apps/networking/headscale/app/tailscale-proxy-loki-secret.sops.yaml
# Replace the PLACEHOLDER string with the real key from each `headscale preauthkeys create`.
```

Tag is on the preauth key, **not** on `--advertise-tags` (see the inline
deployment comment): headscale 0.28+ hard-rejects a `PreAuthKey`-
authenticated node that also passes `--advertise-tags` (#3370).

Policy `ConfigMap` change note: headscale doesn't auto-reload its policy
file when the mounted ConfigMap updates; if it doesn't pick up the new
`tagOwners` / `grants` after Flux applies, `kubectl -n networking rollout
restart statefulset/headscale` (or just `delete pod headscale-0`). This is
the existing operational behaviour of the app — not introduced by this PR.

## AC checklist mapping

- [x] [functional] Two proxy `Deployment`s exist — `tailscale-proxy-prometheus` and `tailscale-proxy-loki`, wired via `kustomization.yaml`.
- [pending post-merge verification, see above] `tag:nixos` peer reaches prometheus via MagicDNS on tcp/9090.
- [pending post-merge verification, see above] `tag:nixos` peer reaches loki via MagicDNS on tcp/3100.
- [x] [functional] Targets are Service DNS names (`*.svc.cluster.local`), no `/32` pin introduced anywhere.
- [x] [functional] `TS_USERSPACE=true` + `TS_SERVE_CONFIG.TCPForward` = origin-socket path (see rationale block above); the `ss -tn` check is the post-merge empirical verification.
- [x] [functional] `tailscale-router-*` files unchanged (`git diff` confirms).
- [x] [security] `policy.hujson` grants list contains only the two intended paths — no grant permits `:22` on any proxy tag, so headscale's default-deny posture rejects `nc :22` at connect time. Empirically verified with the `nc -vzw2` step in the post-merge matrix above. (No static `tests` block on purpose — see "No `tests` block" note above.)
- [x] [security] `git diff --stat` shows zero changes under `apps/kube-system/cilium/`.
- [x] [security] No `hostNetwork`, no `NET_ADMIN`, no `/dev/net/tun`; all caps dropped; `allowPrivilegeEscalation: false`.
- [x] [security] Two distinct SOPS-encrypted preauth-key Secrets (`tailscale-proxy-prometheus-auth`, `tailscale-proxy-loki-auth`).
- [pending post-merge verification, see above] Pod delete → re-registers with tag intact (state persists in `TS_KUBE_SECRET`).
- [x] [functional] `kubectl kustomize kubernetes/cluster0/apps/networking/headscale/app/` renders cleanly (verified locally).

## Files touched

- `kubernetes/cluster0/apps/networking/headscale/app/kustomization.yaml` — wire new resources.
- `kubernetes/cluster0/apps/networking/headscale/app/policy.yaml` — add tag owners, per-tag grants, expanded tests.
- Eight new manifests, four per proxy: `-rbac.yaml`, `-secret.sops.yaml`, `-deployment.yaml` (ConfigMap + Deployment), `-network-policy.yaml`.

Kept as self-contained raw manifests so the queued bjw-s app-template
refactor (#3360) has minimal surface to reconcile.
