### PR TITLE
feat(networking): ts-web proxy + prometheus.ts HTTPRoute (2/2, #3466)

### DIFF
--- a/kubernetes/cluster0/apps/monitoring/kube-prometheus-stack/app/httproute.yaml
+++ b/kubernetes/cluster0/apps/monitoring/kube-prometheus-stack/app/httproute.yaml
@@ -1,0 +1,51 @@
+---
+# =============================================================================
+# prometheus.ts.${SECRET_PUBLIC_DOMAIN} — tailnet-only web UI (pilot #3466)
+#
+# Routes the tailnet hostname prometheus.ts.${SECRET_PUBLIC_DOMAIN} to the
+# in-cluster prometheus Service on the traefik `websecure` listener. Reached
+# only via the ts-web tailscale proxy (networking) -> traefik :443 -> here.
+# TLS terminates on traefik with the *.ts.${SECRET_PUBLIC_DOMAIN} cert.
+#
+# Lives in `monitoring` (same namespace as the backend Service) so the
+# backendRef needs no ReferenceGrant — same pattern as the hubble-ui and
+# longhorn HTTPRoutes, which live beside their own Services.
+#
+# NO forwardauth-authelia middleware: access control is the tailnet ACL
+# (ben@ -> tag:ts-web tcp:443 in headscale policy.hujson). Prometheus is a
+# read-mostly, non-destructive UI; this is the whole point of the pilot.
+#
+# external-dns.alpha.kubernetes.io/controller: none is LOAD-BEARING. Without
+# it, external-dns (source=gateway-httproute, policy=sync) would publish a
+# PUBLIC A record + k8s. TXT for this hostname pointing at the Cloudflare
+# edge, defeating the tailnet-only property. `none` is the only per-object
+# opt-out that external-dns v0.21.0 actually reads — the `.../exclude`
+# annotation does NOT exist in that version and is silently ignored (#3466).
+# =============================================================================
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: prometheus-ts-web
+  namespace: monitoring
+  annotations:
+    external-dns.alpha.kubernetes.io/controller: none
+spec:
+  hostnames:
+    - prometheus.ts.${SECRET_PUBLIC_DOMAIN}
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: traefik-gateway
+      namespace: networking
+      sectionName: websecure
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: prometheus-kube-prometheus-prometheus
+          namespace: monitoring
+          port: 9090
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/kubernetes/cluster0/apps/monitoring/kube-prometheus-stack/app/kustomization.yaml
+++ b/kubernetes/cluster0/apps/monitoring/kube-prometheus-stack/app/kustomization.yaml
@@ -3,6 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helm-release.yaml
+  - ./httproute.yaml
   - ./network-policy.yaml
   - ./cilium-network-policy.yaml
 labels:

--- a/kubernetes/cluster0/apps/monitoring/kube-prometheus-stack/app/network-policy.yaml
+++ b/kubernetes/cluster0/apps/monitoring/kube-prometheus-stack/app/network-policy.yaml
@@ -146,6 +146,36 @@ spec:
         - port: 8080
           protocol: TCP
 ---
+# Allow ingress from Traefik (networking namespace) on :9090 for the
+# tailnet-only web UI (prometheus.ts.${SECRET_PUBLIC_DOMAIN}, pilot #3466).
+# Reciprocal to traefik's traefik-allow-backend-egress (monitoring carries
+# netpol.home-ops/traefik-backend=true): that rule is the traefik egress
+# half; this is the prometheus ingress half. Without it the tailnet UI path
+# ts-web -> traefik -> prometheus:9090 is denied silently at the prometheus
+# pod. Distinct from the ts-prometheus :9090 proxy path, which is a direct
+# ingress from the tailscale-proxy-prometheus pod (see headscale app).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: prometheus-allow-traefik-ingress
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: networking
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: traefik
+      ports:
+        - port: 9090
+          protocol: TCP
+---
 # Allow egress to intra-ns Alertmanager on :9093 (alert push)
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/kubernetes/cluster0/apps/networking/headscale/app/kustomization.yaml
+++ b/kubernetes/cluster0/apps/networking/headscale/app/kustomization.yaml
@@ -26,6 +26,17 @@ resources:
   - ./tailscale-proxy-metrics-ingest-secret.sops.yaml
   - ./tailscale-proxy-metrics-ingest-deployment.yaml
   - ./tailscale-proxy-metrics-ingest-network-policy.yaml
+  # Shared tailnet-only web-UI proxy (pilot #3466). One ts-web node fronts
+  # every *.ts.<domain> web UI; TCPForwards :443 to the traefik gateway,
+  # which terminates TLS and routes by hostname. First consumer:
+  # prometheus.ts.<domain> (HTTPRoute in monitoring/kube-prometheus-stack).
+  - ./tailscale-proxy-ts-web-rbac.yaml
+  # Preauth-key Secret: created + SOPS-encrypted by the operator and landed on
+  # main via #3468 (tagged tag:ts-web). Referenced here so the ts-web proxy
+  # Deployment can mount TS_AUTHKEY.
+  - ./tailscale-proxy-ts-web-secret.sops.yaml
+  - ./tailscale-proxy-ts-web-deployment.yaml
+  - ./tailscale-proxy-ts-web-network-policy.yaml
 labels:
   - pairs:
       app.kubernetes.io/name: headscale

--- a/kubernetes/cluster0/apps/networking/headscale/app/tailscale-proxy-ts-web-deployment.yaml
+++ b/kubernetes/cluster0/apps/networking/headscale/app/tailscale-proxy-ts-web-deployment.yaml
@@ -1,0 +1,147 @@
+---
+# =============================================================================
+# tailscale-proxy-ts-web
+#
+# Shared tailnet entrypoint for tailnet-only web UIs served with a public-CA
+# cert (pilot: prometheus.ts.${SECRET_PUBLIC_DOMAIN}; design/issue #3466).
+#
+# Unlike tailscale-proxy-prometheus / -loki / -metrics-ingest, this proxy is
+# NOT bound to one backend Service. It is a dumb L4 pipe: it TCPForwards
+# inbound tailnet TCP :443 straight to the in-cluster traefik gateway on
+# :443. Traefik terminates TLS on the *.ts.${SECRET_PUBLIC_DOMAIN} cert and
+# routes by SNI/hostname to the right backend via an HTTPRoute. One proxy
+# fronts every *.ts.${SECRET_PUBLIC_DOMAIN} name; the per-service piece is an
+# HTTPRoute + a target-side ingress NetworkPolicy, not a new proxy.
+#
+# Why tailscale never terminates TLS here:
+#   The proxy forwards the raw TCP stream, SNI intact. TLS terminates on
+#   traefik, on a real public-CA cert. The base-domain (.internal) cert
+#   limitation of tailscale `serve` HTTPS does not apply because we never
+#   ask tailscale to serve HTTPS — we TCPForward L4.
+#
+# Everything below mirrors tailscale-proxy-prometheus. Read that file's
+# header for the origin-socket rationale (why userspace mode is load-bearing
+# under Cilium socket-LB) and the tag-from-preauth-key rule; both apply here
+# unchanged.
+#
+# Tag from preauth key, NOT --advertise-tags:
+#   headscale 0.28+ hard-rejects registration when a PreAuthKey-authenticated
+#   node ALSO passes --advertise-tags. The preauth key committed in
+#   tailscale-proxy-ts-web-secret.sops.yaml MUST be created with
+#   `headscale preauthkeys create --tags tag:ts-web --reusable`; do NOT set
+#   --advertise-tags in TS_EXTRA_ARGS.
+# =============================================================================
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tailscale-proxy-ts-web-serve
+  namespace: networking
+data:
+  # ipn.ServeConfig — TCP handler that TCPForwards inbound tailnet TCP on
+  # port 443 to the traefik gateway Service by DNS name. TCPForward does a
+  # standard net.Dial (fresh outbound socket) per accepted connection; it
+  # does NOT proxy packets and does NOT terminate TLS. Target is the Service
+  # DNS name, not a pinned ClusterIP: no /32 pin drift when the Service is
+  # reconstituted.
+  serve.json: |-
+    {
+      "TCP": {
+        "443": {
+          "TCPForward": "traefik.networking.svc.cluster.local:443"
+        }
+      }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tailscale-proxy-ts-web
+  namespace: networking
+spec:
+  replicas: 1
+  strategy:
+    # Recreate rather than RollingUpdate: two tailnet nodes with the same
+    # hostname would collide on registration. A brief gap on redeploy is
+    # acceptable for the web-UI use case.
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tailscale-proxy-ts-web
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tailscale-proxy-ts-web
+    spec:
+      serviceAccountName: tailscale-proxy-ts-web
+      containers:
+        - name: tailscale
+          image: ghcr.io/tailscale/tailscale:v1.102.2@sha256:321ce041508c19079b57a28b6666c8d81ab0b08accc0a2585b3ab663d557ac24
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            # Userspace mode needs no capabilities. Drop everything.
+            capabilities:
+              drop: [ALL]
+            allowPrivilegeEscalation: false
+          env:
+            # Persist tailnet node state (machine key, node key, ...) into
+            # this Secret. The RBAC in tailscale-proxy-ts-web-rbac.yaml pins
+            # get/update/patch to exactly this name. Surviving a pod delete +
+            # reschedule with the tag intact depends on this Secret being
+            # reused across pod lifecycles.
+            - name: TS_KUBE_SECRET
+              value: tailscale-proxy-ts-web-state
+            # Userspace networking — no tun, no packet forwarding. This is
+            # what makes the origin-socket path (see file header) hold.
+            - name: TS_USERSPACE
+              value: "true"
+            - name: TS_AUTHKEY
+              valueFrom:
+                secretKeyRef:
+                  name: tailscale-proxy-ts-web-auth
+                  key: TS_AUTHKEY
+            - name: TS_EXTRA_ARGS
+              # No --advertise-tags: the tag is on the preauth key (see
+              # file header). Hostname becomes the MagicDNS label:
+              # ts-web.tailnet.internal.
+              value: >-
+                --login-server=https://hs.${SECRET_PUBLIC_DOMAIN}
+                --hostname=ts-web
+            # We do not want tailscaled rewriting the pod's resolv.conf;
+            # the pod already gets cluster DNS via ClusterFirst.
+            - name: TS_ACCEPT_DNS
+              value: "false"
+            # Serve config: mounted from the ConfigMap above. containerboot
+            # applies this after tailscale up.
+            - name: TS_SERVE_CONFIG
+              value: /etc/tsserve/serve.json
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+          volumeMounts:
+            - name: serve-config
+              mountPath: /etc/tsserve
+              readOnly: true
+            # tailscaled needs a writable state area even with
+            # TS_KUBE_SECRET (localapi socket, scratch). Backed by memory
+            # rather than the container FS so it survives readOnlyRootFs
+            # tightening if we ever add it.
+            - name: tailscale-run
+              mountPath: /var/run/tailscale
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 128Mi
+      volumes:
+        - name: serve-config
+          configMap:
+            name: tailscale-proxy-ts-web-serve
+        - name: tailscale-run
+          emptyDir:
+            medium: Memory

--- a/kubernetes/cluster0/apps/networking/headscale/app/tailscale-proxy-ts-web-network-policy.yaml
+++ b/kubernetes/cluster0/apps/networking/headscale/app/tailscale-proxy-ts-web-network-policy.yaml
@@ -1,0 +1,190 @@
+---
+# =============================================================================
+# tailscale-proxy-ts-web NetworkPolicies
+#
+# The proxy runs with a real pod identity (userspace mode, no hostNetwork),
+# so these NetworkPolicy resources ARE enforced at runtime. Mirrors
+# tailscale-proxy-prometheus-network-policy.yaml; the only difference is the
+# forward target — traefik on :443 rather than prometheus on :9090.
+#
+# Egress needed:
+#   - DNS to CoreDNS (kube-system): resolve hs.${DOMAIN} + traefik Service
+#   - HTTPS/DERP to internet: control-plane + DERP relay fallback
+#   - UDP high-ports to internet: direct WireGuard + STUN
+#   - TCP :443 to networking/traefik pods: the actual forward target
+#   - kube-apiserver: read/write the node-state Secret (TS_KUBE_SECRET)
+#
+# No ingress needed on the proxy pod: tailnet peers reach it via the
+# WireGuard userspace stack (inside the tailscale process), not via any
+# pod-network ingress path.
+#
+# The reciprocal traefik-side ingress rule (AGENTS.md reciprocal-pair
+# guidance) is the last resource in this file: traefik ingress from the
+# ts-web pod on :443.
+# =============================================================================
+---
+# Default deny-all. All egress must be explicitly permitted below.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: tailscale-proxy-ts-web-default-deny
+  namespace: networking
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: tailscale-proxy-ts-web
+  policyTypes: [Ingress, Egress]
+---
+# DNS resolution to cluster CoreDNS. Needed for hs.${SECRET_PUBLIC_DOMAIN}
+# (control plane) and the traefik Service's DNS name.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: tailscale-proxy-ts-web-allow-dns
+  namespace: networking
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: tailscale-proxy-ts-web
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+---
+# Internet egress on :443/TCP — the headscale control endpoint at
+# hs.${SECRET_PUBLIC_DOMAIN} and Tailscale's public DERP relay pool
+# (DERP falls back to :443/TCP when direct WireGuard fails). Private
+# ranges excluded so the proxy can't accidentally reach the internal
+# network on :443. The in-cluster traefik target is a private address and
+# is handled by the dedicated allow-target-egress rule below.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: tailscale-proxy-ts-web-allow-internet-egress
+  namespace: networking
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: tailscale-proxy-ts-web
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+---
+# Direct WireGuard + STUN (UDP). tailscaled binds a random UDP port and
+# sends/receives WireGuard datagrams peer-to-peer when direct path is
+# available. STUN on UDP 3478 for NAT discovery. Full high-port UDP range
+# to any public IP; private ranges excluded.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: tailscale-proxy-ts-web-allow-wireguard-egress
+  namespace: networking
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: tailscale-proxy-ts-web
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - protocol: UDP
+      to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+---
+# The actual forward target: TCP :443 to traefik pods in the networking
+# namespace. This is the outbound net.Dial the TCPForward handler makes for
+# each accepted tailnet connection. Under Cilium socket-LB the connect() to
+# the traefik ClusterIP:443 is DNAT'd to a traefik PodIP:443 before egress
+# policy evaluation, so this podSelector rule matches the translated target.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: tailscale-proxy-ts-web-allow-target-egress
+  namespace: networking
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: tailscale-proxy-ts-web
+  policyTypes: [Egress]
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: networking
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: traefik
+---
+# tailscaled runs in Kubernetes state-store mode (TS_KUBE_SECRET) and must
+# reach the kube-apiserver ClusterIP (10.43.0.1:443) to read/write its
+# node-state Secret. Expressed via the Cilium `kube-apiserver` entity rather
+# than a hardcoded ClusterIP. Port is intentionally unrestricted: with
+# kubeProxyReplacement=true, Cilium socket-LB translates the ClusterIP
+# (10.43.0.1:443) to the host apiserver backend port (6443) before egress
+# policy evaluation, so a :443-only toPorts rule would deny the translated
+# traffic. See #2829/#2947 and the AGENTS.md kube-apiserver guidance.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: tailscale-proxy-ts-web-allow-kube-apiserver-egress
+  namespace: networking
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: tailscale-proxy-ts-web
+  egress:
+    - toEntities:
+        - kube-apiserver
+---
+# Reciprocal traefik-side ingress (AGENTS.md reciprocal-pair guidance):
+# allow the ts-web proxy pod to reach traefik on :443. Traefik's broad
+# traefik-allow-intracluster-ingress already admits any in-namespace pod on
+# :443, but this explicit narrow rule documents the ts-web -> traefik half of
+# the pair so the pilot path is legible in one place.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: traefik-allow-ts-web-ingress
+  namespace: networking
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: traefik
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: networking
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: tailscale-proxy-ts-web
+      ports:
+        - port: 443
+          protocol: TCP

--- a/kubernetes/cluster0/apps/networking/headscale/app/tailscale-proxy-ts-web-rbac.yaml
+++ b/kubernetes/cluster0/apps/networking/headscale/app/tailscale-proxy-ts-web-rbac.yaml
@@ -1,0 +1,46 @@
+---
+# =============================================================================
+# tailscale-proxy-ts-web RBAC
+#
+# Per-proxy ServiceAccount so this tailnet node has its own kube identity and
+# its own state Secret. Mirrors tailscale-proxy-prometheus-rbac.yaml.
+#
+# The state Secret name (tailscale-proxy-ts-web-state) is pinned in the Role's
+# resourceNames, matching the TS_KUBE_SECRET env in the Deployment. The
+# `create` verb is granted on the whole `secrets` resource because Kubernetes
+# RBAC does not allow resourceNames on `create` (the object does not exist yet
+# at create time).
+# =============================================================================
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tailscale-proxy-ts-web
+  namespace: networking
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: tailscale-proxy-ts-web
+  namespace: networking
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["tailscale-proxy-ts-web-state"]
+    verbs: ["get", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tailscale-proxy-ts-web
+  namespace: networking
+subjects:
+  - kind: ServiceAccount
+    name: tailscale-proxy-ts-web
+    namespace: networking
+roleRef:
+  kind: Role
+  name: tailscale-proxy-ts-web
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes/cluster0/apps/networking/traefik/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/networking/traefik/app/helm-release.yaml
@@ -83,6 +83,11 @@ spec:
           certificateRefs:
             - kind: Secret
               name: "${SECRET_PUBLIC_DOMAIN/./-}-tls"
+            # Second cert for the tailnet-only web UIs (*.ts.<domain>, #3466).
+            # Traefik selects the listener cert by SNI, so both the base
+            # wildcard and this ts. wildcard are served side by side.
+            - kind: Secret
+              name: "ts-${SECRET_PUBLIC_DOMAIN/./-}-tls"
     additionalArguments:
       - "--api.insecure=true"
       - "--providers.kubernetesingress.ingressclass=traefik"


### PR DESCRIPTION
Second of the tailnet-only web-UI pilot (**#3466**). Builds on **#3467** (tagOwner + grant + `*.ts` cert) and **#3468** (SOPS preauth-key secret, already on main). This PR wires the shared ts-web proxy, the traefik cert reference, and the first consumer HTTPRoute.

## ⚠️ MERGE GATE — do not merge until the `ts-${SECRET_PUBLIC_DOMAIN}` Certificate is Ready

The traefik `websecure` listener in this PR references `ts-tinfoilforest-nz-tls`. That listener terminates TLS for ~20 live public apps. If the referenced secret does not exist yet, the listener goes `ResolvedRefs=False`. **Merging is gated on the Certificate reaching `Ready`; opening the PR is not.**

Cert status at hand-off (known, expected, needs no action): the ACME TXT is published and visible at Cloudflare's authoritative NS and at 9.9.9.9, but 1.1.1.1 negatively cached the name before it existed (zone SOA negative TTL 1800s, clears ~09:07). cert-manager is pinned to 1.1.1.1 + 9.9.9.9 and waits for both. Do **not** touch the issuer/solver/Certificate to "fix" this — it resolves itself.

## What this PR does

- **traefik gateway** — adds a **second** `certificateRef` (`ts-<domain>-tls`) on the `websecure` listener, alongside the existing base wildcard. Traefik selects by SNI; the base wildcard is untouched.
- **`tailscale-proxy-ts-web`** — userspace-mode proxy in `networking` (Recreate, no `NET_ADMIN`, no tun). Serve config TCPForwards `:443 → traefik.networking.svc:443`. Tag comes from the `tag:ts-web` preauth key, never `--advertise-tags`. Deployment, serve ConfigMap, RBAC, and the #3468 secret are now referenced by the kustomization.
- **HTTPRoute** `prometheus.ts.<domain> → prometheus:9090`, no `forwardauth-authelia`, carrying `external-dns.alpha.kubernetes.io/controller: none` so external-dns publishes **no** public A/TXT record.
- **NetworkPolicies** — reciprocal `ts-web egress → traefik:443` + `traefik ingress ← ts-web:443`, plus `prometheus ingress ← traefik:9090` (the `ts-web → traefik → prometheus` path is otherwise denied at the prometheus pod).

## Deferred to phase 3 (needs the proxy node registered with a tailnet IP)

- the headscale split route (`ts.<domain>: []`) and the `extra_records` A record pinning `prometheus.ts.<domain>` to the proxy IP — both in `config.yaml`, landed together in one headscale restart;
- the `tag:ts-web` policy `tests` assertions — an `accept` against a zero-node tag fails policy load (the #3370/#3398 trap).

Refs #3466