### PR TITLE
fix(grafana): disable Flux envsubst for prism-fleet dashboard ConfigMap

### DIFF
--- a/kubernetes/cluster0/apps/monitoring/grafana/app/dashboard-prism-fleet.yaml
+++ b/kubernetes/cluster0/apps/monitoring/grafana/app/dashboard-prism-fleet.yaml
@@ -20,6 +20,12 @@ metadata:
     grafana_dashboard: "1"
   annotations:
     grafana_folder: Fleet
+    # Grafana's $var / ${var:regex} template syntax collides with Flux's
+    # postBuild envsubst (strict mode): Flux sees $hostname etc. as its own
+    # substitution targets and fails the build when no such variable exists.
+    # Disable Flux substitution for this resource so the literal Grafana
+    # variables reach the sidecar unmodified.
+    kustomize.toolkit.fluxcd.io/substitute: disabled
 data:
   prism-fleet.json: |
     {


### PR DESCRIPTION
## Problem

`flux get kustomizations -A` reports `cluster-apps-grafana` stuck as
non-ready:

```
post build failed for 'ConfigMap.v1.[noGrp]/grafana-dashboard-prism-fleet':
envsubst error: variable substitution failed: variable not set (strict mode): "hostname"
```

This is a regression from #3464, which added
`kubernetes/cluster0/apps/monitoring/grafana/app/dashboard-prism-fleet.yaml`.
Grafana is still running (not an outage), but the grafana app is frozen —
no further change to that directory reconciles until this is fixed.

## Root cause

`kubernetes/cluster0/flux/apps.yaml` injects `postBuild.substituteFrom`
into every app Kustomization, so every rendered resource passes through
Flux envsubst in strict mode. The dashboard JSON embeds Grafana template
variables (`$hostname`, `$repo`, `$agent_role`, `$profile`,
`${var:regex}`). Flux envsubst treats `$hostname` as its own substitution
target, finds no such cluster variable, and fails the build.

A local `kustomize build` does not catch this — envsubst is a Flux
postBuild step that runs after `kustomize build`.

## Fix

Annotate the ConfigMap with the documented Flux escape hatch:

```yaml
kustomize.toolkit.fluxcd.io/substitute: disabled
```

The dashboard needs no cluster variables of its own, so disabling
substitution for this one resource costs nothing. Left a comment
explaining why, since this is the first use of the annotation in-repo.

## Out of scope

`cluster-apps-alloy` and `cluster-apps-loki` also show non-ready in the
same `flux get kustomizations -A` listing. That is a separate
pre-existing dependency chain (alloy waits on loki, loki reconciling)
and is not touched by this PR.

No panel query, the datasource uid pin, or any other file from #3464 is
modified here — only the annotation is added.

Closes nothing (no tracking issue); fixes a regression from #3464.