### PR TITLE
fix(cilium): narrow LB-IPAM pool to exclude router and control-plane VIP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -330,6 +330,24 @@ up automatically just because no objects use that version. Always check both `sp
 If upgrade fails with `Unable to update CRD ... storedVersions` or similar, the operator
 crashed during the createCRDs hook — check operator pod logs and rerun the patch command above.
 
+## Changing an allocatable IP range or address pool
+
+Any change to an allocatable IP range (a `CiliumLoadBalancerIPPool` block, a DHCP
+range, a metallb pool, or similar) must enumerate the reserved infrastructure
+addresses that fall inside the proposed range and confirm each one is excluded.
+At minimum, check the range against:
+
+- the LAN router (`10.87.42.1`)
+- the kube-vip control-plane VIP (`10.87.42.2`)
+- the cluster nodes' InternalIPs (`10.87.42.100`-`.103`)
+- NAS0_IP, the physical Synology (`10.87.42.200`)
+
+A narrowing fix can silently become a widening one at the other end of the range —
+see PR #3521, where fixing the lower bound of the Cilium LB-IPAM pool first
+introduced a new upper-bound overreach into the node IPs and NAS0_IP, caught only
+by a human second pass after two review rounds passed it. State the reserved
+addresses you checked, and the result, in the PR description.
+
 ## Init Containers
 
 Some applications use init containers that must complete before the main container starts:

--- a/kubernetes/cluster0/apps/kube-system/cilium/config/cilium-ippool.yaml
+++ b/kubernetes/cluster0/apps/kube-system/cilium/config/cilium-ippool.yaml
@@ -6,14 +6,19 @@ metadata:
   name: pool
 spec:
   disabled: false
-  # Range starts at .10, not .0/.1, to keep two addresses out of the
-  # allocatable pool that Cilium does not own:
+  # Range is .10 to .31 - the same top boundary as the original
+  # 10.87.42.0/27 block, deliberately NOT widened. Two addresses are cut
+  # from the bottom, addresses Cilium does not own:
   #   10.87.42.1 - the LAN router (CoreDNS's only upstream)
   #   10.87.42.2 - the kube-vip control-plane VIP
   # Do NOT express this as a CIDR (e.g. 10.87.42.10/27): CIDR notation
   # normalises to the containing network (10.87.42.0/27), which silently
   # widens the pool back to include .0-.9 and hands out .1/.2 to the next
   # unpinned LoadBalancer Service.
+  #
+  # Do NOT raise the stop bound past .31: 10.87.42.100-.103 are the
+  # cluster nodes' InternalIPs and 10.87.42.200 is NAS0_IP (a physical
+  # Synology) - both must stay outside this pool.
   #
   # 10.87.42.13 is deliberately excluded (split into two blocks below)
   # instead of pinned: Cilium hands out the lowest free address in the

--- a/kubernetes/cluster0/apps/kube-system/cilium/config/cilium-ippool.yaml
+++ b/kubernetes/cluster0/apps/kube-system/cilium/config/cilium-ippool.yaml
@@ -19,14 +19,6 @@ spec:
   # Do NOT raise the stop bound past .31: 10.87.42.100-.103 are the
   # cluster nodes' InternalIPs and 10.87.42.200 is NAS0_IP (a physical
   # Synology) - both must stay outside this pool.
-  #
-  # 10.87.42.13 is deliberately excluded (split into two blocks below)
-  # instead of pinned: Cilium hands out the lowest free address in the
-  # pool, so if .13 were allocatable, the next unpinned Service would take
-  # it instead of .16+, contradicting the intent that .16+ is the free
-  # range for new, unpinned Services.
   blocks:
-    - start: ${LOADBALANCER_IP_POOL_BLOCK1_START}
-      stop: ${LOADBALANCER_IP_POOL_BLOCK1_STOP}
-    - start: ${LOADBALANCER_IP_POOL_BLOCK2_START}
-      stop: ${LOADBALANCER_IP_POOL_BLOCK2_STOP}
+    - start: ${LOADBALANCER_IP_POOL_START}
+      stop: ${LOADBALANCER_IP_POOL_STOP}

--- a/kubernetes/cluster0/apps/kube-system/cilium/config/cilium-ippool.yaml
+++ b/kubernetes/cluster0/apps/kube-system/cilium/config/cilium-ippool.yaml
@@ -14,6 +14,14 @@ spec:
   # normalises to the containing network (10.87.42.0/27), which silently
   # widens the pool back to include .0-.9 and hands out .1/.2 to the next
   # unpinned LoadBalancer Service.
+  #
+  # 10.87.42.13 is deliberately excluded (split into two blocks below)
+  # instead of pinned: Cilium hands out the lowest free address in the
+  # pool, so if .13 were allocatable, the next unpinned Service would take
+  # it instead of .16+, contradicting the intent that .16+ is the free
+  # range for new, unpinned Services.
   blocks:
-    - start: ${LOADBALANCER_IP_POOL_START}
-      stop: ${LOADBALANCER_IP_POOL_STOP}
+    - start: ${LOADBALANCER_IP_POOL_BLOCK1_START}
+      stop: ${LOADBALANCER_IP_POOL_BLOCK1_STOP}
+    - start: ${LOADBALANCER_IP_POOL_BLOCK2_START}
+      stop: ${LOADBALANCER_IP_POOL_BLOCK2_STOP}

--- a/kubernetes/cluster0/apps/kube-system/cilium/config/cilium-ippool.yaml
+++ b/kubernetes/cluster0/apps/kube-system/cilium/config/cilium-ippool.yaml
@@ -6,5 +6,14 @@ metadata:
   name: pool
 spec:
   disabled: false
+  # Range starts at .10, not .0/.1, to keep two addresses out of the
+  # allocatable pool that Cilium does not own:
+  #   10.87.42.1 - the LAN router (CoreDNS's only upstream)
+  #   10.87.42.2 - the kube-vip control-plane VIP
+  # Do NOT express this as a CIDR (e.g. 10.87.42.10/27): CIDR notation
+  # normalises to the containing network (10.87.42.0/27), which silently
+  # widens the pool back to include .0-.9 and hands out .1/.2 to the next
+  # unpinned LoadBalancer Service.
   blocks:
-    - cidr: ${LOADBALANCER_IP_POOL}
+    - start: ${LOADBALANCER_IP_POOL_START}
+      stop: ${LOADBALANCER_IP_POOL_STOP}

--- a/kubernetes/cluster0/flux/vars/cluster-settings.yaml
+++ b/kubernetes/cluster0/flux/vars/cluster-settings.yaml
@@ -10,20 +10,22 @@ data:
   CONTROLPLANE_IP:  "10.87.42.2"
   # Explicit start/stop ranges, not a CIDR: 10.87.42.10/27 normalises to
   # 10.87.42.0/27 and would silently re-include .1 (LAN router) and .2
-  # (kube-vip control-plane VIP). Split into two blocks around .13, which
-  # is deliberately excluded so the next unpinned Service lands on .16+
-  # (see the comment in cilium-ippool.yaml). Keep this in sync with
+  # (kube-vip control-plane VIP). The upper bound stays at .31 (the top
+  # of the original /27) so this narrows the pool and does not widen it
+  # to cover the cluster nodes (.100-.103) or NAS0_IP (.200). Split into
+  # two blocks around .13, which is deliberately excluded so the next
+  # unpinned Service lands on .16+ (see the comment in cilium-ippool.yaml).
+  # Keep this in sync with
   # kubernetes/cluster0/apps/kube-system/cilium/config/cilium-ippool.yaml.
   LOADBALANCER_IP_POOL_BLOCK1_START: "10.87.42.10"
   LOADBALANCER_IP_POOL_BLOCK1_STOP: "10.87.42.12"
   LOADBALANCER_IP_POOL_BLOCK2_START: "10.87.42.14"
-  LOADBALANCER_IP_POOL_BLOCK2_STOP: "10.87.42.199"
+  LOADBALANCER_IP_POOL_BLOCK2_STOP: "10.87.42.31"
   TRAEFIK_IP:       "10.87.42.10"
   PRIMARY_DNS_IP:   "10.87.42.11"
   PLEX_IP:          "10.87.42.12"
   SYNC_ENDPOINT:    "10.87.42.14"
   SECONDARY_DNS_IP: "10.87.42.15"
-  GATEWAY_IP:       "10.87.42.16"
   # external service IPs
   NAS0_IP:          "10.87.42.200"
   UNIFI_IP:         "10.87.1.1"

--- a/kubernetes/cluster0/flux/vars/cluster-settings.yaml
+++ b/kubernetes/cluster0/flux/vars/cluster-settings.yaml
@@ -8,7 +8,12 @@ data:
   CLUSTER_NAME: "home-ops-cluster0"
   TIMEZONE: "Pacific/Auckland"
   CONTROLPLANE_IP:  "10.87.42.2"
-  LOADBALANCER_IP_POOL: "10.87.42.10/27"
+  # Explicit start/stop range, not a CIDR: 10.87.42.10/27 normalises to
+  # 10.87.42.0/27 and would silently re-include .1 (LAN router) and .2
+  # (kube-vip control-plane VIP). Keep this in sync with
+  # kubernetes/cluster0/apps/kube-system/cilium/config/cilium-ippool.yaml.
+  LOADBALANCER_IP_POOL_START: "10.87.42.10"
+  LOADBALANCER_IP_POOL_STOP: "10.87.42.199"
   TRAEFIK_IP:       "10.87.42.10"
   PRIMARY_DNS_IP:   "10.87.42.11"
   PLEX_IP:          "10.87.42.12"

--- a/kubernetes/cluster0/flux/vars/cluster-settings.yaml
+++ b/kubernetes/cluster0/flux/vars/cluster-settings.yaml
@@ -8,12 +8,16 @@ data:
   CLUSTER_NAME: "home-ops-cluster0"
   TIMEZONE: "Pacific/Auckland"
   CONTROLPLANE_IP:  "10.87.42.2"
-  # Explicit start/stop range, not a CIDR: 10.87.42.10/27 normalises to
+  # Explicit start/stop ranges, not a CIDR: 10.87.42.10/27 normalises to
   # 10.87.42.0/27 and would silently re-include .1 (LAN router) and .2
-  # (kube-vip control-plane VIP). Keep this in sync with
+  # (kube-vip control-plane VIP). Split into two blocks around .13, which
+  # is deliberately excluded so the next unpinned Service lands on .16+
+  # (see the comment in cilium-ippool.yaml). Keep this in sync with
   # kubernetes/cluster0/apps/kube-system/cilium/config/cilium-ippool.yaml.
-  LOADBALANCER_IP_POOL_START: "10.87.42.10"
-  LOADBALANCER_IP_POOL_STOP: "10.87.42.199"
+  LOADBALANCER_IP_POOL_BLOCK1_START: "10.87.42.10"
+  LOADBALANCER_IP_POOL_BLOCK1_STOP: "10.87.42.12"
+  LOADBALANCER_IP_POOL_BLOCK2_START: "10.87.42.14"
+  LOADBALANCER_IP_POOL_BLOCK2_STOP: "10.87.42.199"
   TRAEFIK_IP:       "10.87.42.10"
   PRIMARY_DNS_IP:   "10.87.42.11"
   PLEX_IP:          "10.87.42.12"

--- a/kubernetes/cluster0/flux/vars/cluster-settings.yaml
+++ b/kubernetes/cluster0/flux/vars/cluster-settings.yaml
@@ -8,19 +8,15 @@ data:
   CLUSTER_NAME: "home-ops-cluster0"
   TIMEZONE: "Pacific/Auckland"
   CONTROLPLANE_IP:  "10.87.42.2"
-  # Explicit start/stop ranges, not a CIDR: 10.87.42.10/27 normalises to
+  # Explicit start/stop range, not a CIDR: 10.87.42.10/27 normalises to
   # 10.87.42.0/27 and would silently re-include .1 (LAN router) and .2
   # (kube-vip control-plane VIP). The upper bound stays at .31 (the top
   # of the original /27) so this narrows the pool and does not widen it
-  # to cover the cluster nodes (.100-.103) or NAS0_IP (.200). Split into
-  # two blocks around .13, which is deliberately excluded so the next
-  # unpinned Service lands on .16+ (see the comment in cilium-ippool.yaml).
-  # Keep this in sync with
+  # to cover the cluster nodes (.100-.103) or NAS0_IP (.200). Keep this
+  # in sync with
   # kubernetes/cluster0/apps/kube-system/cilium/config/cilium-ippool.yaml.
-  LOADBALANCER_IP_POOL_BLOCK1_START: "10.87.42.10"
-  LOADBALANCER_IP_POOL_BLOCK1_STOP: "10.87.42.12"
-  LOADBALANCER_IP_POOL_BLOCK2_START: "10.87.42.14"
-  LOADBALANCER_IP_POOL_BLOCK2_STOP: "10.87.42.31"
+  LOADBALANCER_IP_POOL_START: "10.87.42.10"
+  LOADBALANCER_IP_POOL_STOP: "10.87.42.31"
   TRAEFIK_IP:       "10.87.42.10"
   PRIMARY_DNS_IP:   "10.87.42.11"
   PLEX_IP:          "10.87.42.12"


### PR DESCRIPTION
## Problem

The Cilium LoadBalancer IPAM pool was `10.87.42.10/27`, which CIDR normalisation makes `10.87.42.0/27` — addresses .0 to .31. That range covers two addresses Cilium does not own:

- `10.87.42.1` — the LAN router, and CoreDNS's only upstream
- `10.87.42.2` — the kube-vip control-plane VIP

The next LoadBalancer Service created without an `io.cilium/lb-ipam-ips` pin would have taken `10.87.42.1`, breaking cluster DNS and the LAN gateway.

## Change

- `cilium-ippool.yaml`: express the pool as a single explicit `start`/`stop` block (`.10`-`.31`) instead of a `cidr`, so the range cannot silently widen back to a CIDR-aligned boundary.
  - The upper bound stays at `.31` — the top of the original `/27` block — so this change only narrows the pool. It does **not** widen it to cover the cluster nodes' InternalIPs (`.100`-`.103`) or NAS0_IP (`.200`, a physical Synology). An earlier version of this PR used `.199` as the stop bound; that was wrong and has been corrected.
  - An earlier version of this PR also split the range into two blocks to carve out `.13`. That carve-out has been dropped: git history (`ac5b51f82`, "remove mosquitto loadbalancer ip") shows `.13` was mosquitto's old LoadBalancer IP, vacated and never reused — it answers no ICMP and nothing references it. It is a free address, not reserved infrastructure, so it stays allocatable.
- `cluster-settings.yaml`: replaced `LOADBALANCER_IP_POOL` (a CIDR string) with `LOADBALANCER_IP_POOL_START` / `LOADBALANCER_IP_POOL_STOP`, matching the manifest's start/stop fields.
- Removed `GATEWAY_IP` (`10.87.42.16`), which fell inside the pool range. It had no referrer anywhere else in the repo and does not answer ICMP — it is a leftover from a removed Cilium Gateway API experiment (commit `b289a510`, July 2025). Since it's unused, it's dropped rather than carved out as a reserved address.
- `AGENTS.md`: added a subsection requiring any future IP-range/address-pool change to enumerate and confirm exclusion of the LAN router, kube-vip VIP, node InternalIPs, and NAS0_IP — codifying the check that caught the `.199` overreach in this PR after two review rounds passed it.

The new range covers `.10`-`.15` (all five currently-pinned allocations: traefik, blocky-primary-dns, plex, syncthing-listdisc, blocky-secondary-dns), excludes `.1` and `.2`, and does not extend past `.31`. A LoadBalancer Service created with no pin receives the lowest free address inside `.10`-`.31` — currently `.13`, since it is unallocated and unreserved.

## Verification plan (post-merge)

After Flux reconciles, verify:
```bash
kubectl get svc -A -o wide | grep LoadBalancer
kubectl get ciliumloadbalancerippool pool -o yaml
```
All five existing Services should keep their current IPs and show no `pending` state.

Closes #3517