### PR TITLE
feat(networking): headscale split route + prometheus.ts DNS (3/3, #3466)

### DIFF
--- a/kubernetes/cluster0/apps/networking/headscale/app/config/config.yaml
+++ b/kubernetes/cluster0/apps/networking/headscale/app/config/config.yaml
@@ -35,6 +35,43 @@ dns:
     global:
       - 1.1.1.1
       - 8.8.8.8
+    split:
+      # =====================================================================
+      # THE SINGLE MOST DANGEROUS LINE IN THE #3466 PILOT. DO NOT WIDEN IT.
+      #
+      # A headscale split route is a SUFFIX match. Scoped to
+      # ts.${SECRET_PUBLIC_DOMAIN} it captures ONLY *.ts.<domain>. If anyone
+      # ever changes the key to the bare ${SECRET_PUBLIC_DOMAIN}, the empty
+      # resolver list ([]) becomes a client-side LocalDomains suffix entry
+      # that returns NXDOMAIN for every name under it not pinned in
+      # extra_records -- i.e. it NXDOMAINs ~20 live public app hostnames
+      # (grafana, jellyfin, home-assistant, ...) for EVERY tailnet device on
+      # EVERY network. grafana.${SECRET_PUBLIC_DOMAIN} is not a subdomain of
+      # ts.${SECRET_PUBLIC_DOMAIN}, so with this scoping it never routes here
+      # and resolves exactly as it does today. Keep it scoped to ts.
+      # The empty list is deliberate: the only name that resolves under this
+      # suffix is the one pinned in extra_records below.
+      # =====================================================================
+      ts.${SECRET_PUBLIC_DOMAIN}: []
+  extra_records:
+    # Pins the pilot hostname to the tailscale-proxy-ts-web node's assigned
+    # tailnet IP (read from its tailscale-proxy-ts-web-state Secret:
+    # device_ips=100.64.0.3 / fd7a:115c:a1e0::3, device_fqdn=
+    # ts-web.tailnet.internal). This is served as a MagicDNS Hosts (exact)
+    # entry, which takes precedence over the LocalDomains NXDOMAIN above.
+    #
+    # A-only, no AAAA -- deliberate, reasoning recorded per the phase-3 brief:
+    # every tailnet node is always assigned a 100.64.0.0/10 IPv4 by tailscale
+    # regardless of the client's underlying network, so a single A record
+    # reaches every tailnet client. The node's ULA IPv6 (fd7a:115c:a1e0::3)
+    # adds a second address family to reason about (happy-eyeballs ordering,
+    # v6 reachability) for zero functional gain, since no tailnet client is
+    # v4-less. The design doc and issue #3466 specify an A record only. If a
+    # genuinely IPv6-only consumer ever appears, add the AAAA then -- not
+    # reflexively now.
+    - name: "prometheus.ts.${SECRET_PUBLIC_DOMAIN}"
+      type: "A"
+      value: "100.64.0.3"
 
 policy:
   mode: file

--- a/kubernetes/cluster0/apps/networking/headscale/app/config/policy.hujson
+++ b/kubernetes/cluster0/apps/networking/headscale/app/config/policy.hujson
@@ -111,10 +111,12 @@
       "accept": [
         "tag:ts-prometheus:9090",
         "tag:ts-loki:3100",
+        "tag:ts-web:443",       // tailnet-only web UI proxy (#3466)
       ],
       "deny": [
         "tag:ts-prometheus:22", // no SSH on the prometheus proxy
         "tag:ts-loki:22",       // no SSH on the loki proxy
+        "tag:ts-web:9090",      // ben@ reaches ts-web ONLY on tcp:443, not the backend port
       ],
     },
     {
@@ -122,20 +124,9 @@
       "deny": [
         "tag:ts-loki:3100",           // no cross-tag: loki port from prom node
         "tag:ts-metrics-ingest:9090", // ts-metrics-ingest is not granted to tag:ts-prometheus
+        "tag:ts-web:443",             // ts-web is granted to ben@ only, not to tag:ts-prometheus
       ],
     },
-    // PHASE 2 (#3466) -- add ts-web test assertions ONLY after the
-    // tailscale-proxy-ts-web node registers:
-    //   accept: src ben@            -> "tag:ts-web:443"  (the granted path)
-    //   deny:   src ben@            -> "tag:ts-web:9090" (backend port, not granted)
-    //   deny:   src tag:ts-prometheus -> "tag:ts-web:443" (unauthorised source)
-    // They are deferred because a test entry whose tag resolves to zero
-    // registered nodes both (a) can FAIL policy load for an accept -- the
-    // #3370 / #3398 trap that keeps the previous policy and would deadlock
-    // preauth-key creation -- and (b) emits the misleading "resolved to no IP
-    // addresses" warning that #3398 flags as actively harmful. Phase 1 ships
-    // the tagOwner + grant so the node can register; the assertions land once
-    // it has.
   ],
 }
 


### PR DESCRIPTION
Final piece of the tailnet-only web-UI pilot (**#3466**). The `tailscale-proxy-ts-web` node registered post-#3469 (tailnet IPv4 **100.64.0.3**), so the DNS resolution and the policy test assertions that had to wait for a real node can now land. **Closes #3466.**

## What this PR does

- **`config.yaml` split route** — `dns.nameservers.split: { ts.${SECRET_PUBLIC_DOMAIN}: [] }`, scoped to the `ts.` label **only**. Commented in-file as the single most dangerous line in the pilot: widening it to the bare zone would NXDOMAIN ~20 live public app hostnames on every tailnet device on every network. `grafana.<domain>` is not a subdomain of `ts.<domain>`, so it never routes here and resolves exactly as it does today.
- **`config.yaml` extra_records** — `prometheus.ts.${SECRET_PUBLIC_DOMAIN} A -> 100.64.0.3`. Served as a MagicDNS Hosts (exact) entry, which takes precedence over the LocalDomains NXDOMAIN from the split route.
- **`policy.hujson` tests** — adds the deferred `tag:ts-web` assertions now that a node carries the tag: `accept ben@ -> tag:ts-web:443`, `deny ben@ -> tag:ts-web:9090`, `deny tag:ts-prometheus -> tag:ts-web:443`. Removes the PHASE 2 comment block so the file no longer tells a reader to add what is now present.

## AAAA decision (recorded per the brief)

The node also has a ULA IPv6 (`fd7a:115c:a1e0::3`). This PR adds an **A record only, no AAAA** — deliberately. Every tailnet node is always assigned a `100.64.0.0/10` IPv4 by tailscale regardless of the client's underlying network, so a single A record reaches every tailnet client; no tailnet client is v4-less. Adding AAAA would introduce a second address family to reason about (happy-eyeballs ordering, v6 reachability) for zero functional gain in a minimal, copyable pilot. If a genuinely IPv6-only consumer ever appears, add the AAAA then.

## Operational note

Applying this **restarts headscale**. That is **control-plane only**: WireGuard tunnels are peer-to-peer and survive the restart. The `ts-prometheus`, `ts-loki` and `ts-metrics-ingest` proxies all set `TS_ACCEPT_DNS=false` and ignore pushed DNS, so **fleet Alloy `remote_write` is unaffected**.

## Post-merge verification (owner: coordinator/Ben, has cluster read + dig + off-tailnet)

- `dig` at an authoritative NS returns nothing for `prometheus.ts.<domain>` and nothing for its `k8s.` TXT.
- `dig A grafana.<domain>` still resolves (split route did not over-capture).
- >=3 other app hostnames still resolve from a tailnet device.
- From a tailnet device `https://prometheus.ts.<domain>` loads over TLS, public-CA, no warning.
- Off-tailnet the name does not resolve and the service is unreachable.
- `ts-prometheus` / `ts-loki` / `ts-metrics-ingest` stay reachable and Alloy `remote_write` is healthy after the restart.

Closes #3466