### PR TITLE
headscale: grant ben@ user devices access to prometheus/loki over the tailnet

### DIFF
--- a/kubernetes/cluster0/apps/networking/headscale/app/policy.yaml
+++ b/kubernetes/cluster0/apps/networking/headscale/app/policy.yaml
@@ -86,6 +86,21 @@ data:
           "dst": ["tag:ts-loki"],
           "ip":  ["tcp:3100"],
         },
+        // Grant Ben's personal user-identity devices (headscale user
+        // ben@, e.g. navi, bens-s25) the same least-privilege
+        // observability access as the tag:nixos machines. These devices
+        // register without a tag, so they're granted by user src
+        // ("ben@") rather than a machine tag.
+        {
+          "src": ["ben@"],
+          "dst": ["tag:ts-prometheus"],
+          "ip":  ["tcp:9090"],
+        },
+        {
+          "src": ["ben@"],
+          "dst": ["tag:ts-loki"],
+          "ip":  ["tcp:3100"],
+        },
         // Legacy router path (kept until #3379).
         {
           "src": ["tag:nixos"],


### PR DESCRIPTION
## Context

Per-service tailscale proxies for prometheus (`tag:ts-prometheus`) and loki
(`tag:ts-loki`) went live in #3378, but the initial grants (design in #3377)
only covered `tag:nixos` machine-identity peers. Ben's personal devices
(e.g. `navi`, `bens-s25`) register under headscale user `ben@` with no tag,
so today they can't even resolve the proxies via MagicDNS — no grant, no
peering.

Ben has decided to widen the policy so his own devices can also reach the
observability services. This PR adds two additional grants for `ben@`,
mirroring the existing per-service-proxy `tag:nixos` grants exactly.

## Change

Additive only. Two grants added to the `grants` block:

- `src: ["ben@"]  ->  dst: ["tag:ts-prometheus"]  ip: ["tcp:9090"]`
- `src: ["ben@"]  ->  dst: ["tag:ts-loki"]        ip: ["tcp:3100"]`

Placed immediately after the two existing `tag:nixos` per-service-proxy
grants and preceded by a comment explaining why user-identity peers exist
alongside the tag-identity peers.

Nothing else changes:

- `tag:nixos` per-service-proxy grants: unchanged
- Legacy `tag:nixos` -> named-host grants (kept until #3379): unchanged
- `tagOwners`, `hosts`, `autoApprovers`: unchanged
- No `tests` block is added (comprehensive tests re-add remains scope of
  the blocked #3379; the in-file NOTE explains the "policy tests failed at
  boot" trap we hit in #3370).

Diff is 15 insertions, 0 deletions, one file.

## Validation

- `kubectl kustomize kubernetes/cluster0/apps/networking/headscale/app/`
  renders cleanly (exit 0).
- Extracted the rendered `policy.hujson` from the ConfigMap and parsed it
  with a HuJSON-aware pass (strip `//` comments outside strings, strip
  trailing commas before `}`/`]`, then `json.loads`). Result: 6 grants
  total (4 `tag:nixos` + 2 new `ben@`), balanced brackets/quotes, all keys
  present.
- Security check: the two new `ben@` grants are exactly `tcp:9090` to
  `tag:ts-prometheus` and `tcp:3100` to `tag:ts-loki`. Nothing else. No
  other ports or destinations are granted to `ben@`, so least-privilege
  holds.

## Deploy notes for the operator

Headscale does NOT hot-reload its policy ConfigMap. After merge, restart
`headscale-0` (`kubectl -n networking rollout restart statefulset/headscale`
or delete the pod) so the new policy takes effect, then test reachability
from a `ben@` device — e.g. `curl http://ts-prometheus:9090/-/ready` on
`navi`.

## Related

- #3377 — original per-service-proxy design (initially chose machine-identity
  only; this PR widens to user-identity as a follow-up per Ben's decision)
- #3378 — per-service proxies rollout
- #3379 — retire legacy router path + re-add tests block (still blocked)