### PR TITLE
fix(renovate): replace invalid matchCurrentRegistryUrls with allowedVersions cap

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -166,21 +166,21 @@
       internalChecksFilter: 'strict',
     },
     {
-      // Never propose loki chart bumps from the old grafana-charts source.
-      // The `loki` chart in grafana/helm-charts went GEL-only from v7.0.0 --
-      // maintained for Grafana Enterprise Logs users only -- with OSS
-      // installs redirected to grafana-community/helm-charts, forked at
-      // exactly chart v6.55.0 (see #3400, grafana/loki#20705). This cluster's
-      // `loki` HelmRelease now sources from the `grafana-community-charts`
-      // HelmRepository instead, so future bumps should come from that
-      // registry. This rule is a defence-in-depth guard: if the HelmRelease
-      // is ever accidentally repointed back at grafana.github.io/helm-charts,
-      // Renovate must not silently walk it onto the GEL-only 7.x line.
-      description: 'Never propose loki chart v7+ from the GEL-only grafana-charts source; track the OSS community fork instead (#3400)',
+      // Never propose loki chart v7+ bumps. The `loki` chart in
+      // grafana/helm-charts went GEL-only from v7.0.0 -- maintained for
+      // Grafana Enterprise Logs users only -- with OSS installs redirected to
+      // grafana-community/helm-charts, forked at exactly chart v6.55.0 (see
+      // #3400, grafana/loki#20705). This cluster's `loki` HelmRelease now
+      // sources from the `grafana-community-charts` HelmRepository, which is
+      // currently pre-7.0.0, so this cap still allows community-fork 6.x
+      // updates through while guarding against Renovate ever walking this
+      // OSS install onto the GEL-only 7.x line (whether from the community
+      // fork eventually mirroring it, or the HelmRelease being accidentally
+      // repointed back at grafana.github.io/helm-charts).
+      description: 'Never propose loki chart v7+ (GEL-only line); cap to the OSS community fork releases instead (#3400)',
       matchDatasources: ['helm'],
       matchPackageNames: ['loki'],
-      matchCurrentRegistryUrls: ['https://grafana.github.io/helm-charts'],
-      enabled: false,
+      allowedVersions: '<7.0.0',
     },
     {
       // Group both Flux dependencies into a single PR. The Flux version is


### PR DESCRIPTION
## Problem

Renovate has stopped proposing all PRs on this repo because `.github/renovate.json5` fails config validation (#3404):

    Invalid configuration option: packageRules[6].matchCurrentRegistryUrls

## Root cause

PR #3403 (#3400, the Loki chart-source migration) added a packageRule using `matchCurrentRegistryUrls` to stop this OSS SingleBinary Loki install from being proposed onto the Grafana Enterprise Logs (GEL) 7.x line. `matchCurrentRegistryUrls` is not a valid Renovate packageRule matcher (it was invented), which broke config validation for the whole file.

## Fix

Replaced the invalid registry-URL matcher with a version cap:

```js
{
  description: 'Never propose loki chart v7+ (GEL-only line); cap to the OSS community fork releases instead (#3400)',
  matchDatasources: ['helm'],
  matchPackageNames: ['loki'],
  allowedVersions: '<7.0.0',
},
```

This achieves the original intent directly and more robustly:
- `loki` went GEL-only from chart v7.0.0 (grafana/loki#20705); OSS installs are redirected to the `grafana-community/helm-charts` fork, currently held at v6.55.0.
- The cluster's `loki` HelmRelease already sources from `grafana-community-charts` (repointed in #3403), which is pre-7.0.0 — so `allowedVersions: '<7.0.0'` still allows community-fork 6.x updates through, while guarding against Renovate ever proposing the GEL-only 7.x line, regardless of which registry the chart happens to come from.
- The original source-based guard was defence-in-depth anyway since the sourceRef was already migrated; the version cap achieves the actual goal (never jump to GEL 7.x) more directly.

No other packageRule was touched.

## Validation

`renovate-config-validator` passes with zero errors:

```
$ renovate-config-validator .github/renovate.json5
 INFO: Validating .github/renovate.json5 as global config
 INFO: Config validated successfully against 1 file(s)
```

Closes #3404
Refs #3400