### PR TITLE
feat(headscale): add MPD grant to ACL policy for ben@ devices

### DIFF
--- a/kubernetes/cluster0/apps/networking/headscale/app/config/policy.hujson
+++ b/kubernetes/cluster0/apps/networking/headscale/app/config/policy.hujson
@@ -63,6 +63,14 @@
       "dst": ["tag:ts-metrics-ingest"],
       "ip":  ["tcp:9090"],
     },
+    // MPD (Music Player Daemon) control/streaming port 6600. Scoped to ben@
+    // devices only; enables device-to-device music access (e.g. navi <-> bens-s25).
+    // TCP only, no UDP. Does not widen any other access.
+    {
+      "src": ["ben@"],
+      "dst": ["ben@"],
+      "ip":  ["tcp:6600"],
+    },
   ],
 
   // Static assertions evaluated on every policy load/boot. If any accept


### PR DESCRIPTION
## Summary

Add a new ACL grant to the headscale policy allowing Music Player Daemon (MPD) access between personal devices registered under the ben@ user.

## Changes

- Added one new grant: `src: ben@`, `dst: ben@`, `ip: tcp:6600`
- Added a clear comment explaining the grant purpose and scope
- No other grants, tagOwners, or tests were modified

## Technical Details

**Reload mechanism:** The policy file is mounted via ConfigMap with Reloader annotation (`reloader.stakater.com/auto: "true"`), which automatically restarts the headscale pod when the ConfigMap changes. This existing wiring handles policy updates without manual intervention.

**Test assertions:** No test assertion was added to the `tests` block. While the existing test suite in the file validates connectivity with tag-based sources and destinations, a user-valued destination like `ben@:6600` may not be a documented feature of the headscale policy v2 test engine. The file's own comments (issue #3398) warn that test assertions can fail silently if the resolved IP address set is empty or unexpected. Rather than risk a boot-time failure that silently keeps the old policy live, only the grant itself was added. The Flux deployment will validate the HuJSON syntax via the `flux-local` workflow, and the policy syntax will be validated by headscale itself when it starts the pod.

## Acceptance Criteria

- ✅ One new grant added: `src: ben@`, `dst: ben@`, `ip: tcp:6600`
- ✅ No existing grants, tagOwners, or tests modified
- ✅ New grant includes a comment in house style
- ✅ File is valid HuJSON (verified manually)
- ✅ ConfigMap reload wiring is already in place (Reloader annotation present)

This is an ad-hoc operator request from Ben to enable MPD access across personal tailnet devices.