### PR TITLE
changedetection-io: allow SMTP egress on 587 for notifications

### DIFF
--- a/kubernetes/cluster0/apps/monitoring/changedetection-io/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/monitoring/changedetection-io/app/helm-release.yaml
@@ -108,6 +108,21 @@ spec:
                       - 10.0.0.0/8
                       - 172.16.0.0/12
                       - 192.168.0.0/16
+      allow-smtp-egress:
+        controller: main
+        policyTypes: [Egress]
+        rules:
+          egress:
+            - ports:
+                - port: 587
+                  protocol: TCP
+              to:
+                - ipBlock:
+                    cidr: 0.0.0.0/0
+                    except:
+                      - 10.0.0.0/8
+                      - 172.16.0.0/12
+                      - 192.168.0.0/16
       allow-browserless-egress:
         controller: main
         policyTypes: [Egress]


### PR DESCRIPTION
## Problem

changedetection-io could not send email notifications. Its default-deny egress NetworkPolicy had no rule for SMTP submission on port 587, so the connection to `smtp-relay.gmail.com` was denied.

## Fix

Adds an `allow-smtp-egress` NetworkPolicy entry to `kubernetes/cluster0/apps/monitoring/changedetection-io/app/helm-release.yaml`, permitting egress on TCP/587 to `0.0.0.0/0` minus the RFC1918 ranges — matching the shape of the existing `allow-external-egress` rule in the same file and the precedent set by authelia and alertmanager for the same relay.

## Scope

Single additive block in one file. No other policy or app touched.

Closes #3485