### PR TITLE
Add sops-encrypted TS_AUTHKEY secret for headscale tailscale-proxy

### DIFF
--- a/kubernetes/cluster0/apps/networking/headscale/app/tailscale-proxy-ts-web-secret.sops.yaml
+++ b/kubernetes/cluster0/apps/networking/headscale/app/tailscale-proxy-ts-web-secret.sops.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: tailscale-proxy-ts-web-auth
+  namespace: networking
+type: Opaque
+stringData:
+  TS_AUTHKEY: ENC[AES256_GCM,data:ca6Ms53huKMjvPY9LaBRGUctTo4lWq6SJTwxZzfinDmMFHBeJF3q2WpIX74XccmuFYmbbqa7vGv4Qz9z38ph5ZoAX7sse2X+NKB/Le1SXSyzyOt/KdY0rg==,iv:7+jsCdeavbLNKddOEz/gl4FKHxHx2/GjsDJD91TYgHY=,tag:XJ68juMdiD9XR0LM8LZtCg==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBJc2E3aVc0Z09nbUZneG1Q
+        L2RwQU1ZQjdOcVV4VUJOZUp0aEVwdDdwTVg4CjFzT2l1VGV5Q0tFWlNTcEpEOG8v
+        VUR0YkNDUURKaXYxUUZ3cjYxaTJjT0kKLS0tIGdMcmR5dnJSRmJhSUZtcDM5VTVs
+        RDJLbnJPNmw2amlWb3VGUS9JR25sU3MK0He3VZ8cWrfiPvBB8iZb913Wpu0DcckO
+        fwLj8DaOR/Yjq1U/fHAxegGZRkZBTOMcqiKUbRZu8xcP7DEZ7jVNWQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1582vh25trj6w7klwt38d44n5nr8njr8rrxxx5kcfu3y2ezx9ss3s6j24ex
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBTDF0Y0gvRXUvcUJxeXZW
+        OG5OUGxmUkdlL2dDZDdUL0FNaUJUMUoyY0JRCjFodlZjakc5czhIQjI4c1l5aW16
+        TVUxUkIxL1lRMkYxM210YkJYWU50TkUKLS0tIDFScHlaN0FIMjlHR1RoSVpvT3hw
+        ZktCclZYd0VwcWIxQVNhQmw1RHNiNXcKp2gFtr1PimIcyhH61n3bNUgwFbja3zVF
+        jHvP/7+/Pu7ErOrvmdVpnF3MHDKn8yLUtqvetmJUoEQQ9z+wI+xsQQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age185kanaq3uw2gjx5enu2v69nk9ner3lamdevrfgx3wqucsl9ewa2qlt2gf7
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-14T08:42:32Z"
+  mac: ENC[AES256_GCM,data:m9ibXxOXIBKT4aer2paNyH0NrgZXlhUVd2SesOXzc7vgkxNADYWmKlHEUG+iLY8VmZzpSdiaUY1aGawSjdWsl4JU5sqwLPb0uEgbTajTPMDqCOHUanVmyNWo7pKYlxYLMoCqaHvalSWs8mHlLb26tUauokHSJ9QNLcVIR9LlLpk=,iv:dejt1W+MwCayX1Nvd0fWPqrmSQtbmnAGtSxTKmEIAj8=,tag:QBXdQmR31FPyLSFXWkyMGQ==,type:str]
+  version: 3.13.3


### PR DESCRIPTION
The headscale tailscale-proxy sidecar needs a Tailscale auth key to join the tailnet; this adds the sops-encrypted Secret so it's available for the HelmRelease to reference.