### PR TITLE
tailscale-proxy: drop port restriction on kube-apiserver egress (match repo convention)

### DIFF
--- a/kubernetes/cluster0/apps/networking/headscale/app/tailscale-proxy-loki-network-policy.yaml
+++ b/kubernetes/cluster0/apps/networking/headscale/app/tailscale-proxy-loki-network-policy.yaml
@@ -118,6 +118,10 @@ spec:
 # than a hardcoded ClusterIP, since the entity resolves correctly even if the
 # ClusterIP changes. Mirrors the pattern used for coredns-allow-kube-apiserver
 # in kube-system/coredns/policy/cilium-network-policy.yaml.
+# Port is intentionally unrestricted: with kubeProxyReplacement=true, Cilium
+# socket-LB translates the kubernetes.default.svc ClusterIP (10.43.0.1:443) to
+# the host apiserver backend port (6443) before egress policy evaluation,
+# so a :443-only toPorts rule would deny the translated traffic. See #2829/#2947.
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -130,10 +134,6 @@ spec:
   egress:
     - toEntities:
         - kube-apiserver
-      toPorts:
-        - ports:
-            - port: "443"
-              protocol: TCP
 ---
 # Loki-side ingress: allow the proxy pod to reach loki on :3100.
 apiVersion: cilium.io/v2

--- a/kubernetes/cluster0/apps/networking/headscale/app/tailscale-proxy-prometheus-network-policy.yaml
+++ b/kubernetes/cluster0/apps/networking/headscale/app/tailscale-proxy-prometheus-network-policy.yaml
@@ -139,6 +139,10 @@ spec:
 # than a hardcoded ClusterIP, since the entity resolves correctly even if the
 # ClusterIP changes. Mirrors the pattern used for coredns-allow-kube-apiserver
 # in kube-system/coredns/policy/cilium-network-policy.yaml.
+# Port is intentionally unrestricted: with kubeProxyReplacement=true, Cilium
+# socket-LB translates the kubernetes.default.svc ClusterIP (10.43.0.1:443) to
+# the host apiserver backend port (6443) before egress policy evaluation,
+# so a :443-only toPorts rule would deny the translated traffic. See #2829/#2947.
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -151,10 +155,6 @@ spec:
   egress:
     - toEntities:
         - kube-apiserver
-      toPorts:
-        - ports:
-            - port: "443"
-              protocol: TCP
 ---
 # Prometheus-side ingress: allow the proxy pod (regular pod identity,
 # no hostNetwork) to reach prometheus on :9090. Complements the


### PR DESCRIPTION
Refs #3378

Remove the `toPorts: port 443` restriction from both tailscale-proxy-loki and tailscale-proxy-prometheus CiliumNetworkPolicy rules for kube-apiserver egress.

With `kubeProxyReplacement=true`, Cilium's socket-LB translates the kubernetes.default.svc ClusterIP (10.43.0.1:443) to the host apiserver backend port (6443) BEFORE egress policy evaluation. A :443-only toPorts rule therefore denies the translated traffic, causing connection timeouts.

The fix matches the repo convention established in coredns, cert-manager, and external-dns policies: use a bare `toEntities: [kube-apiserver]` egress rule with no port restriction.