### PR TITLE
AGENTS.md: record public-repo disclosure rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -334,6 +334,28 @@ Some applications use init containers that must complete before the main contain
 - **home-assistant**: Uses `git-sync` init container to pull config from Git
 - Check pod status carefully - `Init:0/1` is normal during startup
 
+## Public Repository Disclosure Rule
+
+This repository is **public**. Anything committed to it, or written into a GitHub
+issue body, PR description, or commit message, is visible to the internet. This
+rule applies to those surfaces, not only to files tracked in the repo.
+
+**Never publish:**
+- Ben's home WAN IP, or any other publicly routable address belonging to their
+  network. Use the placeholder `<WAN_IP>` instead.
+- Secrets of any kind. Secrets always go through SOPS and are never committed
+  in plaintext.
+
+**Accepted and in scope — do not retro-scrub:**
+- RFC1918 addresses (`10.87.x.x`) and `*.tinfoilforest.nz` hostnames. These are
+  already published deliberately across the repo, notably in
+  `kubernetes/cluster0/flux/vars/cluster-settings.yaml`. They are not a leak.
+  Do not treat them as one, and do not "helpfully" remove them from files where
+  they already appear.
+
+If you are unsure whether a value is safe to publish, escalate to the operator
+and ask before writing it into a file, issue, PR, or commit.
+
 ## Best Practices
 
 1. **Never assume resource names** - Always verify with `kubectl get`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -343,12 +343,29 @@ rule applies to those surfaces, not only to files tracked in the repo.
 **Never publish:**
 - Ben's home WAN IP, or any other publicly routable address belonging to their
   network. Use the placeholder `<WAN_IP>` instead.
+- The domain `tinfoilforest.nz`, and any subdomain of it. In prose, issue
+  bodies, PR descriptions, and commit messages, use the placeholder
+  `<DOMAIN>` instead. The domain is already present in git history and that
+  cannot be undone, but a casual reader who finds it in history, rather than
+  in current files, cannot tell whether it is current or stale — keeping it
+  out of current files degrades the value of the history find for an
+  opportunistic reader. That is a real reduction in exposure, even though it
+  is not an absolute one.
 - Secrets of any kind. Secrets always go through SOPS and are never committed
   in plaintext.
 
+The domain's in-tree config occurrences are a separate matter from prose, and
+are NOT covered by the prose rule above: several are functional (the
+headscale `server_url`, the split-DNS suffix key in `policy.hujson`, ingress
+hostnames) and cannot simply be deleted. These will migrate to a
+`${SECRET_DOMAIN}` substitution variable sourced from
+`cluster-secrets.sops.yaml`. That migration is tracked separately and is NOT
+yet done — do not read this rule as a signal that the tree is already clean,
+and do not start removing the domain from config files yourself.
+
 **Accepted and in scope — do not retro-scrub:**
-- RFC1918 addresses (`10.87.x.x`) and `*.tinfoilforest.nz` hostnames. These are
-  already published deliberately across the repo, notably in
+- RFC1918 addresses (`10.87.x.x`). These are already published deliberately
+  across the repo, notably in
   `kubernetes/cluster0/flux/vars/cluster-settings.yaml`. They are not a leak.
   Do not treat them as one, and do not "helpfully" remove them from files where
   they already appear.


### PR DESCRIPTION
Closes #3482

Adds a new, purely additive section to `AGENTS.md` recording the public-repository disclosure rule:

- Never publish the home WAN IP (or any publicly routable address on Ben's network) in files, issue bodies, PR descriptions, or commit messages. Use `<WAN_IP>` instead.
- Never publish the domain `tinfoilforest.nz` or any subdomain of it in prose (issue bodies, PR descriptions, commit messages) — use `<DOMAIN>` instead. Policy update authorized by the operator mid-review; see [issue #3482 comment](https://github.com/prismatic-koi/home-ops/issues/3482#issuecomment-5304492957) for the traceable record and rationale. In-tree functional config occurrences of the domain (headscale `server_url`, split-DNS suffix key in `policy.hujson`, ingress hostnames) are explicitly out of scope here and are tracked separately for a future `${SECRET_DOMAIN}` substitution migration.
- Secrets always go through SOPS, never committed in plaintext.
- RFC1918 addresses (`10.87.x.x`) are accepted and in scope — already deliberately published in `kubernetes/cluster0/flux/vars/cluster-settings.yaml` — and must not be retro-scrubbed. This half is unchanged from the original AC.
- When unsure whether a value is safe to publish, escalate to the operator before writing it anywhere.

No existing line in `AGENTS.md` was removed, reworded, reordered, or reformatted — verified with `git diff origin/main -- AGENTS.md` (all changes are additions).