### PR TITLE
tailscale-proxy: allow kube-apiserver egress so proxies can persist state

### DIFF
--- a/kubernetes/cluster0/apps/networking/headscale/app/tailscale-proxy-loki-network-policy.yaml
+++ b/kubernetes/cluster0/apps/networking/headscale/app/tailscale-proxy-loki-network-policy.yaml
@@ -112,6 +112,29 @@ spec:
             matchLabels:
               app.kubernetes.io/name: loki
 ---
+# tailscaled runs in Kubernetes state-store mode (TS_KUBE_SECRET) and must
+# reach the kube-apiserver ClusterIP (10.43.0.1:443) to read/write its
+# node-state Secret. Expressed via the Cilium `kube-apiserver` entity rather
+# than a hardcoded ClusterIP, since the entity resolves correctly even if the
+# ClusterIP changes. Mirrors the pattern used for coredns-allow-kube-apiserver
+# in kube-system/coredns/policy/cilium-network-policy.yaml.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: tailscale-proxy-loki-allow-kube-apiserver-egress
+  namespace: networking
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: tailscale-proxy-loki
+  egress:
+    - toEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+---
 # Loki-side ingress: allow the proxy pod to reach loki on :3100.
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy

--- a/kubernetes/cluster0/apps/networking/headscale/app/tailscale-proxy-prometheus-network-policy.yaml
+++ b/kubernetes/cluster0/apps/networking/headscale/app/tailscale-proxy-prometheus-network-policy.yaml
@@ -133,6 +133,29 @@ spec:
             matchLabels:
               app.kubernetes.io/name: prometheus
 ---
+# tailscaled runs in Kubernetes state-store mode (TS_KUBE_SECRET) and must
+# reach the kube-apiserver ClusterIP (10.43.0.1:443) to read/write its
+# node-state Secret. Expressed via the Cilium `kube-apiserver` entity rather
+# than a hardcoded ClusterIP, since the entity resolves correctly even if the
+# ClusterIP changes. Mirrors the pattern used for coredns-allow-kube-apiserver
+# in kube-system/coredns/policy/cilium-network-policy.yaml.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: tailscale-proxy-prometheus-allow-kube-apiserver-egress
+  namespace: networking
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: tailscale-proxy-prometheus
+  egress:
+    - toEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+---
 # Prometheus-side ingress: allow the proxy pod (regular pod identity,
 # no hostNetwork) to reach prometheus on :9090. Complements the
 # per-app default-deny in monitoring.


### PR DESCRIPTION
## Summary

Refs #3378

The per-service tailscale proxies for prometheus and loki landed in #3380 but
both proxy pods crash-loop in Error state after Flux applies them:

```
kubeclient: error checking Events permissions: Post
"https://kubernetes.default.svc/.../selfsubjectaccessreviews": dial tcp
10.43.0.1:443: connect: connection timed out
```

Root cause: `tailscaled` runs in Kubernetes state-store mode
(`TS_KUBE_SECRET`) and needs to read/write its node-state Secret via the
kube-apiserver, reached at the ClusterIP `10.43.0.1:443`. This cluster runs
default-deny egress, and the existing proxy NetworkPolicies (DNS, internet
443/TCP excluding RFC1918, wireguard UDP, forward-target TCP) have no rule
permitting egress to the apiserver — in fact the internet-443 rule explicitly
*excludes* `10.0.0.0/8`, which is where `10.43.0.1` lives.

## Fix

Added a `CiliumNetworkPolicy` to each proxy's existing `network-policy.yaml`,
using the Cilium `kube-apiserver` entity (`toEntities: [kube-apiserver]`) on
port 443/TCP, rather than hardcoding the ClusterIP — this stays correct if the
apiserver ClusterIP ever changes. This mirrors the existing
`coredns-allow-kube-apiserver` policy in
`kube-system/coredns/policy/cilium-network-policy.yaml`.

### Why this admits `10.43.0.1:443` for the proxy pods

Cilium resolves the `kube-apiserver` entity to the actual apiserver
endpoint(s) it observes at runtime (the Kubernetes Service ClusterIP and any
backing endpoints), independent of a static CIDR. The new
`CiliumNetworkPolicy` selects each proxy pod via
`endpointSelector.matchLabels: app.kubernetes.io/name: tailscale-proxy-{loki,prometheus}`
and permits egress `toEntities: [kube-apiserver]` restricted to port
443/TCP — the exact port/identity tailscaled's Kubernetes state-store client
dials. This is additive: no existing rule (DNS, internet-except-RFC1918,
wireguard, forward-target) is broadened, narrowed, or removed.

## Scope

- Only the two `tailscale-proxy-*-network-policy.yaml` files touched.
- `tailscale-router-*` manifests untouched.
- Nothing under `apps/kube-system/cilium/` touched.
- Internet-egress `except` RFC1918 block unchanged.

## Verification

- `kubectl kustomize kubernetes/cluster0/apps/networking/headscale/app/` renders cleanly (confirmed locally).
- Post-merge pod-status verification (pods reaching `Running` + registering as headscale nodes) needs to be done by the coordinator — my service account is read-only and can't exec into pods.