### PR TITLE
feat(networking): tag:ts-web policy + ts wildcard cert (1/2, #3466)

### DIFF
--- a/kubernetes/cluster0/apps/networking/headscale/app/config/policy.hujson
+++ b/kubernetes/cluster0/apps/networking/headscale/app/config/policy.hujson
@@ -11,6 +11,11 @@
     // fits; homeops@ owns the machine identity so any cluster admin can
     // redeploy without needing to re-own the tag.
     "tag:ts-metrics-ingest": ["homeops@"],
+    // Shared tailnet-only web-UI proxy (pilot #3466). Same rationale as the
+    // per-service proxies above: cluster-managed workload, no human owner
+    // fits, so homeops@ owns the machine identity. One ts-web node fronts
+    // every *.ts.<domain> web UI (prometheus first; Hubble/Longhorn later).
+    "tag:ts-web":            ["homeops@"],
   },
 
   // Least-privilege access: tag:nixos peers may reach ONLY
@@ -63,6 +68,16 @@
       "dst": ["tag:ts-metrics-ingest"],
       "ip":  ["tcp:9090"],
     },
+    // Tailnet-only web UI (pilot #3466). ben@ devices reach the shared
+    // ts-web proxy on tcp:443 ONLY; the proxy TCPForwards to the in-cluster
+    // traefik gateway, which terminates TLS and routes by hostname. No other
+    // ports. TLS terminates on traefik, not on tailscale, so the base-domain
+    // cert limitation does not apply.
+    {
+      "src": ["ben@"],
+      "dst": ["tag:ts-web"],
+      "ip":  ["tcp:443"],
+    },
     // MPD (Music Player Daemon) control/streaming port 6600. Scoped to ben@
     // devices only; enables device-to-device music access (e.g. navi <-> bens-s25).
     // TCP only, no UDP. Does not widen any other access.
@@ -109,6 +124,18 @@
         "tag:ts-metrics-ingest:9090", // ts-metrics-ingest is not granted to tag:ts-prometheus
       ],
     },
+    // PHASE 2 (#3466) -- add ts-web test assertions ONLY after the
+    // tailscale-proxy-ts-web node registers:
+    //   accept: src ben@            -> "tag:ts-web:443"  (the granted path)
+    //   deny:   src ben@            -> "tag:ts-web:9090" (backend port, not granted)
+    //   deny:   src tag:ts-prometheus -> "tag:ts-web:443" (unauthorised source)
+    // They are deferred because a test entry whose tag resolves to zero
+    // registered nodes both (a) can FAIL policy load for an accept -- the
+    // #3370 / #3398 trap that keeps the previous policy and would deadlock
+    // preauth-key creation -- and (b) emits the misleading "resolved to no IP
+    // addresses" warning that #3398 flags as actively harmful. Phase 1 ships
+    // the tagOwner + grant so the node can register; the assertions land once
+    // it has.
   ],
 }
 

--- a/kubernetes/cluster0/apps/networking/traefik/certificates/certificates.yaml
+++ b/kubernetes/cluster0/apps/networking/traefik/certificates/certificates.yaml
@@ -13,3 +13,30 @@ spec:
   dnsNames:
     - "${SECRET_PUBLIC_DOMAIN}"
     - "*.${SECRET_PUBLIC_DOMAIN}"
+---
+# Second wildcard, one label deeper, for the tailnet-only web UIs served over
+# the ts-web tailscale proxy (pilot: prometheus.ts.${SECRET_PUBLIC_DOMAIN},
+# #3466). A wildcard covers EXACTLY one label, so the existing
+# *.${SECRET_PUBLIC_DOMAIN} cert does NOT match a two-label name like
+# prometheus.ts.${SECRET_PUBLIC_DOMAIN}; this dedicated cert is required.
+# Issued by the same Cloudflare DNS-01 ClusterIssuer; the _acme-challenge
+# TXT lands in the ${SECRET_PUBLIC_DOMAIN} zone, which the issuer solves.
+# This PR only lands the Certificate; the follow-up wires it as a SECOND
+# certificateRef on the traefik websecure listener (#3466). Landing the
+# Certificate first means the secret is Ready before the listener references
+# it, so the websecure listener that terminates TLS for the live public apps
+# never goes ResolvedRefs=False. It does not replace the base wildcard.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: "ts-${SECRET_PUBLIC_DOMAIN/./-}"
+  namespace: networking
+spec:
+  secretName: "ts-${SECRET_PUBLIC_DOMAIN/./-}-tls"
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  commonName: "ts.${SECRET_PUBLIC_DOMAIN}"
+  dnsNames:
+    - "ts.${SECRET_PUBLIC_DOMAIN}"
+    - "*.ts.${SECRET_PUBLIC_DOMAIN}"


### PR DESCRIPTION
First of a sequence for the tailnet-only web-UI pilot (**#3466**). Deliberately **traffic-neutral and safe to merge on its own** — it changes nothing about how any live app resolves or serves. Its purpose is to make `tag:ts-web` a known tagOwner so the operator can create the ts-web preauth key, and to land the `*.ts` cert ahead of the listener that will reference it.

## What this PR does

- **headscale `policy.hujson`** — adds a `tag:ts-web` tagOwner (`homeops@`) and a `ben@ -> tag:ts-web tcp:443` grant. Both are inert until a node carries the tag. `headscale preauthkeys create --tags tag:ts-web` is rejected unless the tag is a known tagOwner, so this must land before key creation.
- **cert-manager `Certificate`** for `*.ts.${SECRET_PUBLIC_DOMAIN}` via the existing Cloudflare DNS-01 ClusterIssuer. The base `*.${SECRET_PUBLIC_DOMAIN}` wildcard covers exactly one label and cannot match a two-label name like `prometheus.ts.${SECRET_PUBLIC_DOMAIN}`.

## What this PR deliberately does NOT do

- **No `tests` assertions for `tag:ts-web`.** No node carries the tag yet, so an `accept` assertion would resolve to no IP addresses and fail policy load — the #3370 / #3398 trap the file records twice. They land once the proxy registers (phase 3).
- **No traefik gateway `certificateRef`.** The Certificate is landed first so its secret is `Ready` before the follow-up references it; wiring the ref against a not-yet-`Ready` secret risks the `websecure` listener (TLS for ~20 live apps) going `ResolvedRefs=False`.

## Sequence

- **PR 2** (after the operator creates + SOPS-encrypts the preauth key): ts-web proxy (deployment, serve ConfigMap, RBAC, NetworkPolicies), the HTTPRoute with `external-dns.alpha.kubernetes.io/controller: none`, the gateway `certificateRef`, and the SOPS secret.
- **Phase 3** (after the proxy node registers and has a tailnet IP): the `extra_records` A record and the `tag:ts-web` policy tests.

Refs #3466