### PR TITLE
fleet-metrics: dedicated single-replica remote_write ingest Prometheus + tailnet proxy

### DIFF
--- a/kubernetes/cluster0/apps/monitoring/grafana/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/monitoring/grafana/app/helm-release.yaml
@@ -75,6 +75,22 @@ spec:
             isDefault: true
             jsonData:
               timeInterval: 30s
+          # Fleet-metrics ingest Prometheus (issue #3386) — separate single-
+          # replica CR that receives remote_write pushes from roaming fleet
+          # devices. Deliberately a distinct datasource from `Prometheus`
+          # above so ad-hoc explore queries can be aimed at push-only data
+          # without touching the HA scrape pair. NOT isDefault. Egress from
+          # Grafana to :9090 in the monitoring namespace is already covered
+          # by grafana-allow-prometheus-egress (podSelector matches this
+          # instance too via app.kubernetes.io/name=prometheus).
+          - name: Prometheus (Fleet Ingest)
+            type: prometheus
+            access: proxy
+            url: http://fleet-ingest.monitoring.svc:9090
+            jsonData:
+              # Fleet Alloy typically pushes on a 15s interval; keep the
+              # query time step aligned.
+              timeInterval: 15s
           # Loki datasource — SingleBinary Loki backed by SeaweedFS S3 (#3347).
           # Loki auth_enabled is false, so no basicAuth / X-Scope-OrgID needed.
           - name: Loki

--- a/kubernetes/cluster0/apps/monitoring/kustomization.yaml
+++ b/kubernetes/cluster0/apps/monitoring/kustomization.yaml
@@ -12,4 +12,9 @@ resources:
   - ./grafana/ks.yaml
   - ./kube-prometheus-stack/ks.yaml
   - ./loki/ks.yaml
+  # Push-only fleet-metrics ingest Prometheus (issue #3386).
+  # Dedicated single-replica CR alongside the HA pair; MUST NOT be
+  # merged into kube-prometheus-stack (see prometheus-fleet-ingest/
+  # prometheus.yaml header for why remote_write and HA don't mix).
+  - ./prometheus-fleet-ingest/ks.yaml
   - ./uptime-kuma/ks.yaml

--- a/kubernetes/cluster0/apps/monitoring/prometheus-fleet-ingest/app/kustomization.yaml
+++ b/kubernetes/cluster0/apps/monitoring/prometheus-fleet-ingest/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./rbac.yaml
+  - ./service.yaml
+  - ./prometheus.yaml
+  - ./network-policy.yaml

--- a/kubernetes/cluster0/apps/monitoring/prometheus-fleet-ingest/app/network-policy.yaml
+++ b/kubernetes/cluster0/apps/monitoring/prometheus-fleet-ingest/app/network-policy.yaml
@@ -1,0 +1,79 @@
+---
+# =============================================================================
+# fleet-ingest NetworkPolicies (issue #3386)
+#
+# Interaction with the HA pair's policies
+# ---------------------------------------
+# All existing HA Prometheus NetworkPolicies in kube-prometheus-stack/app/
+# use `podSelector: matchLabels: {app.kubernetes.io/name: prometheus}`. That
+# label is stamped on ALL Prometheus operator pods regardless of CR, so
+# those policies already spillover-apply to this ingest pod. In particular:
+#
+#   * `prometheus-default-deny`      — default-deny already applies here.
+#   * `prometheus-allow-dns`         — DNS egress already allowed.
+#   * `prometheus-allow-kube-apiserver` (CiliumNP) — apiserver egress
+#     already allowed. This ingest instance does no k8s SD (see rbac.yaml)
+#     so it will not exercise this allow, but the allow existing is
+#     harmless.
+#   * `prometheus-allow-grafana-ingress` — Grafana can already reach
+#     :9090 on the ingest pod. That is what makes the "fleet ingest as
+#     Grafana datasource" wiring work without a new ingress rule here.
+#
+# Rules ADDED below are only the ones that are strictly new for the
+# ingest — i.e. the tailscale-proxy-metrics-ingest ingress. Deliberately
+# scoped by `app.kubernetes.io/instance: fleet-ingest` so they select
+# only the ingest pod, keeping the "rip out cleanly" property (delete
+# this dir + the proxy dir and nothing lingers on the HA pod).
+# =============================================================================
+---
+# Allow the tailscale-proxy-metrics-ingest proxy (networking namespace) to
+# reach the ingest Prometheus on :9090 — this is the receiver port for both
+# remote_write POSTs (/api/v1/write) and any PromQL queries a tailnet peer
+# runs against the instance directly (e.g. via the tailscale port-forwarded
+# UI on ts-metrics-ingest.tailnet.internal:9090).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: fleet-ingest-allow-tailscale-proxy-ingress
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+      app.kubernetes.io/instance: fleet-ingest
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: networking
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: tailscale-proxy-metrics-ingest
+      ports:
+        - port: 9090
+          protocol: TCP
+---
+# Cilium companion (defence-in-depth) — mirrors the standard-NP rule above
+# under kubeProxyReplacement=true semantics. The HA pair uses the same
+# NP/CiliumNP pairing pattern for grafana/operator ingress; we mirror it
+# here so the ingest pod's exposure is enforced by both policy engines.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: fleet-ingest-allow-tailscale-proxy-ingress
+  namespace: monitoring
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+      app.kubernetes.io/instance: fleet-ingest
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: networking
+            app.kubernetes.io/name: tailscale-proxy-metrics-ingest
+      toPorts:
+        - ports:
+            - port: "9090"
+              protocol: TCP

--- a/kubernetes/cluster0/apps/monitoring/prometheus-fleet-ingest/app/prometheus.yaml
+++ b/kubernetes/cluster0/apps/monitoring/prometheus-fleet-ingest/app/prometheus.yaml
@@ -1,0 +1,142 @@
+---
+# =============================================================================
+# fleet-ingest — dedicated single-replica remote_write ingest Prometheus
+# (issue #3386, design context in nixos-config #2458 / #2460)
+#
+# Purpose
+# -------
+# Roaming NixOS/Darwin devices (laptops, phones) push metrics via Alloy
+# `prometheus.remote_write` over the tailnet. Because these devices NAT/roam,
+# scrape is architecturally wrong — push is. The HA kube-prometheus-stack pair
+# is a 2-replica scrape pair; pushing remote_write at its Service round-robins
+# samples across replicas so neither holds the complete series
+# (`__replica__` dedup assumes redundant data, not complementary).
+#
+# THIS CR MUST STAY SEPARATE from the HA pair:
+#   * Distinct CR name (`fleet-ingest`) — the operator stamps
+#     `app.kubernetes.io/instance=fleet-ingest` onto the pod.
+#   * Distinct governing service (`spec.serviceName: fleet-ingest-operated` +
+#     pre-created Service in service.yaml). Two Prometheus CRs in the same
+#     namespace cannot share the default `prometheus-operated` governing
+#     service.
+#   * Distinct ServiceAccount (`fleet-ingest`) — see rbac.yaml.
+#   * Nil scrape-target selectors: this instance MUST NOT scrape. It exists
+#     purely as a remote_write sink.
+#
+# Reversibility
+# -------------
+# This is a deliberately lean, easily-retired exploration ("see what we can
+# do with fleet data"). Everything about the ingest lives under this one dir
+# + a proxy under headscale/ + a datasource entry in Grafana + one ACL grant.
+# To rip out: delete this dir, the proxy files, the datasource entry, and
+# the ACL grant. Nothing else needs to change.
+#
+# Growth bound
+# ------------
+# `retention: 7d` + `retentionSize: 4GB` cap on-disk data (whichever hits
+# first). PVC is 10Gi giving headroom for WAL + head chunks; the size cap
+# stops runaway growth if push volume balloons. TSDB block compaction keeps
+# 7d of typical fleet metrics well below the retentionSize cap.
+#
+# Storage class choice
+# --------------------
+# `local-path` mirrors the HA pair's storage class. Trade-off:
+#   * Node failure loses the pod's data until reschedule (acceptable —
+#     7d retention on exploratory data; roaming devices continue pushing
+#     to the new pod).
+#   * Longhorn would give replicated durability but adds operational load
+#     for an exploratory instance the design says "may be retired".
+# Migration to longhorn (or Mimir) is future work if the exploration
+# proves lasting.
+# =============================================================================
+apiVersion: monitoring.coreos.com/v1
+kind: Prometheus
+metadata:
+  name: fleet-ingest
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: fleet-ingest
+    app.kubernetes.io/component: fleet-ingest
+spec:
+  # Pinned to the same version the HA pair currently runs to avoid the
+  # operator's baked-in default drifting under us. Bump alongside the HA
+  # pair when kube-prometheus-stack is upgraded.
+  version: v3.13.1-distroless
+  image: quay.io/prometheus/prometheus:v3.13.1-distroless
+
+  replicas: 1
+
+  # Governing headless Service is pre-created in service.yaml so we don't
+  # collide with the HA pair's `prometheus-operated` (two Prometheus CRs
+  # in one namespace can't share the default governing Service).
+  serviceName: fleet-ingest-operated
+
+  serviceAccountName: fleet-ingest
+
+  # =========================================================================
+  # Remote-write receiver — the whole point of this instance.
+  # Exposes /api/v1/write on the same web port (:9090). Alloy on fleet
+  # devices posts to http://ts-metrics-ingest.tailnet.internal:9090/api/v1/write
+  # via the tailscale-proxy-metrics-ingest proxy.
+  # =========================================================================
+  enableRemoteWriteReceiver: true
+
+  # Admin API stays off — remote_write does not need it and it would expose
+  # /api/v1/admin/tsdb/{delete_series,clean_tombstones,snapshot} to any peer
+  # allowed to reach :9090.
+  enableAdminAPI: false
+
+  # =========================================================================
+  # Scrape targets: NONE.
+  #
+  # Nil selectors (omit the field entirely) cause the operator to select no
+  # resources of that type. Contrast the kube-prometheus-stack chart's
+  # `xxxSelectorNilUsesHelmValues: false` which forces `{}` (select all).
+  # This instance is push-only; setting `{}` here would make it try to
+  # scrape every ServiceMonitor / PodMonitor in the cluster and fight the
+  # HA pair for the same targets. We do NOT want that.
+  # =========================================================================
+  # serviceMonitorSelector, podMonitorSelector, probeSelector,
+  # scrapeConfigSelector: intentionally not set.
+
+  # No alerting: the ingest is a data sink; alert evaluation happens on the
+  # HA pair (which owns all the PrometheusRule resources).
+  # ruleSelector: intentionally not set.
+
+  # =========================================================================
+  # Storage — real PVC, not emptyDir. See file header for storage class
+  # rationale and growth bound.
+  # =========================================================================
+  retention: 7d
+  retentionSize: 4GB
+  walCompression: true
+  storage:
+    volumeClaimTemplate:
+      spec:
+        storageClassName: local-path
+        accessModes: [ReadWriteOnce]
+        resources:
+          requests:
+            storage: 10Gi
+
+  # Modest resource ask. Push-only + no scraping keeps CPU/memory well under
+  # what the HA pair uses (2Gi/replica). Bump if remote_write consumers grow.
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 1Gi
+
+  # Standard pod hardening. Mirrors the HA pair's securityContext so the
+  # PVC's ownership (fsGroup=2000) matches what Prometheus expects.
+  securityContext:
+    fsGroup: 2000
+    runAsGroup: 2000
+    runAsNonRoot: true
+    runAsUser: 1000
+    seccompProfile:
+      type: RuntimeDefault
+
+  portName: http-web

--- a/kubernetes/cluster0/apps/monitoring/prometheus-fleet-ingest/app/rbac.yaml
+++ b/kubernetes/cluster0/apps/monitoring/prometheus-fleet-ingest/app/rbac.yaml
@@ -1,0 +1,23 @@
+---
+# =============================================================================
+# fleet-ingest ServiceAccount
+#
+# Dedicated SA for the push-only ingest Prometheus (issue #3386). Kept
+# deliberately minimal:
+#
+#   * No ClusterRole / ClusterRoleBinding. The ingest instance has no
+#     ServiceMonitor / PodMonitor / Probe / ScrapeConfig selectors set (see
+#     prometheus.yaml — nil selectors = select nothing, contrast the chart's
+#     `{}` "select everything" pattern), so it never performs Kubernetes SD.
+#     Prometheus itself boots fine without cluster-wide list/watch on
+#     nodes/services/endpoints/pods.
+#
+#   * Distinct name from the HA pair's `prometheus-kube-prometheus-prometheus`
+#     SA. Keeps the ingest fully self-contained so the "rip it out cleanly"
+#     property in the issue holds — delete this dir and nothing else changes.
+# =============================================================================
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fleet-ingest
+  namespace: monitoring

--- a/kubernetes/cluster0/apps/monitoring/prometheus-fleet-ingest/app/service.yaml
+++ b/kubernetes/cluster0/apps/monitoring/prometheus-fleet-ingest/app/service.yaml
@@ -1,0 +1,66 @@
+---
+# =============================================================================
+# fleet-ingest Services (issue #3386)
+#
+# Two Services are required, both selecting exclusively the ingest pod:
+#
+#   1. `fleet-ingest-operated` — headless governing Service for the
+#      StatefulSet the operator materialises. Pinned via
+#      `spec.serviceName: fleet-ingest-operated` on the Prometheus CR so we
+#      do NOT collide with the HA pair's default `prometheus-operated`
+#      governing Service (the operator would otherwise try to create a
+#      second Service by that name and clash — see the CRD note on
+#      `serviceName` when running multiple Prometheus resources in one
+#      namespace).
+#
+#   2. `fleet-ingest` — regular ClusterIP Service used by:
+#        * the tailscale-proxy-metrics-ingest proxy as its TCPForward target
+#          (by DNS name — no /32 pin, matches the #3378 per-service-proxy
+#          pattern);
+#        * Grafana as the datasource URL.
+#
+# Both Services must select ONLY the ingest pod, not the HA pair. Prometheus
+# pods carry `app.kubernetes.io/name=prometheus` unconditionally, so we
+# disambiguate on `app.kubernetes.io/instance=fleet-ingest` (the operator
+# stamps this label to the Prometheus CR's name).
+# =============================================================================
+apiVersion: v1
+kind: Service
+metadata:
+  name: fleet-ingest-operated
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: fleet-ingest
+    app.kubernetes.io/component: fleet-ingest
+spec:
+  type: ClusterIP
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: fleet-ingest
+  ports:
+    - name: http-web
+      port: 9090
+      protocol: TCP
+      targetPort: http-web
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: fleet-ingest
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: fleet-ingest
+    app.kubernetes.io/component: fleet-ingest
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: fleet-ingest
+  ports:
+    - name: http-web
+      port: 9090
+      protocol: TCP
+      targetPort: http-web

--- a/kubernetes/cluster0/apps/monitoring/prometheus-fleet-ingest/ks.yaml
+++ b/kubernetes/cluster0/apps/monitoring/prometheus-fleet-ingest/ks.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-apps-prometheus-fleet-ingest
+  namespace: flux-system
+spec:
+  # Depends on kube-prometheus-stack because the Prometheus CRD is installed by
+  # that chart. Without the CRD present the Prometheus resource here fails to
+  # apply. The operator itself (also installed by kube-prometheus-stack) is what
+  # reconciles our Prometheus CR into a StatefulSet.
+  dependsOn:
+    - name: cluster-apps-kube-prometheus-stack
+  path: ./kubernetes/cluster0/apps/monitoring/prometheus-fleet-ingest/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-cluster0
+  # No healthChecks: this is a bare Prometheus CR (not a HelmRelease). The
+  # operator reconciles it into a StatefulSet; Flux's own reconcile of the
+  # kustomization is sufficient status signal for a lean, exploratory ingest.
+  interval: 30m
+  retryInterval: 1m
+  timeout: 3m

--- a/kubernetes/cluster0/apps/networking/headscale/app/config/policy.hujson
+++ b/kubernetes/cluster0/apps/networking/headscale/app/config/policy.hujson
@@ -8,6 +8,11 @@
     // that any cluster admin might need to redeploy.
     "tag:ts-prometheus": ["homeops@"],
     "tag:ts-loki":       ["homeops@"],
+    // Fleet-metrics remote_write ingest proxy (issue #3386). Same rationale
+    // as ts-prometheus / ts-loki: cluster-managed workload, no human owner
+    // fits; homeops@ owns the machine identity so any cluster admin can
+    // redeploy without needing to re-own the tag.
+    "tag:ts-metrics-ingest": ["homeops@"],
   },
 
   // Named hosts referenced from `grants`. /32s pin to the current
@@ -63,6 +68,17 @@
       "src": ["ben@"],
       "dst": ["tag:ts-loki"],
       "ip":  ["tcp:3100"],
+    },
+    // Fleet-metrics remote_write ingest (issue #3386). ONLY tcp:9090 -
+    // the fleet-ingest Prometheus's web port also serves the receiver
+    // (/api/v1/write) when enableRemoteWriteReceiver is true. No other
+    // ports, no other destinations. Deliberately scoped so ben@ devices
+    // (which push their own device metrics via Alloy remote_write) get
+    // the minimum surface needed to POST samples and query them back.
+    {
+      "src": ["ben@"],
+      "dst": ["tag:ts-metrics-ingest"],
+      "ip":  ["tcp:9090"],
     },
     // Legacy router path (kept until #3379).
     {

--- a/kubernetes/cluster0/apps/networking/headscale/app/kustomization.yaml
+++ b/kubernetes/cluster0/apps/networking/headscale/app/kustomization.yaml
@@ -20,6 +20,13 @@ resources:
   - ./tailscale-proxy-loki-secret.sops.yaml
   - ./tailscale-proxy-loki-deployment.yaml
   - ./tailscale-proxy-loki-network-policy.yaml
+  # Fleet-metrics remote_write ingest proxy (issue #3386). Additive:
+  # exposes the dedicated single-replica fleet-ingest Prometheus to the
+  # tailnet as tag:ts-metrics-ingest. Independent of the HA-pair proxy above.
+  - ./tailscale-proxy-metrics-ingest-rbac.yaml
+  - ./tailscale-proxy-metrics-ingest-secret.sops.yaml
+  - ./tailscale-proxy-metrics-ingest-deployment.yaml
+  - ./tailscale-proxy-metrics-ingest-network-policy.yaml
 labels:
   - pairs:
       app.kubernetes.io/name: headscale

--- a/kubernetes/cluster0/apps/networking/headscale/app/tailscale-proxy-metrics-ingest-deployment.yaml
+++ b/kubernetes/cluster0/apps/networking/headscale/app/tailscale-proxy-metrics-ingest-deployment.yaml
@@ -1,0 +1,118 @@
+---
+# =============================================================================
+# tailscale-proxy-metrics-ingest (issue #3386)
+#
+# Per-service tailscale proxy exposing the fleet-ingest Prometheus (in the
+# monitoring namespace) to the headscale tailnet as its own node
+# (tag:ts-metrics-ingest). Roaming fleet devices push metrics to this proxy
+# via `prometheus.remote_write` -> the proxy re-originates a fresh outbound
+# socket to the ingest Service by DNS name -> hits the receiver on :9090.
+#
+# This mirrors the tailscale-proxy-prometheus / tailscale-proxy-loki design
+# from #3378 in every material way — see tailscale-proxy-prometheus-
+# deployment.yaml for the full rationale (origin-socket property under
+# Cilium socket-LB, tag-from-preauth-key vs --advertise-tags, userspace
+# mode + no NET_ADMIN + no hostNetwork). The only differences here are:
+#
+#   * Target Service: fleet-ingest.monitoring.svc.cluster.local:9090
+#     (the single-replica ingest, NOT the HA pair — this is the whole point).
+#   * Hostname / tag: ts-metrics-ingest / tag:ts-metrics-ingest.
+#   * Preauth key: its own SOPS-encrypted secret
+#     (tailscale-proxy-metrics-ingest-secret.sops.yaml).
+# =============================================================================
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tailscale-proxy-metrics-ingest-serve
+  namespace: networking
+data:
+  # ipn.ServeConfig — TCP handler that TCPForwards inbound tailnet TCP on
+  # port 9090 to the fleet-ingest Service by DNS name. TCPForward does a
+  # standard net.Dial (fresh outbound socket) per accepted connection; it
+  # does NOT proxy packets. Target is the Service DNS name, not a pinned
+  # ClusterIP: no /32 pin drift when the Service is reconstituted.
+  serve.json: |-
+    {
+      "TCP": {
+        "9090": {
+          "TCPForward": "fleet-ingest.monitoring.svc.cluster.local:9090"
+        }
+      }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tailscale-proxy-metrics-ingest
+  namespace: networking
+spec:
+  replicas: 1
+  strategy:
+    # Recreate rather than RollingUpdate: two tailnet nodes with the same
+    # hostname would collide on registration.
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tailscale-proxy-metrics-ingest
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tailscale-proxy-metrics-ingest
+    spec:
+      serviceAccountName: tailscale-proxy-metrics-ingest
+      containers:
+        - name: tailscale
+          image: ghcr.io/tailscale/tailscale:v1.98.9@sha256:f15d5d3f4a68773a853180b72496f70ba614b64de0878c43fe3da39fe0afba47
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            # Userspace mode needs no capabilities. Drop everything.
+            capabilities:
+              drop: [ALL]
+            allowPrivilegeEscalation: false
+          env:
+            - name: TS_KUBE_SECRET
+              value: tailscale-proxy-metrics-ingest-state
+            - name: TS_USERSPACE
+              value: "true"
+            - name: TS_AUTHKEY
+              valueFrom:
+                secretKeyRef:
+                  name: tailscale-proxy-metrics-ingest-auth
+                  key: TS_AUTHKEY
+            - name: TS_EXTRA_ARGS
+              # No --advertise-tags: tag comes from the preauth key
+              # (headscale 0.28+ rejects both; see #3370).
+              value: >-
+                --login-server=https://hs.${SECRET_PUBLIC_DOMAIN}
+                --hostname=ts-metrics-ingest
+            - name: TS_ACCEPT_DNS
+              value: "false"
+            - name: TS_SERVE_CONFIG
+              value: /etc/tsserve/serve.json
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+          volumeMounts:
+            - name: serve-config
+              mountPath: /etc/tsserve
+              readOnly: true
+            - name: tailscale-run
+              mountPath: /var/run/tailscale
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 128Mi
+      volumes:
+        - name: serve-config
+          configMap:
+            name: tailscale-proxy-metrics-ingest-serve
+        - name: tailscale-run
+          emptyDir:
+            medium: Memory

--- a/kubernetes/cluster0/apps/networking/headscale/app/tailscale-proxy-metrics-ingest-network-policy.yaml
+++ b/kubernetes/cluster0/apps/networking/headscale/app/tailscale-proxy-metrics-ingest-network-policy.yaml
@@ -1,0 +1,154 @@
+---
+# =============================================================================
+# tailscale-proxy-metrics-ingest NetworkPolicies (issue #3386)
+#
+# Mirrors tailscale-proxy-prometheus-network-policy.yaml — only the target
+# Service + pod selectors differ. All rationale (why kube-apiserver egress
+# uses `toEntities: [kube-apiserver]` with NO `toPorts` — the trap from
+# #3381/#3382 — and why DNS/internet/wireguard/target are the four egress
+# clauses needed for a userspace tailscale proxy) is documented there and
+# in AGENTS.md's "Pods accessing the Kubernetes API server" note.
+#
+# Enforced at runtime because the proxy runs with a real pod endpoint
+# identity (no hostNetwork, no NET_ADMIN, userspace tailscaled).
+# =============================================================================
+---
+# Default deny-all.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: tailscale-proxy-metrics-ingest-default-deny
+  namespace: networking
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: tailscale-proxy-metrics-ingest
+  policyTypes: [Ingress, Egress]
+---
+# DNS resolution to cluster CoreDNS. Needed for hs.${SECRET_PUBLIC_DOMAIN}
+# (control plane) and the target Service's DNS name
+# (fleet-ingest.monitoring.svc.cluster.local).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: tailscale-proxy-metrics-ingest-allow-dns
+  namespace: networking
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: tailscale-proxy-metrics-ingest
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+---
+# Internet egress on :443/TCP — headscale control endpoint + Tailscale DERP.
+# Private ranges excluded so the proxy can't accidentally reach internal
+# networks on :443.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: tailscale-proxy-metrics-ingest-allow-internet-egress
+  namespace: networking
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: tailscale-proxy-metrics-ingest
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+---
+# Direct WireGuard + STUN (UDP high ports to any public IP). Private ranges
+# excluded.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: tailscale-proxy-metrics-ingest-allow-wireguard-egress
+  namespace: networking
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: tailscale-proxy-metrics-ingest
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - protocol: UDP
+      to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+---
+# The actual forward target: TCP :9090 to the fleet-ingest Prometheus in
+# the monitoring namespace. The TCPForward handler's outbound net.Dial hits
+# this from the pod's netns (origin-socket) so Cilium socket-LB translates
+# the ClusterIP correctly.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: tailscale-proxy-metrics-ingest-allow-target-egress
+  namespace: networking
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: tailscale-proxy-metrics-ingest
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 9090
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+              app.kubernetes.io/instance: fleet-ingest
+---
+# tailscaled runs in Kubernetes state-store mode (TS_KUBE_SECRET) and must
+# reach the kube-apiserver to read/write its node-state Secret. Expressed
+# via the Cilium `kube-apiserver` entity — a bare `NetworkPolicy` `ipBlock`
+# rule is silently bypassed under kubeProxyReplacement=true because Cilium
+# assigns the k3s apiserver the `kube-apiserver` entity identity, not a
+# pod identity.
+#
+# Port is intentionally unrestricted (NO `toPorts`): with kubeProxyReplacement
+# =true, Cilium socket-LB translates the kubernetes.default.svc ClusterIP
+# (10.43.0.1:443) to the host apiserver backend port (6443) BEFORE egress
+# policy evaluation. A `:443`-only `toPorts` rule silently denies the
+# translated traffic and the pod times out. This is the exact trap that
+# bit #3381/#3382 — see AGENTS.md "Pods accessing the Kubernetes API server".
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: tailscale-proxy-metrics-ingest-allow-kube-apiserver-egress
+  namespace: networking
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: tailscale-proxy-metrics-ingest
+  egress:
+    - toEntities:
+        - kube-apiserver

--- a/kubernetes/cluster0/apps/networking/headscale/app/tailscale-proxy-metrics-ingest-rbac.yaml
+++ b/kubernetes/cluster0/apps/networking/headscale/app/tailscale-proxy-metrics-ingest-rbac.yaml
@@ -1,0 +1,46 @@
+---
+# =============================================================================
+# tailscale-proxy-metrics-ingest RBAC (issue #3386)
+#
+# Per-proxy ServiceAccount so the fleet-metrics-ingest tailnet node has its
+# own kube identity and its own state Secret. Mirrors the pattern in
+# tailscale-proxy-prometheus-rbac.yaml — the state Secret name
+# (tailscale-proxy-metrics-ingest-state) is pinned in the Role's
+# resourceNames, matching the TS_KUBE_SECRET env in the Deployment. The
+# `create` verb is granted on the whole `secrets` resource because
+# Kubernetes RBAC does not allow resourceNames on `create` (the object does
+# not exist yet at create time).
+# =============================================================================
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tailscale-proxy-metrics-ingest
+  namespace: networking
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: tailscale-proxy-metrics-ingest
+  namespace: networking
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["tailscale-proxy-metrics-ingest-state"]
+    verbs: ["get", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tailscale-proxy-metrics-ingest
+  namespace: networking
+subjects:
+  - kind: ServiceAccount
+    name: tailscale-proxy-metrics-ingest
+    namespace: networking
+roleRef:
+  kind: Role
+  name: tailscale-proxy-metrics-ingest
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes/cluster0/apps/networking/headscale/app/tailscale-proxy-metrics-ingest-secret.sops.yaml
+++ b/kubernetes/cluster0/apps/networking/headscale/app/tailscale-proxy-metrics-ingest-secret.sops.yaml
@@ -1,0 +1,64 @@
+# =============================================================================
+# tailscale-proxy-metrics-ingest preauth key (issue #3386)
+#
+# OPERATOR TODO BEFORE MERGE
+# --------------------------
+# The value below is a PLACEHOLDER. Before merging this PR, an operator must:
+#
+#   1. Exec into a headscale pod (or run `headscale` locally against the
+#      control server) and generate a reusable, tagged preauth key:
+#
+#        headscale preauthkeys create \
+#          --user homeops \
+#          --tags tag:ts-metrics-ingest \
+#          --reusable \
+#          --expiration 8760h
+#
+#      Both --user homeops and --tags tag:ts-metrics-ingest are important:
+#      the tag has to be one homeops@ owns (see policy.hujson), and the tag
+#      must come from the key (not --advertise-tags — see #3370).
+#
+#   2. Replace the TS_AUTHKEY placeholder below with the real key, then
+#      run `sops --encrypt --in-place <this-file>`.
+#
+#   3. Commit the encrypted file BEFORE Flux reconciles the proxy Deployment,
+#      or the pod will crash-loop trying to authenticate with a bogus key.
+#
+# Mirrors the pattern from #3378 (tailscale-proxy-prometheus / -loki) where
+# the operator generated the real key at merge time.
+# =============================================================================
+apiVersion: v1
+kind: Secret
+metadata:
+    name: tailscale-proxy-metrics-ingest-auth
+    namespace: networking
+type: Opaque
+stringData:
+    #ENC[AES256_GCM,data:+9y1NQzsCvTKQiUYxeOKaknhoXbBz9xbvg1vrNg5jrLCpWWAll0u1yzszZGUukdJq4ZF1sE5nWjrj3EJwXe0NCLwn7+NyqjI,iv:chz0k5XqufjHRPfxNDjYWGesYWgRysi3R0IDAhvrxRk=,tag:jJsLoU0NSNIECiA832lXHg==,type:comment]
+    #ENC[AES256_GCM,data:oFfX0dEGx3/+cr6Z7Zs8CwGoALdzCHZ0YHdQYP0M2Bz5ZZjp3A2R/vRIdmPvVQ49E1FzwESI+iOQe5SsIF0uc4xbqtO1YJLRU+8=,iv:3ZXIKEl7gSaDziICsK9fkdMe4/N00Y9xyM+ZbDUfFfE=,tag:0TEx7dm1csZI8P6N+CxDZg==,type:comment]
+    #ENC[AES256_GCM,data:f4ktJ7vL5PsoS333OikRAj1CHFPD2W+JfXt4+TURBBOXz9fAKXuV8OwQHHdYLhL5j/sL5KjyIjMzyN8qO4njh95mGrc=,iv:sC9RuPmvkNW3iNlxlaG30iZNdnaA1aWDzc2wUsTN9KY=,tag:9XGWzGaFwWCcOqKZo6xdkA==,type:comment]
+    TS_AUTHKEY: ENC[AES256_GCM,data:zHQjMkA5ZvxDDU9X6mqzpNiOOtuZsf5db/PtxYTlIKS2HxphFADVeweLPSnpBPfH3YBIpkt0Ek0ec6h+bjTD,iv:Mk7M1Slqysggh7qqs0q5egwSlgFAtnizf4X5mjGwJ3k=,tag:HhISjJ6glr1PIGSjEOIX5A==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxTVlMQjVwaytDSFhKRm5H
+            WkdEbkYzZ3hrWGpvYXZ6VXNJdTJ0V3V1ekZzCmExZ3JCbStuNmpBVXlIZ1Y1QXVI
+            TUFmWWJNUFM2S1c4YXFUaEJwMTdHOFEKLS0tIHROOWI2MmdyUTJ0cnlwdmpuNTRs
+            WUR6MTAyc0xTaXdHbmdnY0lzRmg3NGMKf1Eb9jmvwlvIhbihqyOTNk659e/iUePS
+            K+UpRPPw3gK0ruouRgxxxwFm+HgGkDvaIcRrqueA5uv/m93kjQ3/ow==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1582vh25trj6w7klwt38d44n5nr8njr8rrxxx5kcfu3y2ezx9ss3s6j24ex
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB1K2JhbUJiSUxDV245RkRh
+            R3VHc29SN0NJK2NReGtmT1pxdWtJa1ZZT0Y0CkpJUFJMQ2pRTVNmUnloWk1uY3V6
+            VGlsY1BwUmNXWmdkaUtiaWYyRkVWVUEKLS0tIFh0RTI1bWs4SitMWXlDS0phRWN6
+            QnBZYjUrRUh6WHBjYzREK1FsSVVBVlEKjV2V7yhGFDtsCBk58IA49BqAcbpEv41N
+            edHClgdsSMTT46rWsa44Lr72GvlXMDDdSEfIoQ8EK7ZVQuw+wyIWXQ==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age185kanaq3uw2gjx5enu2v69nk9ner3lamdevrfgx3wqucsl9ewa2qlt2gf7
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-07-29T09:16:26Z"
+    mac: ENC[AES256_GCM,data:1CRi2Msaj5Gsvmm/YqrBIhmQ1qIAU2yBLnvBMjTbYNQw/DolPjdXPeqs+2+Lap3FvIcQfiPeZBjNbZBtHvSytfF2pGyIEeHvVICj+pDlpEvmj7xjXq+qMsZjbY/N2aVk9yN8UpVsiyjZGEhTmJA3ud3JAd4YI3BRwBzDEF9uhkk=,iv:29Qm3n4QNvHHEC44/BoJRE3o25c+QbQq1YVOcs2k9K0=,tag:2l6oO7ORN/rvWoVADmiG0w==,type:str]
+    version: 3.13.3

--- a/kubernetes/cluster0/apps/networking/headscale/app/tailscale-proxy-metrics-ingest-secret.sops.yaml
+++ b/kubernetes/cluster0/apps/networking/headscale/app/tailscale-proxy-metrics-ingest-secret.sops.yaml
@@ -30,35 +30,35 @@
 apiVersion: v1
 kind: Secret
 metadata:
-    name: tailscale-proxy-metrics-ingest-auth
-    namespace: networking
+  name: tailscale-proxy-metrics-ingest-auth
+  namespace: networking
 type: Opaque
 stringData:
-    #ENC[AES256_GCM,data:+9y1NQzsCvTKQiUYxeOKaknhoXbBz9xbvg1vrNg5jrLCpWWAll0u1yzszZGUukdJq4ZF1sE5nWjrj3EJwXe0NCLwn7+NyqjI,iv:chz0k5XqufjHRPfxNDjYWGesYWgRysi3R0IDAhvrxRk=,tag:jJsLoU0NSNIECiA832lXHg==,type:comment]
-    #ENC[AES256_GCM,data:oFfX0dEGx3/+cr6Z7Zs8CwGoALdzCHZ0YHdQYP0M2Bz5ZZjp3A2R/vRIdmPvVQ49E1FzwESI+iOQe5SsIF0uc4xbqtO1YJLRU+8=,iv:3ZXIKEl7gSaDziICsK9fkdMe4/N00Y9xyM+ZbDUfFfE=,tag:0TEx7dm1csZI8P6N+CxDZg==,type:comment]
-    #ENC[AES256_GCM,data:f4ktJ7vL5PsoS333OikRAj1CHFPD2W+JfXt4+TURBBOXz9fAKXuV8OwQHHdYLhL5j/sL5KjyIjMzyN8qO4njh95mGrc=,iv:sC9RuPmvkNW3iNlxlaG30iZNdnaA1aWDzc2wUsTN9KY=,tag:9XGWzGaFwWCcOqKZo6xdkA==,type:comment]
-    TS_AUTHKEY: ENC[AES256_GCM,data:zHQjMkA5ZvxDDU9X6mqzpNiOOtuZsf5db/PtxYTlIKS2HxphFADVeweLPSnpBPfH3YBIpkt0Ek0ec6h+bjTD,iv:Mk7M1Slqysggh7qqs0q5egwSlgFAtnizf4X5mjGwJ3k=,tag:HhISjJ6glr1PIGSjEOIX5A==,type:str]
+  #ENC[AES256_GCM,data:mBsXofAmiR7tFMHkGF97Xy+fUPziZM9vnKEICM5LZHG1M+5LJ0EJjryOj5nRPk01Z8XTx1Y5yjeSr2iEJZM5cbbt+RZzX2Ks,iv:B9M8/g76etW6p/pUDJ8XWrkVAgx6UHrYauhYEIQodEA=,tag:ApUsXwQaJ2eZllJ6q+eDkA==,type:comment]
+  #ENC[AES256_GCM,data:KEYRj6L4F9tD4e4kv+rZxnPlP01IAPJlnOKih3ytT9fYyq4/eFoebd+ZQwLLuqw2CCDCvCU1ueNl+ePKRBGGHmxPjnPBWv1m9JA=,iv:4TCiOBfxH/Zct0JN00ZGPmjDir01e8AtVRH1UZAhW3s=,tag:4rLBCynuI+2k192N0Sp3EA==,type:comment]
+  #ENC[AES256_GCM,data:5Qgb2YWst6EKRrE90EgzFWQ0PiQnpNAvIPQbb+2fr4oyTQ9SqqXRnG23eqQ/nJZpoQOEPXNrP9yDpzdEC5rVZp2BwPc=,iv:hIn5HKewoE0xoz+EbiYuFNzfCGbUggLYwFDcf3kluHE=,tag:7VJI1MhMRL+gZTbIZCohCw==,type:comment]
+  TS_AUTHKEY: ENC[AES256_GCM,data:uR0q6mEL3hSwGxr8hvOjRp3mVCkkM3zc8+F53UCh4EAgzsyWDye08gPgUfGozRaWQ93puePvkMFG6O+G8xSC2Z/FzwJp68yE7lckMa20iV6eWT0VjTSfbg==,iv:j0W1/+GzdCVahVBF/+YqGYJ2qjKN1AvgHMuNFdWj+PY=,tag:/e7/3qNfsPiQdgNwjXJNCw==,type:str]
 sops:
-    age:
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxTVlMQjVwaytDSFhKRm5H
-            WkdEbkYzZ3hrWGpvYXZ6VXNJdTJ0V3V1ekZzCmExZ3JCbStuNmpBVXlIZ1Y1QXVI
-            TUFmWWJNUFM2S1c4YXFUaEJwMTdHOFEKLS0tIHROOWI2MmdyUTJ0cnlwdmpuNTRs
-            WUR6MTAyc0xTaXdHbmdnY0lzRmg3NGMKf1Eb9jmvwlvIhbihqyOTNk659e/iUePS
-            K+UpRPPw3gK0ruouRgxxxwFm+HgGkDvaIcRrqueA5uv/m93kjQ3/ow==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1582vh25trj6w7klwt38d44n5nr8njr8rrxxx5kcfu3y2ezx9ss3s6j24ex
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB1K2JhbUJiSUxDV245RkRh
-            R3VHc29SN0NJK2NReGtmT1pxdWtJa1ZZT0Y0CkpJUFJMQ2pRTVNmUnloWk1uY3V6
-            VGlsY1BwUmNXWmdkaUtiaWYyRkVWVUEKLS0tIFh0RTI1bWs4SitMWXlDS0phRWN6
-            QnBZYjUrRUh6WHBjYzREK1FsSVVBVlEKjV2V7yhGFDtsCBk58IA49BqAcbpEv41N
-            edHClgdsSMTT46rWsa44Lr72GvlXMDDdSEfIoQ8EK7ZVQuw+wyIWXQ==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age185kanaq3uw2gjx5enu2v69nk9ner3lamdevrfgx3wqucsl9ewa2qlt2gf7
-    encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-07-29T09:16:26Z"
-    mac: ENC[AES256_GCM,data:1CRi2Msaj5Gsvmm/YqrBIhmQ1qIAU2yBLnvBMjTbYNQw/DolPjdXPeqs+2+Lap3FvIcQfiPeZBjNbZBtHvSytfF2pGyIEeHvVICj+pDlpEvmj7xjXq+qMsZjbY/N2aVk9yN8UpVsiyjZGEhTmJA3ud3JAd4YI3BRwBzDEF9uhkk=,iv:29Qm3n4QNvHHEC44/BoJRE3o25c+QbQq1YVOcs2k9K0=,tag:2l6oO7ORN/rvWoVADmiG0w==,type:str]
-    version: 3.13.3
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBYR3JzUE5OMStNZGZ1MCtm
+        NG5PMUJhYjQ2TGUyUkRPNko5aUNxNjRVYUI4CjVZc0k4a1NJNFIxQ3pZeDF0alN3
+        SWhxb3JwY29FL3Jnak1hcE5QbmhtT1UKLS0tIHR0aE83amkra2xMMXF2dVVHNkow
+        YmYrNXNjWUFBdWcyOWU2QWdCNWhheGcKi0BjTUT4HTpPiUmXrYJE2hJnZBn0HKmO
+        DaMtuWOzoT6wBJzxRRAkCsiNthdRG7/j8O6YVrx6dHwShjXi3XDGyQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1582vh25trj6w7klwt38d44n5nr8njr8rrxxx5kcfu3y2ezx9ss3s6j24ex
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBIdDFnQkM2bVZEbkE1dmRF
+        WnFvQmxKdUZydTFiNVYxSXNHN1JwblJwUDNrCm9GNDlER0lnWWpwMDBUQ3UzSm8w
+        ZWZaK0drNEt6amlaem0vVk0xU1lRQzgKLS0tIFozVVBnNFlZQWRuekFhVFAzNWlL
+        L0xnbXdqOUxsZm1hZmdwakpkb2x5UmsK5tYTpFD7JdbIytT7LxA2n+T4ZU0s36Bx
+        ZndUFv5cD3MNrCrQW4cV/RLW8naOI5nFNplmA8Z2YM64PP+8eGClBg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age185kanaq3uw2gjx5enu2v69nk9ner3lamdevrfgx3wqucsl9ewa2qlt2gf7
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-07-29T19:44:24Z"
+  mac: ENC[AES256_GCM,data:K4l8i13yDHTVahgs1GgKNOezwOB+HtluD4eChc8FALWnuS6RVzQwIz/dWm/jmQ+pXxklqmZ3Ea+fIB49m91EVvH0jDXOISxelRjA36O65uTyQFr+2E2QrhY8fa17BF9eExZgfsKI1I5PUTlIbb+hAIcVVGQophDxyZWWVlK2okE=,iv:U5E5eGLA+AirkEvyz4W9p+vCrpbdvyP6unJwoy9jG8s=,tag:yRk+u4VPgfXFl+0iNc6yuQ==,type:str]
+  version: 3.13.3


### PR DESCRIPTION
Closes #3386.

## What

Stand up a dedicated single-replica remote_write ingest Prometheus for roaming
fleet devices, plus a per-service tailscale proxy that exposes it to the tailnet,
plus the matching headscale ACL grant, plus a Grafana datasource. Deliberately
lean and reversible — the design says "may be retired" and this PR keeps every
piece self-contained so we can rip it out cleanly.

## Why not the existing HA Prometheus

`kube-prometheus-stack` runs Prometheus as a 2-replica HA scrape pair fronted by
a Service. Pushing `remote_write` at that Service round-robins connections, so
each replica receives a *different partial slice* of the pushed samples —
neither holds the complete series. `__replica__` dedup can't fix it (it assumes
redundant, not complementary, data). We must NOT enable
`enableRemoteWriteReceiver` on the HA pair.

## Changes

**`kubernetes/cluster0/apps/monitoring/prometheus-fleet-ingest/`** (new dir)

- `ks.yaml`: Flux `Kustomization`, `dependsOn: cluster-apps-kube-prometheus-stack`
  (needs the Prometheus CRD + operator).
- `app/prometheus.yaml`: bare `monitoring.coreos.com/v1 Prometheus` CR named
  `fleet-ingest`. Single replica. `enableRemoteWriteReceiver: true`,
  `enableAdminAPI: false`, `retention: 7d`, `retentionSize: 4GB`, 10Gi
  `local-path` PVC via `volumeClaimTemplate` (real claim, not emptyDir), version
  pinned to `v3.13.1-distroless` to match the HA pair. Nil scrape-target
  selectors (operator treats absent selectors as "select nothing") so this
  instance is push-only — it never scrapes anything, avoiding any collision
  with the HA pair.
- `app/service.yaml`: `fleet-ingest-operated` headless governing Service (pinned
  via `spec.serviceName` on the CR so we don't collide with the HA pair's
  default `prometheus-operated`) and `fleet-ingest` ClusterIP Service for both
  the proxy target and the Grafana datasource. Both select by
  `app.kubernetes.io/name=prometheus + app.kubernetes.io/instance=fleet-ingest`
  so they pick up ONLY the ingest pod.
- `app/rbac.yaml`: dedicated `fleet-ingest` ServiceAccount, no ClusterRole
  binding (push-only + no scrape config = no k8s SD, so no cluster-wide RBAC
  needed).
- `app/network-policy.yaml`: `NetworkPolicy` +  `CiliumNetworkPolicy` allowing
  ingress from `networking/tailscale-proxy-metrics-ingest` on `:9090` only.
  The HA-pair `prometheus-default-deny` selects `app.kubernetes.io/name=prometheus`
  and therefore already spillover-applies to the ingest pod, so the starting
  posture is denied.

**`kubernetes/cluster0/apps/networking/headscale/app/tailscale-proxy-metrics-ingest-*`**
(new files, mirrors the #3378 per-service-proxy pattern)

- `-deployment.yaml`: userspace tailscaled + `TCPForward` to
  `fleet-ingest.monitoring.svc.cluster.local:9090` (Service DNS name, no
  ClusterIP pin), `--hostname=ts-metrics-ingest`, `TS_USERSPACE=true`, tag
  arrives via the preauth key (not `--advertise-tags` — the #3370 trap), no
  `hostNetwork`, no `NET_ADMIN`.
- `-rbac.yaml`: dedicated ServiceAccount + Role + RoleBinding, `resourceNames`
  pinned to `tailscale-proxy-metrics-ingest-state` for the state Secret.
- `-network-policy.yaml`: default-deny + DNS + internet (:443) + WireGuard
  (UDP) + target (:9090 to the fleet-ingest pod in monitoring) egress rules,
  plus the bare `toEntities: [kube-apiserver]` CiliumNP with **no `toPorts`**
  (the AGENTS.md apiserver-egress convention, exactly the #3381/#3382 fix).
- `-secret.sops.yaml`: SOPS-encrypted stub. **Operator TODO before merge** —
  see below.

**`kubernetes/cluster0/apps/networking/headscale/app/config/policy.hujson`**

- Adds `tag:ts-metrics-ingest` to `tagOwners`, owned by `homeops@` (comment
  explains why: cluster-managed workload, no human owner fits).
- Adds ONE new grant:
  ```
  { "src": ["ben@"], "dst": ["tag:ts-metrics-ingest"], "ip": ["tcp:9090"] }
  ```
  Nothing else. All existing tagOwners / hosts / grants left untouched.

**`kubernetes/cluster0/apps/monitoring/grafana/app/helm-release.yaml`**

- Adds a `Prometheus (Fleet Ingest)` datasource pointing at
  `http://fleet-ingest.monitoring.svc:9090`. Not `isDefault`. Grafana's egress
  to `:9090` in `monitoring` is already covered by the existing
  `grafana-allow-prometheus-egress` rule (its podSelector matches the ingest
  pod too via `app.kubernetes.io/name=prometheus`), so no new NetworkPolicy is
  needed.

**Kustomization glue**: `apps/monitoring/kustomization.yaml` and
`apps/networking/headscale/app/kustomization.yaml` list the new files.

## What is deliberately NOT changed

- Nothing in `apps/monitoring/kube-prometheus-stack/` (the HA pair).
- Nothing in the existing `tailscale-proxy-prometheus-*` /
  `tailscale-proxy-loki-*` / `tailscale-router-*` manifests.
- Nothing under `apps/kube-system/cilium/`.
- No ServiceMonitor for the ingest instance — it's push-only, we're
  deliberately not scraping it. No speculative
  `prometheus-allow-fleet-ingest-scrape-egress` rule was added (the Prometheus
  scrape NetworkPolicy lint would only flag one if a matching ingress rule
  existed).

## How a push reaches the receiver

Tracing a POST to `http://ts-metrics-ingest.tailnet.internal:9090/api/v1/write`
from a `ben@` device (e.g. navi):

1. **ACL check.** headscale evaluates the grant
   `src [ben@] -> dst [tag:ts-metrics-ingest] on tcp:9090`. Match → allow.
   No other grant / no other port would be permitted.
2. **Tailnet forward.** The tailnet routes the TCP flow to the node advertising
   `ts-metrics-ingest.tailnet.internal` — that is the
   `tailscale-proxy-metrics-ingest` Deployment's tailscaled pod (userspace,
   TS_SERVE_CONFIG binding TCP:9090).
3. **Re-origination.** tailscaled's `TCPForward` handler accepts the inbound
   tailnet TCP connection, terminates it, and opens a **fresh outbound
   `net.Dial`** from the pod netns to
   `fleet-ingest.monitoring.svc.cluster.local:9090`. Because this is an
   origin-socket `connect()` inside the pod, Cilium's cgroup-attached
   socket-LB translates the ClusterIP → PodIP correctly under
   `kubeProxyReplacement=true`. This is the exact property #3377 established.
4. **NetworkPolicy checks.**
   - Egress from proxy: `tailscale-proxy-metrics-ingest-allow-target-egress`
     (:9090 to namespace `monitoring` + pod selector
     `app.kubernetes.io/name=prometheus, app.kubernetes.io/instance=fleet-ingest`)
     → allow.
   - Ingress on fleet-ingest: `fleet-ingest-allow-tailscale-proxy-ingress`
     (from namespace `networking` + pod selector
     `app.kubernetes.io/name=tailscale-proxy-metrics-ingest` on :9090) →
     allow. Also the Cilium companion policy `fleet-ingest-allow-tailscale-
     proxy-ingress` mirrors this at the Cilium enforcement layer.
5. **Receiver.** Prometheus's HTTP web server (with
   `enableRemoteWriteReceiver: true`) handles `POST /api/v1/write`, ingesting
   the samples into the local TSDB. The 10Gi local-path PVC persists them;
   retention (7d / 4GB whichever hits first) bounds growth.

## HuJSON validation

Parsed the rendered ConfigMap payload locally after stripping HuJSON's
extensions (line comments, trailing commas). Result: valid JSON with
`tagOwners=[k8s-router, nixos, ts-prometheus, ts-loki, ts-metrics-ingest]`
and 7 grants including the new
`{src: [ben@], dst: [tag:ts-metrics-ingest], ip: [tcp:9090]}`. No changes to
pre-existing entries.

## Render checks

- `kubectl kustomize kubernetes/cluster0/apps/monitoring/prometheus-fleet-ingest/app`
  renders cleanly (SA, 2 Services, Prometheus CR, NetworkPolicy,
  CiliumNetworkPolicy).
- `kubectl kustomize kubernetes/cluster0/apps/networking/headscale/app` renders
  cleanly and includes all four new `tailscale-proxy-metrics-ingest-*`
  resources plus the updated `headscale-policy` ConfigMap.
- `flux build kustomization cluster-apps-prometheus-fleet-ingest ...` and
  `flux build kustomization cluster-apps-headscale ...` both succeed with the
  full post-substitution output as expected.
- The bidirectional Prometheus-scrape NetworkPolicy lint
  (`scripts/lint-prometheus-scrape-netpol.py`) still passes — the ingest
  instance has no scrape ingress rule and no matching egress is required.

## Operator TODO before merge

`tailscale-proxy-metrics-ingest-secret.sops.yaml` currently contains a
PLACEHOLDER encrypted value. Before merging, an operator must:

```bash
# 1. Generate a real headscale preauth key
headscale preauthkeys create \
  --user homeops \
  --tags tag:ts-metrics-ingest \
  --reusable \
  --expiration 8760h

# 2. Replace the TS_AUTHKEY value in the SOPS secret, then re-encrypt
sops kubernetes/cluster0/apps/networking/headscale/app/tailscale-proxy-metrics-ingest-secret.sops.yaml

# 3. Commit the encrypted result and push
```

Same pattern used for `ts-prometheus` / `ts-loki` preauth secrets in #3378.
If the placeholder ships as-is, the proxy pod will crash-loop trying to
authenticate — fail-safe, but not functional.

## Post-merge verification (coordinator)

- `kubectl -n monitoring get prometheus fleet-ingest` → available.
- `kubectl -n monitoring get pod -l app.kubernetes.io/instance=fleet-ingest` →
  Running.
- `headscale nodes list` shows `ts-metrics-ingest` with tag
  `tag:ts-metrics-ingest`.
- From a `ben@` tailnet peer:
  ```
  curl -sv --data-binary "@/dev/null" -H "Content-Encoding: snappy" \
    -H "Content-Type: application/x-protobuf" \
    -H "X-Prometheus-Remote-Write-Version: 0.1.0" \
    http://ts-metrics-ingest.tailnet.internal:9090/api/v1/write
  ```
  should reach the receiver (400/422 for bad payload = wire path works;
  connection-refused / timeout = wire path broken).
- Grafana → Explore → "Prometheus (Fleet Ingest)" datasource returns instant
  query results (`up{}` after first push, or empty until data arrives).

## Reversibility

To retire: delete `apps/monitoring/prometheus-fleet-ingest/`, delete the four
`tailscale-proxy-metrics-ingest-*` files, remove the new tag owner + grant
from `policy.hujson`, remove the datasource entry from
`grafana/app/helm-release.yaml`, remove the kustomization list entries. No
other file needs to change.
