### PR TITLE
fix(cilium): rotate Hubble mTLS certs with the certgen CronJob

### DIFF
--- a/kubernetes/cluster0/apps/kube-system/cilium/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/kube-system/cilium/app/helm-release.yaml
@@ -70,6 +70,35 @@ spec:
         prometheus:
           serviceMonitor:
             enabled: true
+      tls:
+        enabled: true
+        # The chart default is `auto.method: helm`. That method generates the
+        # Hubble CA and leaf certs inside the Helm release at install time and
+        # never renews them. The certs expired on 2026-08-01, hubble-relay
+        # CrashLooped on the expired peer cert, and the blocked `helm --wait`
+        # also stalled the 1.20.1 chart bump (#3494). See #3508.
+        #
+        # `cronJob` moves issuance to cilium-certgen: a one-shot Job on each
+        # install and upgrade, plus a recurring CronJob that regenerates every
+        # Hubble leaf cert on the schedule below.
+        auto:
+          enabled: true
+          method: cronJob
+          # Leaf validity in days, for hubble-server-certs and
+          # hubble-relay-client-certs. 180 days against a monthly schedule
+          # gives about 6 renewal attempts of margin. Several consecutive
+          # CronJob failures therefore cannot expire a cert.
+          certValidityDuration: 180
+          # 03:00 on the 1st of every month. CronJob schedules are UTC. The
+          # chart does not expose spec.timeZone for the certgen CronJob, so
+          # this is not the Pacific/Auckland timezone of the cluster.
+          schedule: "0 3 1 * *"
+          # The CA (`cilium-ca`) is not on this rotation. certgen runs with
+          # `--ca-reuse-secret`, so it creates the CA once with its own
+          # 3-year validity and reuses it after that. certgen also runs with
+          # `--ca-enforce-validity-throughout-leaves-duration=true`, so this
+          # CronJob starts to fail about 180 days before the CA expires. That
+          # failure is the signal to rotate the CA by hand.
       ui:
         enabled: true
         rollOutPods: true


### PR DESCRIPTION
Closes #3508

## Problem

The Hubble mTLS certs expired on 2026-08-01. `hubble-relay` fails its startup probe with `NOT_SERVING` and CrashLoops. The TLS handshake reports `x509: certificate has expired`. The `KubeDeploymentReplicasMismatch` alert fires for `deployment=hubble-relay` in `kube-system`.

The cilium HelmRelease used the chart default `hubble.tls.auto.method: helm`. That method generates the Hubble CA and the leaf certs inside the Helm release at install time. It never renews them. No certgen CronJob and no cert-manager Certificate existed for Hubble.

The expired certs also block the `1.20.0 -> 1.20.1` chart bump from #3494. Helm waits for `hubble-relay` to become Ready, so the release sits in `pending-upgrade` and the agent and relay images stay at `v1.20.0`.

The dataplane is not affected. Only Hubble observability is down.

## Change

One file: `kubernetes/cluster0/apps/kube-system/cilium/app/helm-release.yaml`.

```yaml
hubble:
  tls:
    enabled: true
    auto:
      enabled: true
      method: cronJob
      certValidityDuration: 180
      schedule: "0 3 1 * *"
```

`method: cronJob` moves issuance to cilium-certgen `v0.4.9`. The chart renders a one-shot Job on each install and upgrade, plus a recurring CronJob on the schedule above.

### Rendered resource change

I rendered chart 1.20.1 twice, once with the values from `main` and once with the values from this branch, and compared every object.

Added, 5 objects:

| Kind | Name |
|---|---|
| ServiceAccount | `hubble-generate-certs` |
| Role | `hubble-generate-certs` |
| RoleBinding | `hubble-generate-certs` |
| Job | `hubble-generate-certs-<spec-checksum>` |
| CronJob | `hubble-generate-certs` |

Removed from the release manifest, 3 objects:

| Kind | Name |
|---|---|
| Secret | `cilium-ca` |
| Secret | `hubble-server-certs` |
| Secret | `hubble-relay-client-certs` |

Every other rendered object is byte-identical, including the `cilium-config` ConfigMap, the `cilium` DaemonSet, the `cilium-envoy` DaemonSet, the `cilium-operator` Deployment, the `hubble-relay` Deployment, and the `hubble-ui` Deployment. The pod template of the cilium agent does not change, so this change does not roll the dataplane.

The certgen Job asks for the same two leaf certs that the `helm` method produced, with `validity: 4320h` (180 days):

- `hubble-server-certs`, CN `*.home-ops-cluster0.hubble-grpc.cilium.io`
- `hubble-relay-client-certs`, CN `*.hubble-relay.cilium.io`

`hubble.relay.tls.server.enabled` and `hubble.metrics.tls.enabled` both stay `false`, so `hubble-relay-server-certs`, `hubble-ui-client-certs`, and `hubble-metrics-server-certs` are not requested.

### Why 180 days and a monthly schedule

The CronJob regenerates every leaf cert on each run, and it does not look at the remaining validity. 180-day leaves against a monthly run give about 6 renewal attempts inside the life of one cert. Five consecutive CronJob failures therefore still cannot expire a cert.

CronJob schedules are UTC. The chart does not expose `spec.timeZone` for the certgen CronJob, so `0 3 1 * *` is not the Pacific/Auckland time of the cluster.

### Why cronJob and not cert-manager

cert-manager is in-cluster and `internal-services-clusterissuer` exists. cert-manager still runs *on* this cluster, behind this CNI. If the Hubble certs depended on cert-manager, a from-scratch bootstrap would leave `hubble-relay` without a cert until cert-manager is up. `helm install --wait` would then time out, and `install.remediation.retries: 3` would uninstall the CNI release. The certgen CronJob keeps issuance inside the cilium chart and removes that ordering risk.

### Known limit: the CA is not on this rotation

certgen runs with `--ca-reuse-secret`, so it creates `cilium-ca` once and reuses it after that. The chart passes no CA validity flag, so certgen applies its own default of `3 * 365 * 24h` (cilium/certgen `v0.4.9`, `internal/defaults/defaults.go`). certgen also runs with `--ca-enforce-validity-throughout-leaves-duration=true`, so the CronJob starts to fail once the CA holds less than 180 days.

Step 2 of the runbook deletes `cilium-ca`, so certgen mints a fresh CA at cutover. Against a cutover on 2026-08-22:

| Event | Date |
|---|---|
| CA minted | 2026-08-22 |
| CronJob starts to fail | 2029-02-22 |
| CA expires | 2029-08-21 |

The chart value `tls.ca.certValidityDuration: 1095` does not apply here. It feeds the `helm` method only.

The failing CronJob already pages. `defaultRules.rules.kubernetesApps` is `true` in the kube-prometheus-stack HelmRelease, `KubeJobFailed` is not in the `disabled` map, and the CronJob keeps the failed Job through `failedJobsHistoryLimit: 1`. `KubeJobFailed` therefore fires 15 minutes after a certgen Job fails, about 6 months before any cert expires. No new alert rule is needed.

One follow-up remains, out of scope here:

1. The CA rotation is a manual action, due about 2029-02, when the CronJob starts to fail.

## Live cutover runbook

I cannot mutate the live CNI from a worktree. Run these steps at merge time.

Every command runs against `cluster0`.

### CAUTION: read this before step 2

certgen loads the existing `cilium-ca` secret instead of generating a new one, because it runs with `--ca-reuse-secret`. It then validates the CA expiry against the requested leaf validity. Against the **expired** CA that check is a hard error, the Job fails, and `helm --wait` fails with it. Step 2 deletes `cilium-ca` so that certgen mints a fresh CA. Do not skip it.

### CAUTION: the rollback loop

If the helm upgrade times out, `upgrade.remediation` rolls the release back. The rollback re-applies the stored manifest of the previous revision, which contains the **expired** secrets. The next retry then fails the same way. Step 6 is what prevents this. Run it as soon as the certgen Job completes. If a rollback does occur, repeat step 2 and then run `flux -n kube-system reconcile helmrelease cilium --force`.

### Step 1: record the current state

```bash
kubectl -n kube-system get helmrelease cilium \
  -o jsonpath='{range .status.conditions[*]}{.type}={.status} {.reason}: {.message}{"\n"}{end}'

helm -n kube-system history cilium
kubectl -n kube-system get secret -l owner=helm,name=cilium \
  -o custom-columns=NAME:.metadata.name,STATUS:.metadata.labels.status

kubectl -n kube-system get ds cilium -o wide
kubectl -n kube-system get deploy hubble-relay hubble-ui
kubectl -n kube-system get pod -l k8s-app=hubble-relay

# Confirm the expiry that this PR corrects.
kubectl -n kube-system get secret cilium-ca \
  -o jsonpath='{.data.ca\.crt}' | base64 -d | openssl x509 -noout -subject -dates
for s in hubble-server-certs hubble-relay-client-certs; do
  echo "== $s"
  kubectl -n kube-system get secret "$s" \
    -o jsonpath='{.data.tls\.crt}' | base64 -d | openssl x509 -noout -subject -dates
done
```

Preflight from the AGENTS.md section "Cilium Helm chart minor/major upgrades". The 1.20.1 upgrade has never completed, so run the CRD check before you unblock it:

```bash
kubectl get crd ciliumnodeconfigs.cilium.io -o jsonpath='{.status.storedVersions}'; echo
kubectl get crd ciliumnodeconfigs.cilium.io -o jsonpath='{.spec.versions[*].name}'; echo
```

If `storedVersions` holds a version that `spec.versions` does not list, stop and follow the patch procedure in AGENTS.md before you continue.

### Step 2: suspend the HelmRelease, then delete the expired secrets

Suspend first. The suspend stops helm-controller from reconciling the **old** `method: helm` values in the window between the delete and the merge. Without it, an old-spec reconcile re-bakes a fresh 1-year non-rotating CA, which is the pattern this PR removes.

```bash
flux -n kube-system suspend helmrelease cilium

kubectl -n kube-system delete secret cilium-ca hubble-server-certs hubble-relay-client-certs

# The replacement relay pod waits on the deleted secret instead of entering
# CrashLoopBackOff. This keeps the recovery in step 6 fast.
kubectl -n kube-system delete pod -l k8s-app=hubble-relay
```

The cilium agent mounts `hubble-server-certs` with `optional: true`, verified in the rendered DaemonSet. The absent secret therefore neither restarts a running agent nor blocks a new one. The dataplane stays up.

Confirm that the agents are unaffected:

```bash
kubectl -n kube-system get pod -l k8s-app=cilium -o wide
```

### Step 3: merge this PR and land the new values

```bash
gh pr merge <this-pr> --squash
flux reconcile source git home-ops-cluster0
flux -n flux-system reconcile kustomization cluster-apps-cilium

# Expect: certValidityDuration 180, method cronJob, schedule "0 3 1 * *".
kubectl -n kube-system get helmrelease cilium \
  -o jsonpath='{.spec.values.hubble.tls.auto}'; echo

# The suspend must survive the kustomize-controller apply.
kubectl -n kube-system get helmrelease cilium -o jsonpath='{.spec.suspend}'; echo
```

If `spec.suspend` is not `true`, run `flux -n kube-system suspend helmrelease cilium` again and repeat the check in step 1 for the three secrets.

### Step 4: clear the stuck pending-upgrade

helm-controller unlocks a `pending-*` release by itself. Only if a pending secret is still present, delete it:

```bash
kubectl -n kube-system get secret -l owner=helm,name=cilium,status=pending-upgrade

# Run this only if the command above returns a secret.
kubectl -n kube-system delete secret -l owner=helm,name=cilium,status=pending-upgrade
```

### Step 5: resume the HelmRelease and watch the certgen Job

```bash
flux -n kube-system resume helmrelease cilium

kubectl -n kube-system get job -l k8s-app=hubble-generate-certs -w
kubectl -n kube-system logs -l k8s-app=hubble-generate-certs --tail=50
```

Expect the log line `Successfully generated all requested certificates.`

The Job name carries a checksum of its own spec, so match on the label, not on a fixed name.

### Step 6: restart hubble-relay

Run this as soon as the certgen Job completes.

```bash
kubectl -n kube-system rollout restart deployment/hubble-relay
kubectl -n kube-system rollout status deployment/hubble-relay --timeout=180s
```

The `hubble-relay` pod template is byte-identical before and after this change, so Helm does not roll the pod on its own. hubble-relay reads its cert files at start-up.

### Step 7: verify

```bash
# 1. The CA and both leaves have a notAfter in the future.
kubectl -n kube-system get secret cilium-ca \
  -o jsonpath='{.data.ca\.crt}' | base64 -d | openssl x509 -noout -subject -dates
for s in hubble-server-certs hubble-relay-client-certs; do
  echo "== $s"
  kubectl -n kube-system get secret "$s" \
    -o jsonpath='{.data.tls\.crt}' | base64 -d | openssl x509 -noout -subject -dates
done

# 2. hubble-relay is 1/1 with 0 restarts on the new pod.
kubectl -n kube-system get deploy hubble-relay
kubectl -n kube-system get pod -l k8s-app=hubble-relay \
  -o custom-columns=NAME:.metadata.name,READY:.status.containerStatuses[0].ready,RESTARTS:.status.containerStatuses[0].restartCount

# 3. The HelmRelease is Ready at chart 1.20.1 with v1.20.1 images.
flux -n kube-system get helmrelease cilium
kubectl -n kube-system get ds cilium \
  -o jsonpath='{.spec.template.spec.containers[0].image}'; echo
kubectl -n kube-system get deploy hubble-relay \
  -o jsonpath='{.spec.template.spec.containers[0].image}'; echo

# 4. The renewal mechanism exists and has a next run time.
kubectl -n kube-system get cronjob hubble-generate-certs

# 5. The dataplane held. All agents Ready, no node lost networking.
kubectl -n kube-system get pod -l k8s-app=cilium -o wide
kubectl get node -o wide
kubectl -n kube-system exec ds/cilium -c cilium-agent -- cilium-dbg status --brief

# 6. Hubble itself works end to end.
kubectl -n kube-system exec ds/cilium -c cilium-agent -- cilium-dbg status | grep -i hubble
```

Confirm that the `KubeDeploymentReplicasMismatch` alert for `deployment=hubble-relay` clears in Alertmanager. The alert has a `for` window, so allow a few minutes after relay reaches 1/1.

### Rollback

The change is a values-only edit. To revert, revert the commit and reconcile. The certgen-issued secrets stay valid after the revert, because the `helm` method reads an existing `cilium-ca` through a `lookup` instead of generating a new one. A revert therefore restores the old non-rotating behaviour without breaking Hubble a second time.

## Validation done in the worktree

| Check | Command | Result |
|---|---|---|
| Flux Local - Test | `flux-local test --all-namespaces --enable-helm --path kubernetes/cluster0/flux` | 109 passed |
| Flux Local - Diff, helmrelease | `flux-local diff helmrelease ...` as per `.github/workflows/flux-local.yaml` | exit 0, only the 5 certgen objects added |
| Flux Local - Diff, kustomization | `flux-local diff kustomization ...` | exit 0, only the `hubble.tls` block added |
| Prometheus scrape NetworkPolicy lint | `python3 scripts/lint-prometheus-scrape-netpol.py --verbose` | OK, 23 targets, 22 egress rules |
| Rendered object comparison | `helm template` on old values against new values | 5 added, 3 removed, 0 changed |

### NetworkPolicy check

The certgen pod talks to the kube-apiserver, so I checked the egress path. `kube-system` has no namespace-wide default-deny and the repo declares no `CiliumClusterwideNetworkPolicy`. Every default-deny rule in `kube-system` is scoped by pod selector, and none of them selects `k8s-app: hubble-generate-certs`. The certgen pod is therefore unselected, and its egress is allowed. No new policy is needed.

## Acceptance criteria

Verifiable from the worktree:

- [x] The cilium HelmRelease configures Hubble TLS with an auto-rotating method. `hubble.tls.auto.method: cronJob`, `schedule: "0 3 1 * *"`, `certValidityDuration: 180`.
- [x] A renewal mechanism is in place and its schedule and validity are visible in the committed values.
- [x] The PR documents the exact live cutover steps.

Coordinator-verified after merge, from step 7:

- [ ] `hubble-relay-client-certs`, `hubble-server-certs`, and `cilium-ca` are re-issued with a `notAfter` in the future.
- [ ] The `hubble-relay` deployment reports 1/1 ready with 0 CrashLoop restarts.
- [ ] The cilium HelmRelease reaches `Ready=True` at chart 1.20.1, with agent and relay images at `v1.20.1`.
- [ ] The `KubeDeploymentReplicasMismatch` alert for `deployment=hubble-relay` no longer fires.
- [ ] Cilium dataplane connectivity held. Agents stayed Ready and no node lost networking.
