### PR TITLE
grafana: add hostname filter to Cost by profile panel

### DIFF
--- a/kubernetes/cluster0/apps/monitoring/grafana/app/dashboard-prism-fleet.yaml
+++ b/kubernetes/cluster0/apps/monitoring/grafana/app/dashboard-prism-fleet.yaml
@@ -291,7 +291,7 @@ data:
               "refId": "A",
               "datasource": { "type": "prometheus", "uid": "P09FC0E78B5F11C2D" },
               "instant": true,
-              "expr": "sum by (profile) (increase(prism_spend_by_profile_usd_total{profile=~\"${profile:regex}\"}[$__range]))",
+              "expr": "sum by (profile) (increase(prism_spend_by_profile_usd_total{hostname=~\"${hostname:regex}\", profile=~\"${profile:regex}\"}[$__range]))",
               "legendFormat": "{{profile}}"
             }
           ]


### PR DESCRIPTION
## Summary

Adds the missing `hostname=~"${hostname:regex}"` matcher to the `Cost by profile (range total)` panel query on the Prism Fleet Telemetry dashboard, alongside the existing `profile=~"${profile:regex}"` matcher. Selecting a Host now narrows this panel like every sibling cost panel.

Closes #3475

## Scope

One-line change to the panel's PromQL `expr` in
`kubernetes/cluster0/apps/monitoring/grafana/app/dashboard-prism-fleet.yaml`.

- `Review pass rate` panel query: untouched (byte-for-byte, per issue instructions — it is deliberately fleet-wide pending separate review).
- `kustomize.toolkit.fluxcd.io/substitute: disabled` annotation and its explanatory comment: untouched.
- No other panel, template variable, or datasource uid touched.
- No JSON reformatting/re-indentation — diff is one line.

## Verification

- `kustomize build kubernetes/cluster0/apps/monitoring/grafana/app` succeeds.
- Embedded dashboard JSON still parses (`yq` extraction + `jq .`).
- `git diff` confirms exactly one line changed.

Note: `kustomize build` passing does not prove Flux envsubst compatibility (that's the PR #3464 regression class). The `substitute: disabled` annotation is intact and unmodified, which is what protects against that. Post-merge, I'll verify `cluster-apps-grafana` reconciles READY=True and that the panel responds to the Host variable, per the issue's own verification note.