### PR TITLE
ts-web: forward and grant tcp:80 for HTTP->HTTPS redirect

### DIFF
--- a/kubernetes/cluster0/apps/networking/headscale/app/config/policy.hujson
+++ b/kubernetes/cluster0/apps/networking/headscale/app/config/policy.hujson
@@ -69,14 +69,17 @@
       "ip":  ["tcp:9090"],
     },
     // Tailnet-only web UI (pilot #3466). ben@ devices reach the shared
-    // ts-web proxy on tcp:443 ONLY; the proxy TCPForwards to the in-cluster
-    // traefik gateway, which terminates TLS and routes by hostname. No other
-    // ports. TLS terminates on traefik, not on tailscale, so the base-domain
-    // cert limitation does not apply.
+    // ts-web proxy on tcp:443, and on tcp:80 for the HTTP->HTTPS redirect
+    // only (issue #3471) -- traefik's web entrypoint 308s every request to
+    // websecure, so no application content is ever served in plaintext on
+    // port 80. The proxy TCPForwards to the in-cluster traefik gateway,
+    // which terminates TLS and routes by hostname. No other ports. TLS
+    // terminates on traefik, not on tailscale, so the base-domain cert
+    // limitation does not apply.
     {
       "src": ["ben@"],
       "dst": ["tag:ts-web"],
-      "ip":  ["tcp:443"],
+      "ip":  ["tcp:80", "tcp:443"],
     },
     // MPD (Music Player Daemon) control/streaming port 6600. Scoped to ben@
     // devices only; enables device-to-device music access (e.g. navi <-> bens-s25).
@@ -112,6 +115,7 @@
         "tag:ts-prometheus:9090",
         "tag:ts-loki:3100",
         "tag:ts-web:443",       // tailnet-only web UI proxy (#3466)
+        "tag:ts-web:80",        // HTTP->HTTPS redirect entrypoint (#3471)
       ],
       "deny": [
         "tag:ts-prometheus:22", // no SSH on the prometheus proxy

--- a/kubernetes/cluster0/apps/networking/headscale/app/tailscale-proxy-ts-web-deployment.yaml
+++ b/kubernetes/cluster0/apps/networking/headscale/app/tailscale-proxy-ts-web-deployment.yaml
@@ -8,10 +8,13 @@
 # Unlike tailscale-proxy-prometheus / -loki / -metrics-ingest, this proxy is
 # NOT bound to one backend Service. It is a dumb L4 pipe: it TCPForwards
 # inbound tailnet TCP :443 straight to the in-cluster traefik gateway on
-# :443. Traefik terminates TLS on the *.ts.${SECRET_PUBLIC_DOMAIN} cert and
-# routes by SNI/hostname to the right backend via an HTTPRoute. One proxy
-# fronts every *.ts.${SECRET_PUBLIC_DOMAIN} name; the per-service piece is an
-# HTTPRoute + a target-side ingress NetworkPolicy, not a new proxy.
+# :443, and (since issue #3471) inbound tailnet TCP :80 to traefik on :80
+# for the HTTP->HTTPS redirect -- traefik's web entrypoint 308s every
+# request to websecure, so no application content is ever served in
+# plaintext. Traefik terminates TLS on the *.ts.${SECRET_PUBLIC_DOMAIN} cert
+# and routes by SNI/hostname to the right backend via an HTTPRoute. One
+# proxy fronts every *.ts.${SECRET_PUBLIC_DOMAIN} name; the per-service piece
+# is an HTTPRoute + a target-side ingress NetworkPolicy, not a new proxy.
 #
 # Why tailscale never terminates TLS here:
 #   The proxy forwards the raw TCP stream, SNI intact. TLS terminates on
@@ -38,14 +41,19 @@ metadata:
   namespace: networking
 data:
   # ipn.ServeConfig — TCP handler that TCPForwards inbound tailnet TCP on
-  # port 443 to the traefik gateway Service by DNS name. TCPForward does a
-  # standard net.Dial (fresh outbound socket) per accepted connection; it
-  # does NOT proxy packets and does NOT terminate TLS. Target is the Service
-  # DNS name, not a pinned ClusterIP: no /32 pin drift when the Service is
-  # reconstituted.
+  # ports 80 and 443 to the traefik gateway Service by DNS name. TCPForward
+  # does a standard net.Dial (fresh outbound socket) per accepted connection;
+  # it does NOT proxy packets and does NOT terminate TLS. Target is the
+  # Service DNS name, not a pinned ClusterIP: no /32 pin drift when the
+  # Service is reconstituted. Port 80 (issue #3471) exists only so traefik's
+  # web entrypoint can redirect to websecure; no plaintext app content is
+  # served.
   serve.json: |-
     {
       "TCP": {
+        "80": {
+          "TCPForward": "traefik.networking.svc.cluster.local:80"
+        },
         "443": {
           "TCPForward": "traefik.networking.svc.cluster.local:443"
         }

--- a/kubernetes/cluster0/apps/networking/headscale/app/tailscale-proxy-ts-web-network-policy.yaml
+++ b/kubernetes/cluster0/apps/networking/headscale/app/tailscale-proxy-ts-web-network-policy.yaml
@@ -11,7 +11,8 @@
 #   - DNS to CoreDNS (kube-system): resolve hs.${DOMAIN} + traefik Service
 #   - HTTPS/DERP to internet: control-plane + DERP relay fallback
 #   - UDP high-ports to internet: direct WireGuard + STUN
-#   - TCP :443 to networking/traefik pods: the actual forward target
+#   - TCP :80, :443 to networking/traefik pods: the actual forward targets
+#     (:80 added in issue #3471 for the HTTP->HTTPS redirect)
 #   - kube-apiserver: read/write the node-state Secret (TS_KUBE_SECRET)
 #
 # No ingress needed on the proxy pod: tailnet peers reach it via the
@@ -114,11 +115,13 @@ spec:
               - 172.16.0.0/12
               - 192.168.0.0/16
 ---
-# The actual forward target: TCP :443 to traefik pods in the networking
-# namespace. This is the outbound net.Dial the TCPForward handler makes for
-# each accepted tailnet connection. Under Cilium socket-LB the connect() to
-# the traefik ClusterIP:443 is DNAT'd to a traefik PodIP:443 before egress
-# policy evaluation, so this podSelector rule matches the translated target.
+# The actual forward target: TCP :80 and :443 to traefik pods in the
+# networking namespace. This is the outbound net.Dial the TCPForward handler
+# makes for each accepted tailnet connection -- :443 for the app itself,
+# :80 for the HTTP->HTTPS redirect (issue #3471). Under Cilium socket-LB the
+# connect() to the traefik ClusterIP is DNAT'd to a traefik PodIP before
+# egress policy evaluation, so this podSelector rule matches the translated
+# target.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -131,6 +134,8 @@ spec:
   policyTypes: [Egress]
   egress:
     - ports:
+        - port: 80
+          protocol: TCP
         - port: 443
           protocol: TCP
       to:
@@ -163,10 +168,11 @@ spec:
         - kube-apiserver
 ---
 # Reciprocal traefik-side ingress (AGENTS.md reciprocal-pair guidance):
-# allow the ts-web proxy pod to reach traefik on :443. Traefik's broad
-# traefik-allow-intracluster-ingress already admits any in-namespace pod on
-# :443, but this explicit narrow rule documents the ts-web -> traefik half of
-# the pair so the pilot path is legible in one place.
+# allow the ts-web proxy pod to reach traefik on :80 and :443. Traefik's
+# broad traefik-allow-intracluster-ingress already admits any in-namespace
+# pod on these ports, but this explicit narrow rule documents the ts-web ->
+# traefik half of the pair so the pilot path is legible in one place. :80
+# added in issue #3471 for the HTTP->HTTPS redirect.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -186,5 +192,7 @@ spec:
             matchLabels:
               app.kubernetes.io/name: tailscale-proxy-ts-web
       ports:
+        - port: 80
+          protocol: TCP
         - port: 443
           protocol: TCP


### PR DESCRIPTION
Closes #3471

## Cause
Traefik already redirects `web` -> `websecure` (308), so every public app already redirects HTTP to HTTPS. The tailnet path had two gaps:

1. The `ts-web` proxy serve ConfigMap forwarded only port 443.
2. The headscale grant `ben@ -> tag:ts-web` covered `tcp:443` only.

So `http://prometheus.ts.tinfoilforest.nz` hung and timed out instead of redirecting.

## Fix (additive, 3 files)
- `tailscale-proxy-ts-web-deployment.yaml` — add an `80` entry to the serve ConfigMap, TCPForwarding to `traefik.networking.svc.cluster.local:80`. The existing 443 entry is unchanged.
- `config/policy.hujson` — widen the `ben@ -> tag:ts-web` grant to `["tcp:80", "tcp:443"]`; add a `tag:ts-web:80` accept test. The `tag:ts-web:9090` deny and `tag:ts-prometheus -> tag:ts-web:443` deny are untouched.
- `tailscale-proxy-ts-web-network-policy.yaml` — add port 80 to the ts-web -> traefik egress rule and its reciprocal traefik ingress rule.

## Security note
Port 80 carries redirects only — traefik's `web` entrypoint 308s every request to `websecure`, so no application content is served in plaintext. The hop stays inside the WireGuard tunnel. `prometheus.ts.tinfoilforest.nz` still has no public DNS record (`external-dns.alpha.kubernetes.io/controller: none` untouched), and the headscale split-route scope in `config.yaml` was not touched.

## Verification
Merging restarts headscale (control-plane only; WireGuard tunnels survive). I can't verify the post-merge checks from this session — the coordinator has tailnet and `dig` access and will run:
- `http://prometheus.ts.tinfoilforest.nz` returns a 3xx to the https URL
- `https://prometheus.ts.tinfoilforest.nz` still returns 200 with a valid public-CA cert
- headscale logs show no "policy tests failed" line
- `dig A prometheus.ts.tinfoilforest.nz` at an authoritative NS still returns nothing
- at least three other app hostnames still resolve

Locally verified: `kubectl apply --dry-run=client` passes on both modified YAML manifests; the hujson diff leaves the two existing deny tests untouched.