### PR TITLE
loki: migrate to grafana-community/helm-charts source

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -166,6 +166,23 @@
       internalChecksFilter: 'strict',
     },
     {
+      // Never propose loki chart bumps from the old grafana-charts source.
+      // The `loki` chart in grafana/helm-charts went GEL-only from v7.0.0 --
+      // maintained for Grafana Enterprise Logs users only -- with OSS
+      // installs redirected to grafana-community/helm-charts, forked at
+      // exactly chart v6.55.0 (see #3400, grafana/loki#20705). This cluster's
+      // `loki` HelmRelease now sources from the `grafana-community-charts`
+      // HelmRepository instead, so future bumps should come from that
+      // registry. This rule is a defence-in-depth guard: if the HelmRelease
+      // is ever accidentally repointed back at grafana.github.io/helm-charts,
+      // Renovate must not silently walk it onto the GEL-only 7.x line.
+      description: 'Never propose loki chart v7+ from the GEL-only grafana-charts source; track the OSS community fork instead (#3400)',
+      matchDatasources: ['helm'],
+      matchPackageNames: ['loki'],
+      matchCurrentRegistryUrls: ['https://grafana.github.io/helm-charts'],
+      enabled: false,
+    },
+    {
       // Group both Flux dependencies into a single PR. The Flux version is
       // carried in two places that Renovate tracks independently:
       //   - `kubernetes/cluster0/bootstrap/flux/kustomization.yaml` — Kustomize

--- a/kubernetes/cluster0/apps/monitoring/loki/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/monitoring/loki/app/helm-release.yaml
@@ -10,6 +10,17 @@
 # Chunks + index live in the SeaweedFS S3 bucket "loki"; the StatefulSet keeps
 # a small 10Gi Longhorn PVC for /var/loki (WAL, boltdb-shipper cache, ruler
 # WAL). No bulk log data lives on Longhorn.
+#
+# Chart source (#3400): the `loki` chart in grafana/helm-charts went
+# GEL-only from v7.0.0 onward -- as of chart 7.0.0 it's maintained for
+# Grafana Enterprise Logs users only, and OSS installs moved to the
+# community-maintained fork at grafana-community/helm-charts, forked at
+# exactly chart v6.55.0 (see grafana/loki#20705). This HelmRelease sources
+# from the `grafana-community-charts` HelmRepository, NOT `grafana-charts`,
+# and is deliberately held at 6.55.0 -- the last OSS-supported version. Do
+# NOT repoint this back at `grafana-charts` or bump past 6.55.0 without
+# re-reading #3400; the community chart is what's tracked for future
+# upgrades (see the Renovate carve-out in .github/renovate.json5).
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
@@ -23,7 +34,7 @@ spec:
       version: 6.55.0
       sourceRef:
         kind: HelmRepository
-        name: grafana-charts
+        name: grafana-community-charts
         namespace: flux-system
       interval: 15m
   install:

--- a/kubernetes/cluster0/flux/repositories/helm/grafana-community-charts.yaml
+++ b/kubernetes/cluster0/flux/repositories/helm/grafana-community-charts.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/helmrepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: grafana-community-charts
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://grafana-community.github.io/helm-charts
+  timeout: 3m

--- a/kubernetes/cluster0/flux/repositories/helm/kustomization.yaml
+++ b/kubernetes/cluster0/flux/repositories/helm/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - coredns-charts.yaml
   - external-dns-charts.yaml
   - grafana-charts.yaml
+  - grafana-community-charts.yaml
   - helm-openldap-charts.yaml
   - intel.yaml
   - jetstack-charts.yaml


### PR DESCRIPTION
## Summary

The `loki` chart in `grafana/helm-charts` went **GEL-only** from chart v7.0.0 onward. OSS users are redirected to `grafana-community/helm-charts`, which forked the chart at exactly v6.55.0. Our Loki HelmRelease (SingleBinary, SeaweedFS S3 backend) is pinned at chart `6.55.0`, so this change is a **source-repository swap, not a version bump**.

## Changes

- Adds a `grafana-community-charts` `HelmRepository` under `kubernetes/cluster0/flux/repositories/helm/`, wired into that directory's `kustomization.yaml`, following the interval/type conventions of the sibling manifests (AC1).
- Repoints the `loki` HelmRelease `sourceRef` at the new repository. `version: 6.55.0` is unchanged (AC2).
- `grafana-charts` is left in place unmodified — `grafana` and `alloy` HelmReleases still source from it (AC4, verified via grep).
- Documents the source change and rationale in the Loki HelmRelease header comment, so a future reader doesn't "helpfully" repoint it back (AC6).
- Adds a Renovate carve-out (`.github/renovate.json5`) disabling proposals for `loki` from the old `grafana.github.io/helm-charts` registry URL, in the style of the existing `seaweedfs` carve-out in `automerge.json5` (AC5).
- Closes #3349 (the rejected `6.55.0` → `7.1.0` Renovate PR that prompted this issue) with a comment linking here (AC7).

Closes #3400

## No-op verification (AC3)

Compared the Helm repo index entries for `loki` chart `6.55.0` from both sources:

- `grafana.github.io/helm-charts` index: `digest: f0026f251da5b49cea636a24143dbbadf15b39f51fc4639c9e0d08a4bc975ee3`
- `grafana-community.github.io/helm-charts` index: `digest: f0026f251da5b49cea636a24143dbbadf15b39f51fc4639c9e0d08a4bc975ee3`

**Identical digest** — the community fork's `loki-6.55.0.tgz` is byte-for-byte the same chart content as upstream's. I also downloaded and inspected the community tarball directly: the `single-binary/statefulset.yaml` template still defines the `tmp` `emptyDir` volume that our `bootstrap-s3-bucket` initContainer depends on (mounted at `/tmp` so `mc` can write `.mc` config), unchanged from what the in-tree comment describes for chart v6.55.0.

Given the identical digest, the compactor/retention config, `limits_config` guardrails, and all `replicas: 0` component toggles render identically too — no template content differs at all between sources for this version.

**Note on local CI verification:** I was unable to run `flux-local test`/`diff` locally in this sandbox (podman is non-functional in this environment — `podman info` fails with "no such file or directory" even for basic commands). The digest-identity check above is strong evidence of a no-op, but the coordinator/CI's `Flux Local - Diff (helmrelease)` run is the authoritative confirmation per the issue's own AC3 wording ("primary evidence"). Please treat that CI check as required signal, not just a formality, given I couldn't cross-check it myself.

## Out of scope (per issue)

- No bump above chart `6.55.0`.
- No changes to Alloy, Loki NetworkPolicies, or the SeaweedFS bucket layout.

## Post-merge (AC9, for the coordinator)

After Flux reconciles, please verify:
- `loki` HelmRelease is `Ready=True`
- `loki-0` pod `Running`, init container (`bootstrap-s3-bucket`) completed, no new restarts
- Retention config (`compactor.retention_enabled: true`, `delete_request_store: s3`) still present in the rendered ConfigMap