### PR TITLE
feat(external-dns): make public DNS publication fail-closed (opt-in marker, published set unchanged)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -275,6 +275,165 @@ Working in-tree examples: `coredns-allow-kube-apiserver` in
 `kubernetes/cluster0/apps/cert-manager/cert-manager/app/cilium-network-policy.yaml`.
 Prior occurrences: #2829 (external-dns), #2947 (cnpg), #3381 / #3382 (tailscale).
 
+## Public DNS is opt-in (external-dns)
+
+external-dns publishes a public record **only** for an object that carries this
+label:
+
+```yaml
+dns.home-ops/public: "true"
+```
+
+The flag that enforces it lives in
+`kubernetes/cluster0/apps/networking/external-dns/app/helm-release.yaml`:
+
+```yaml
+extraArgs:
+  - --label-filter=dns.home-ops/public=true
+```
+
+An object without the label is invisible to external-dns. It gets **no** public
+A/CNAME record and **no** `k8s.` TXT ownership record. A new HTTPRoute is
+private by default (#3518).
+
+Before #3518 the default was the reverse: every HTTPRoute was published unless
+it carried `external-dns.alpha.kubernetes.io/controller: none`. A route added
+without that annotation got a public record silently. That is the defect the
+label fixes.
+
+### The label means "published", not "should be public"
+
+#3518 changed the **mechanism** and kept the published set identical. Every
+hostname that external-dns published at the time carries the label. So the
+label on a given route means "external-dns publishes this hostname today". It
+does not mean someone decided the hostname belongs on the public internet.
+
+Only five hostnames are *intended* to stay public:
+
+| Hostname | Why |
+|---|---|
+| `hs` | headscale control plane. **Permanent** — see below. |
+| `plex` | family and guest native apps |
+| `jellyfin` | family and guest native apps |
+| `home-assistant` | mobile app, webhooks, voice |
+| `requests` | guest-facing request UI (overseerr) |
+
+Every other labelled route is a **tailnet-migration candidate**. Its comment
+says so.
+
+`hs.${SECRET_PUBLIC_DOMAIN}` can never be made tailnet-only. A tailscale client
+must reach headscale to register and to re-key, so a tailnet-gated control plane
+is a circular dependency.
+
+### Removing the label withdraws public DNS — do not do it alone
+
+`policy: sync` is unchanged, so removing the label makes external-dns delete the
+record on the next reconcile. **That is not the same as making a service
+internal-only. For most hostnames here it makes the service unreachable from
+everywhere.**
+
+The reason is the client resolver path, not the cluster:
+
+- headscale pushes `1.1.1.1` and `8.8.8.8` as the global resolvers, so a
+  tailnet client resolves app hostnames through **public DNS even on the LAN**.
+- blocky pins only five names in `customDNS`
+  (`kubernetes/cluster0/apps/networking/blocky/app/config.yaml`): `unifi`,
+  `traefik`, `longhorn`, `auth`, `search`. Everything else falls through to the
+  public upstreams.
+- coredns does not serve the public domain, and there is no wildcard, no
+  `conditional` upstream block, and no k8s-gateway.
+
+So for any hostname outside those five pins, the public record **is** the only
+resolution path today, LAN included.
+
+**Never remove the label as a bulk operation.** Withdraw a hostname one service
+at a time, as part of that service's tailnet migration, and land internal
+resolution for it in the same change. `prometheus.ts` is the pilot for that
+pattern (#3466): a `*.ts.${SECRET_PUBLIC_DOMAIN}` hostname, a tailscale proxy, a
+tailnet ACL, and no public record.
+
+### `--label-filter` is global, not per-source
+
+The flag applies to **every** enabled source, not only `gateway-httproute`. The
+effective source set is `ingress`, `crd` and `gateway-httproute`. So:
+
+- `DNSEndpoint` objects need the label as well. See
+  `kubernetes/cluster0/apps/networking/cloudflared/app/dns-endpoint.yaml`,
+  which publishes `tun.${SECRET_PUBLIC_DOMAIN}` for the cloudflared tunnel.
+- Any future `Ingress` object needs the label to publish a record.
+
+Enumerate every active source before you touch this flag. Checking only
+`gateway-httproute` is what nearly deleted the cloudflared tunnel record.
+
+### Records external-dns does not own
+
+external-dns deletes only records for which it holds a `k8s.` TXT ownership
+record — `plan.calculateChanges` filters deletes through
+`FilterEndpointsByOwnerID`. Some names in the zone have no ownership TXT and are
+therefore outside its control entirely, whatever the label says. It logs them
+each loop as `missing owner label` or `owner id does not match`. Check the logs
+before you assume a record is managed here.
+
+### Worked example — publish a new hostname
+
+Most hostnames come from a bjw-s `app-template` HelmRelease. Add `labels` to the
+route, beside `hostnames`:
+
+```yaml
+# kubernetes/cluster0/apps/<namespace>/<app>/app/helm-release.yaml
+  values:
+    route:
+      app:
+        labels:
+          # Public DNS opt-in (#3518). State why the hostname must be public.
+          dns.home-ops/public: "true"
+        hostnames: ["{{ .Release.Name }}.${SECRET_PUBLIC_DOMAIN}"]
+        parentRefs:
+          - name: traefik-gateway
+            namespace: networking
+            sectionName: websecure
+```
+
+For a raw HTTPRoute manifest, put the label in `metadata.labels`:
+
+```yaml
+# kubernetes/cluster0/apps/<namespace>/<app>/app/httproute.yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: <app>
+  namespace: <namespace>
+  labels:
+    # Public DNS opt-in (#3518). State why the hostname must be public.
+    dns.home-ops/public: "true"
+```
+
+The `grafana` chart uses the same `route.<name>.labels` key as `app-template`.
+
+To keep a new hostname private, add nothing — absence of the label is enough.
+Do not copy the old `external-dns.alpha.kubernetes.io/controller: none`
+annotation onto new objects. The one route that still carries it,
+`monitoring/kube-prometheus-stack/app/httproute.yaml`, keeps it as deliberate
+defence in depth and is the only HTTPRoute with no opt-in label.
+
+### Verify
+
+```bash
+# Every labelled route. Expect the full published set, not a subset.
+kubectl get httproute -A -l dns.home-ops/public=true
+
+# Expect cloudflared-tunnel.
+kubectl get dnsendpoint -A -l dns.home-ops/public=true
+
+# Any route that is NOT labelled — each one publishes nothing.
+kubectl get httproute -A -L dns.home-ops/public | grep -v true
+
+# What external-dns actually generates.
+kubectl -n networking logs deploy/external-dns --tail=500 \
+  | grep "Endpoints generated from"
+```
+
+
 ## Cilium Helm chart minor/major upgrades
 
 Cilium CRDs (especially `ciliumnodeconfigs.cilium.io`) track deprecated apiVersions in their

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -412,9 +412,21 @@ The `grafana` chart uses the same `route.<name>.labels` key as `app-template`.
 
 To keep a new hostname private, add nothing — absence of the label is enough.
 Do not copy the old `external-dns.alpha.kubernetes.io/controller: none`
-annotation onto new objects. The one route that still carries it,
-`monitoring/kube-prometheus-stack/app/httproute.yaml`, keeps it as deliberate
-defence in depth and is the only HTTPRoute with no opt-in label.
+annotation onto new objects. One route still carries it —
+`monitoring/kube-prometheus-stack/app/httproute.yaml` — and keeps it as
+deliberate defence in depth.
+
+### The two routes with no opt-in label
+
+Exactly two HTTPRoutes carry no label. They are **not** the same case, and
+neither is an oversight:
+
+| Route | Declares a hostname? | Why it has no label |
+|---|---|---|
+| `monitoring/prometheus-ts-web` | Yes, `prometheus.ts.…` | Tailnet-only pilot (#3466). The missing label is the control that keeps it off public DNS. **Do not add the label.** |
+| `networking/httpsredirect` | No | It declares no hostnames, so it can never produce a record. The missing label is immaterial. |
+
+Do not "reconcile the count" by adding the label to either one.
 
 ### Verify
 
@@ -426,6 +438,8 @@ kubectl get httproute -A -l dns.home-ops/public=true
 kubectl get dnsendpoint -A -l dns.home-ops/public=true
 
 # Any route that is NOT labelled — each one publishes nothing.
+# Expect exactly TWO: monitoring/prometheus-ts-web and networking/httpsredirect.
+# See "The two routes with no opt-in label" above before you change either.
 kubectl get httproute -A -L dns.home-ops/public | grep -v true
 
 # What external-dns actually generates.

--- a/kubernetes/cluster0/apps/auth/authelia/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/auth/authelia/app/helm-release.yaml
@@ -90,6 +90,10 @@ spec:
             port: 8080
     route:
       app:
+        labels:
+          # Public DNS opt-in (#3518). Removing this withdraws public DNS for
+          # the hostname — pair it with internal resolution. See AGENTS.md.
+          dns.home-ops/public: "true"
         hostnames: ["auth.${SECRET_PUBLIC_DOMAIN}"]
         parentRefs:
           - name: traefik-gateway

--- a/kubernetes/cluster0/apps/home/home-assistant/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/home/home-assistant/app/helm-release.yaml
@@ -65,6 +65,12 @@ spec:
             port: &port 8123
     route:
       app:
+        labels:
+          # Public DNS opt-in (#3518). Intended-public endpoint: the mobile
+          # app, inbound webhooks and the voice integrations all resolve this
+          # name off the tailnet. Not a tailnet-migration candidate. See
+          # AGENTS.md.
+          dns.home-ops/public: "true"
         hostnames: ["{{ .Release.Name }}.${SECRET_PUBLIC_DOMAIN}"]
         parentRefs:
           - name: traefik-gateway

--- a/kubernetes/cluster0/apps/home/searxng/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/home/searxng/app/helm-release.yaml
@@ -43,6 +43,10 @@ spec:
             port: &port 8080
     route:
       searxng:
+        labels:
+          # Public DNS opt-in (#3518). Removing this withdraws public DNS for
+          # the hostname — pair it with internal resolution. See AGENTS.md.
+          dns.home-ops/public: "true"
         hostnames: ["search.${SECRET_PUBLIC_DOMAIN}"]
         parentRefs:
           - name: traefik-gateway

--- a/kubernetes/cluster0/apps/home/zigbee2mqtt/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/home/zigbee2mqtt/app/helm-release.yaml
@@ -46,6 +46,10 @@ spec:
             port: &port 8080
     route:
       app:
+        labels:
+          # Public DNS opt-in (#3518). Removing this withdraws public DNS for
+          # the hostname — pair it with internal resolution. See AGENTS.md.
+          dns.home-ops/public: "true"
         hostnames: ["{{ .Release.Name }}.${SECRET_PUBLIC_DOMAIN}"]
         parentRefs:
           - name: traefik-gateway

--- a/kubernetes/cluster0/apps/kube-system/cilium/app/hubble-httproute.yaml
+++ b/kubernetes/cluster0/apps/kube-system/cilium/app/hubble-httproute.yaml
@@ -3,6 +3,10 @@ kind: HTTPRoute
 metadata:
   name: hubble-ui
   namespace: kube-system
+  labels:
+    # Public DNS opt-in (#3518). Removing this withdraws public DNS for the
+    # hostname — pair it with internal resolution. See AGENTS.md.
+    dns.home-ops/public: "true"
 spec:
   hostnames:
     - hubble.${SECRET_PUBLIC_DOMAIN}

--- a/kubernetes/cluster0/apps/longhorn-system/longhorn/app/httproute.yaml
+++ b/kubernetes/cluster0/apps/longhorn-system/longhorn/app/httproute.yaml
@@ -3,6 +3,10 @@ kind: HTTPRoute
 metadata:
   name: longhorn
   namespace: longhorn-system
+  labels:
+    # Public DNS opt-in (#3518). Removing this withdraws public DNS for the
+    # hostname — pair it with internal resolution. See AGENTS.md.
+    dns.home-ops/public: "true"
 spec:
   hostnames:
     - longhorn.${SECRET_PUBLIC_DOMAIN}

--- a/kubernetes/cluster0/apps/media/jellyfin/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/jellyfin/app/helm-release.yaml
@@ -70,6 +70,11 @@ spec:
             port: *port
     route:
       app:
+        labels:
+          # Public DNS opt-in (#3518). Intended-public endpoint: family and
+          # guest consumers reach Jellyfin from native apps off the tailnet.
+          # Not a tailnet-migration candidate. See AGENTS.md.
+          dns.home-ops/public: "true"
         hostnames: ["{{ .Release.Name }}.${SECRET_PUBLIC_DOMAIN}"]
         parentRefs:
           - name: traefik-gateway

--- a/kubernetes/cluster0/apps/media/lidarr/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/lidarr/app/helm-release.yaml
@@ -55,6 +55,10 @@ spec:
             port: &port 8686
     route:
       app:
+        labels:
+          # Public DNS opt-in (#3518). Removing this withdraws public DNS for
+          # the hostname — pair it with internal resolution. See AGENTS.md.
+          dns.home-ops/public: "true"
         hostnames: ["{{ .Release.Name }}.${SECRET_PUBLIC_DOMAIN}"]
         parentRefs:
           - name: traefik-gateway

--- a/kubernetes/cluster0/apps/media/miniflux/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/miniflux/app/helm-release.yaml
@@ -153,6 +153,10 @@ spec:
 
     route:
       app:
+        labels:
+          # Public DNS opt-in (#3518). Removing this withdraws public DNS for
+          # the hostname — pair it with internal resolution. See AGENTS.md.
+          dns.home-ops/public: "true"
         hostnames: ["feed.${SECRET_PUBLIC_DOMAIN}"]
         parentRefs:
           - name: traefik-gateway

--- a/kubernetes/cluster0/apps/media/overseerr/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/overseerr/app/helm-release.yaml
@@ -61,6 +61,11 @@ spec:
             port: &port 5055
     route:
       app:
+        labels:
+          # Public DNS opt-in (#3518). Intended-public endpoint: the
+          # guest-facing request UI, used off the tailnet. Not a
+          # tailnet-migration candidate. See AGENTS.md.
+          dns.home-ops/public: "true"
         hostnames: ["requests.${SECRET_PUBLIC_DOMAIN}"]
         parentRefs:
           - name: traefik-gateway

--- a/kubernetes/cluster0/apps/media/plex/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/plex/app/helm-release.yaml
@@ -80,6 +80,11 @@ spec:
             port: &port 32400
     route:
       app:
+        labels:
+          # Public DNS opt-in (#3518). Intended-public endpoint: family and
+          # guest consumers reach Plex from native apps off the tailnet. Not a
+          # tailnet-migration candidate. See AGENTS.md.
+          dns.home-ops/public: "true"
         hostnames: ["{{ .Release.Name }}.${SECRET_PUBLIC_DOMAIN}"]
         parentRefs:
           - name: traefik-gateway

--- a/kubernetes/cluster0/apps/media/prowlarr/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/prowlarr/app/helm-release.yaml
@@ -55,6 +55,10 @@ spec:
               port: &port 9696
     route:
       app:
+        labels:
+          # Public DNS opt-in (#3518). Removing this withdraws public DNS for
+          # the hostname — pair it with internal resolution. See AGENTS.md.
+          dns.home-ops/public: "true"
         hostnames: ["{{ .Release.Name }}.${SECRET_PUBLIC_DOMAIN}"]
         parentRefs:
           - name: traefik-gateway

--- a/kubernetes/cluster0/apps/media/qbittorrent/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/qbittorrent/app/helm-release.yaml
@@ -86,6 +86,10 @@ spec:
             port: *port
     route:
       app:
+        labels:
+          # Public DNS opt-in (#3518). Removing this withdraws public DNS for
+          # the hostname — pair it with internal resolution. See AGENTS.md.
+          dns.home-ops/public: "true"
         hostnames: ["{{ .Release.Name }}.${SECRET_PUBLIC_DOMAIN}"]
         parentRefs:
           - name: traefik-gateway

--- a/kubernetes/cluster0/apps/media/radarr/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/radarr/app/helm-release.yaml
@@ -55,6 +55,10 @@ spec:
             port: &port 7878
     route:
       app:
+        labels:
+          # Public DNS opt-in (#3518). Removing this withdraws public DNS for
+          # the hostname — pair it with internal resolution. See AGENTS.md.
+          dns.home-ops/public: "true"
         hostnames: ["{{ .Release.Name }}.${SECRET_PUBLIC_DOMAIN}"]
         parentRefs:
           - name: traefik-gateway

--- a/kubernetes/cluster0/apps/media/sabnzbd/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/sabnzbd/app/helm-release.yaml
@@ -56,6 +56,10 @@ spec:
             port: &port 8080
     route:
       app:
+        labels:
+          # Public DNS opt-in (#3518). Removing this withdraws public DNS for
+          # the hostname — pair it with internal resolution. See AGENTS.md.
+          dns.home-ops/public: "true"
         hostnames: ["{{ .Release.Name }}.${SECRET_PUBLIC_DOMAIN}"]
         parentRefs:
           - name: traefik-gateway

--- a/kubernetes/cluster0/apps/media/sonarr/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/media/sonarr/app/helm-release.yaml
@@ -55,6 +55,10 @@ spec:
             port: &port 8989
     route:
       app:
+        labels:
+          # Public DNS opt-in (#3518). Removing this withdraws public DNS for
+          # the hostname — pair it with internal resolution. See AGENTS.md.
+          dns.home-ops/public: "true"
         hostnames: ["{{ .Release.Name }}.${SECRET_PUBLIC_DOMAIN}"]
         parentRefs:
           - name: traefik-gateway

--- a/kubernetes/cluster0/apps/monitoring/changedetection-io/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/monitoring/changedetection-io/app/helm-release.yaml
@@ -52,6 +52,10 @@ spec:
             port: &port 5000
     route:
       app:
+        labels:
+          # Public DNS opt-in (#3518). Removing this withdraws public DNS for
+          # the hostname — pair it with internal resolution. See AGENTS.md.
+          dns.home-ops/public: "true"
         hostnames: ["{{ .Release.Name }}.${SECRET_PUBLIC_DOMAIN}"]
         parentRefs:
           - name: traefik-gateway

--- a/kubernetes/cluster0/apps/monitoring/grafana/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/monitoring/grafana/app/helm-release.yaml
@@ -32,6 +32,10 @@ spec:
     route:
       main:
         enabled: true
+        labels:
+          # Public DNS opt-in (#3518). Removing this withdraws public DNS for
+          # the hostname — pair it with internal resolution. See AGENTS.md.
+          dns.home-ops/public: "true"
         hostnames: ["{{ .Release.Name }}.${SECRET_PUBLIC_DOMAIN}"]
         parentRefs:
           - name: traefik-gateway

--- a/kubernetes/cluster0/apps/monitoring/kube-prometheus-stack/app/httproute.yaml
+++ b/kubernetes/cluster0/apps/monitoring/kube-prometheus-stack/app/httproute.yaml
@@ -18,9 +18,14 @@
 # external-dns publication is now FAIL-CLOSED (#3518): external-dns runs
 # --label-filter=dns.home-ops/public=true, so a route without that label is
 # invisible to it and gets no public record. This route deliberately carries no
-# such label, which is what keeps the hostname tailnet-only. It is the ONLY
-# HTTPRoute on the cluster with no opt-in label — every other route had a
-# public record before #3518 and kept it. Do not add the label here.
+# such label, which is what keeps the hostname tailnet-only. Do not add the
+# label here.
+#
+# Two HTTPRoutes on the cluster carry no opt-in label: this one and
+# networking/httpsredirect. They are NOT the same case. httpsredirect declares
+# no hostnames, so it can never produce a record and its missing label is
+# immaterial. This route DOES declare a hostname, so the missing label is the
+# control. Every other route had a public record before #3518 and kept it.
 #
 # external-dns.alpha.kubernetes.io/controller: none is KEPT as a second,
 # independent layer (#3466). It is no longer the primary control, but it costs

--- a/kubernetes/cluster0/apps/monitoring/kube-prometheus-stack/app/httproute.yaml
+++ b/kubernetes/cluster0/apps/monitoring/kube-prometheus-stack/app/httproute.yaml
@@ -15,12 +15,20 @@
 # (ben@ -> tag:ts-web tcp:443 in headscale policy.hujson). Prometheus is a
 # read-mostly, non-destructive UI; this is the whole point of the pilot.
 #
-# external-dns.alpha.kubernetes.io/controller: none is LOAD-BEARING. Without
-# it, external-dns (source=gateway-httproute, policy=sync) would publish a
-# PUBLIC A record + k8s. TXT for this hostname pointing at the Cloudflare
-# edge, defeating the tailnet-only property. `none` is the only per-object
-# opt-out that external-dns v0.21.0 actually reads — the `.../exclude`
-# annotation does NOT exist in that version and is silently ignored (#3466).
+# external-dns publication is now FAIL-CLOSED (#3518): external-dns runs
+# --label-filter=dns.home-ops/public=true, so a route without that label is
+# invisible to it and gets no public record. This route deliberately carries no
+# such label, which is what keeps the hostname tailnet-only. It is the ONLY
+# HTTPRoute on the cluster with no opt-in label — every other route had a
+# public record before #3518 and kept it. Do not add the label here.
+#
+# external-dns.alpha.kubernetes.io/controller: none is KEPT as a second,
+# independent layer (#3466). It is no longer the primary control, but it costs
+# nothing and it holds even if someone copies this file and pastes the opt-in
+# label in by mistake. Two independent mechanisms must both fail before this
+# hostname leaks to public DNS. `none` is the only per-object opt-out that
+# external-dns v0.21.0 actually reads — the `.../exclude` annotation does NOT
+# exist in that version and is silently ignored.
 # =============================================================================
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute

--- a/kubernetes/cluster0/apps/monitoring/uptime-kuma/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/monitoring/uptime-kuma/app/helm-release.yaml
@@ -89,6 +89,10 @@ spec:
             port: &port 4180
     route:
       app:
+        labels:
+          # Public DNS opt-in (#3518). Removing this withdraws public DNS for
+          # the hostname — pair it with internal resolution. See AGENTS.md.
+          dns.home-ops/public: "true"
         hostnames: ["uptime.${SECRET_PUBLIC_DOMAIN}"]
         parentRefs:
           - name: traefik-gateway

--- a/kubernetes/cluster0/apps/networking/cloudflared/app/dns-endpoint.yaml
+++ b/kubernetes/cluster0/apps/networking/cloudflared/app/dns-endpoint.yaml
@@ -4,6 +4,18 @@ kind: DNSEndpoint
 metadata:
   name: cloudflared-tunnel
   namespace: networking
+  labels:
+    # Public DNS opt-in (#3518). DO NOT REMOVE.
+    #
+    # external-dns runs --label-filter=dns.home-ops/public=true, and that flag
+    # is global: it filters the `crd` source as well as `gateway-httproute`.
+    # Without this label external-dns stops seeing this DNSEndpoint and, under
+    # policy: sync, deletes tun.${SECRET_PUBLIC_DOMAIN} — which breaks the
+    # cloudflared tunnel.
+    #
+    # A DNSEndpoint is an explicit request to publish a record, so the label is
+    # a restatement of intent rather than a new decision.
+    dns.home-ops/public: "true"
 spec:
   endpoints:
     - dnsName: tun.${SECRET_PUBLIC_DOMAIN}

--- a/kubernetes/cluster0/apps/networking/external-dns/app/helm-release.yaml
+++ b/kubernetes/cluster0/apps/networking/external-dns/app/helm-release.yaml
@@ -30,11 +30,40 @@ spec:
           secretKeyRef:
             name: external-dns-cloud-credentials
             key: api-key
+    # Public DNS publication is FAIL-CLOSED (#3518).
+    #
+    # --label-filter makes external-dns list only objects that carry the label
+    # dns.home-ops/public=true. Every other object is invisible to it, so a NEW
+    # HTTPRoute gets no public A/CNAME record and no `k8s.` TXT ownership
+    # record until someone deliberately adds the label. See AGENTS.md, section
+    # "Public DNS is opt-in (external-dns)".
+    #
+    # This flag changed the MECHANISM only. Every hostname that external-dns
+    # published before the flag was added carries the label, so the published
+    # set did not change. The defect this fixes is fail-open publication of new
+    # routes, not the size of the published set.
+    #
+    # The filter is applied by the informer, so an unlabelled object never
+    # enters the cache. external-dns v0.21.0 documents `gateway-httproute`,
+    # `crd` and `ingress` as supported sources for this flag.
+    #
+    # --label-filter is GLOBAL: it applies to every source enabled below, not
+    # only gateway-httproute. Consequences:
+    #   * DNSEndpoint objects need the label too. cloudflared/dns-endpoint.yaml
+    #     carries it, else tun.${SECRET_PUBLIC_DOMAIN} would be deleted.
+    #   * Any future Ingress object needs the label to publish a record.
+    #
+    # `policy: sync` stays as it is, so removal of the label withdraws the
+    # record on the next reconcile. Do NOT remove a label to make a service
+    # private on its own: most clients here resolve app hostnames through
+    # PUBLIC DNS even on the LAN, so withdrawal must be paired with internal
+    # resolution for that hostname. See AGENTS.md.
     extraArgs:
       - --crd-source-apiversion=externaldns.k8s.io/v1alpha1
       - --crd-source-kind=DNSEndpoint
       - --cloudflare-proxied
       - --source=gateway-httproute
+      - --label-filter=dns.home-ops/public=true
     rbac:
       additionalPermissions:
         - apiGroups: [""]

--- a/kubernetes/cluster0/apps/networking/headscale/app/httproute.yaml
+++ b/kubernetes/cluster0/apps/networking/headscale/app/httproute.yaml
@@ -3,6 +3,19 @@ kind: HTTPRoute
 metadata:
   name: headscale
   namespace: networking
+  labels:
+    # PUBLIC DNS OPT-IN — PERMANENT. DO NOT REMOVE (#3518).
+    #
+    # hs.${SECRET_PUBLIC_DOMAIN} is the headscale control plane. It can never
+    # be made tailnet-only, because a tailscale client must reach headscale to
+    # register and to re-key. Put the control plane behind the tailnet and you
+    # get a circular dependency: a client with an expired key cannot re-key,
+    # because it cannot reach the server that issues the key.
+    #
+    # Remove this label and external-dns (policy: sync) deletes the record on
+    # its next reconcile. Every tailnet client then loses the ability to
+    # register or re-key. This label is structural, not a convenience.
+    dns.home-ops/public: "true"
 spec:
   hostnames:
     - hs.${SECRET_PUBLIC_DOMAIN}

--- a/kubernetes/cluster0/apps/networking/traefik/dashboard/dashboard-httproute.yaml
+++ b/kubernetes/cluster0/apps/networking/traefik/dashboard/dashboard-httproute.yaml
@@ -21,6 +21,10 @@ kind: HTTPRoute
 metadata:
   name: traefik-dashboard
   namespace: networking
+  labels:
+    # Public DNS opt-in (#3518). Removing this withdraws public DNS for the
+    # hostname — pair it with internal resolution. See AGENTS.md.
+    dns.home-ops/public: "true"
 spec:
   hostnames: 
   - "traefik.${SECRET_PUBLIC_DOMAIN}"

--- a/kubernetes/cluster0/apps/networking/traefik/external-services/nas0-networking.yaml
+++ b/kubernetes/cluster0/apps/networking/traefik/external-services/nas0-networking.yaml
@@ -33,6 +33,10 @@ kind: HTTPRoute
 metadata:
   name: nas0
   namespace: networking
+  labels:
+    # Public DNS opt-in (#3518). Removing this withdraws public DNS for the
+    # hostname — pair it with internal resolution. See AGENTS.md.
+    dns.home-ops/public: "true"
 spec:
   parentRefs:
     - group: gateway.networking.k8s.io

--- a/kubernetes/cluster0/apps/networking/traefik/external-services/octoprint-networking.yaml
+++ b/kubernetes/cluster0/apps/networking/traefik/external-services/octoprint-networking.yaml
@@ -33,6 +33,10 @@ kind: HTTPRoute
 metadata:
   name: octoprint
   namespace: networking
+  labels:
+    # Public DNS opt-in (#3518). Removing this withdraws public DNS for the
+    # hostname — pair it with internal resolution. See AGENTS.md.
+    dns.home-ops/public: "true"
 spec:
   parentRefs:
     - group: gateway.networking.k8s.io

--- a/kubernetes/cluster0/apps/networking/traefik/external-services/unifi-networking.yaml
+++ b/kubernetes/cluster0/apps/networking/traefik/external-services/unifi-networking.yaml
@@ -50,6 +50,10 @@ kind: HTTPRoute
 metadata:
   name: unifi
   namespace: networking
+  labels:
+    # Public DNS opt-in (#3518). Removing this withdraws public DNS for the
+    # hostname — pair it with internal resolution. See AGENTS.md.
+    dns.home-ops/public: "true"
 spec:
   parentRefs:
     - group: gateway.networking.k8s.io

--- a/kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/httproute.yaml
+++ b/kubernetes/cluster0/apps/seaweedfs/seaweedfs/app/httproute.yaml
@@ -4,6 +4,10 @@ kind: HTTPRoute
 metadata:
   name: seaweedfs-console
   namespace: seaweedfs
+  labels:
+    # Public DNS opt-in (#3518). Removing this withdraws public DNS for the
+    # hostname — pair it with internal resolution. See AGENTS.md.
+    dns.home-ops/public: "true"
 spec:
   hostnames:
     - seaweedfs.${SECRET_PUBLIC_DOMAIN}


### PR DESCRIPTION
Closes #3518

## What changes

Public DNS publication becomes **explicit opt-in**. external-dns now runs:

```yaml
- --label-filter=dns.home-ops/public=true
```

An object without the label `dns.home-ops/public: "true"` is invisible to
external-dns. It gets no public A/CNAME record and no `k8s.` TXT ownership
record. **A new route is private until someone deliberately marks it.**

The label follows the prefix convention already in the repo
(`netpol.home-ops/traefik-backend`).

## This changes the mechanism, not the published set

Every object external-dns published before this commit carries the label — 25
HTTPRoutes and the cloudflared DNSEndpoint. Net effect on DNS is **nothing**.
Net effect on safety is that fail-open publication of new routes is gone.

**Withdrawing a hostname from public DNS is deliberately not part of this
change.** It is a different operation with a different risk profile, and it is
not a bulk one. The reason is the client resolver path:

- headscale pushes `1.1.1.1` and `8.8.8.8` as the global resolvers, so a tailnet
  client resolves app hostnames through **public DNS even on the LAN**.
- blocky pins only five names in `customDNS`
  (`kubernetes/cluster0/apps/networking/blocky/app/config.yaml`): `unifi`,
  `traefik`, `longhorn`, `auth`, `search`.
- coredns does not serve the public domain. There is no wildcard, no
  `conditional` upstream block, no k8s-gateway.

So for most hostnames the public record is the *only* resolution path. Removing
it would take the service offline for every client rather than making it
internal-only. Withdrawal belongs with each service's tailnet migration, one
service at a time, with internal resolution landed in the same change —
`prometheus.ts` (#3466) is the pattern.

This PR therefore has **no prerequisite and no ordering dependency**. It is
independently safe to merge.

## Objects marked (26)

| Where | Count | Objects |
|---|---|---|
| `app-template` HelmRelease `route.<name>.labels` | 16 | authelia, home-assistant, searxng, zigbee2mqtt, jellyfin, lidarr, miniflux, overseerr, plex, prowlarr, qbittorrent, radarr, sabnzbd, sonarr, changedetection-io, uptime-kuma |
| `grafana` chart HelmRelease `route.main.labels` | 1 | grafana |
| Raw HTTPRoute `metadata.labels` | 8 | hubble-ui, longhorn, headscale, traefik-dashboard, nas0, octoprint, unifi, seaweedfs-console |
| Raw DNSEndpoint `metadata.labels` | 1 | cloudflared-tunnel (`tun.`) |

**Two routes deliberately carry no label.** Neither publishes anything today, so
the published set is unaffected — both facts come straight out of the unfiltered
dry-run log:

```
Skipping 'HTTPRoute/monitoring/prometheus-ts-web' because controller
  'external-dns.alpha.kubernetes.io/controller' value does not match,
  found: 'none', required: 'dns-controller'
No endpoints could be generated from HTTPRoute networking/httpsredirect
```

`prometheus-ts-web` is the tailnet-only pilot. `httpsredirect` has no hostnames.

The label means **"external-dns publishes this hostname today"** — not "someone
decided this belongs on the public internet". Only five are intended to stay
public (`hs`, `plex`, `jellyfin`, `home-assistant`, `requests`); the rest are
tailnet-migration candidates and their comments say so. `hs` carries the full
reason it can never be tailnet-gated: a tailscale client must reach headscale to
register and re-key, so a tailnet-gated control plane is a circular dependency.

## AC: published set is identical before and after

Dry-run comparison against the live cluster, in the same style as the `tun.`
reproducer. The real v0.21.0 binary, `--provider=inmemory --dry-run --once`, no
writes and no Cloudflare calls. "After" uses a selector that picks out exactly
the marked set:

```
BEFORE: no filter                                        -> 26 records
AFTER:  --label-filter='app.kubernetes.io/name notin (prometheus)' -> 26 records
diff before after -> empty
IDENTICAL: 26 records, zero difference
```

The `notin` selector is the live-cluster stand-in for the marked set: the labels
are not on the cluster yet (this is a branch), and set-based `notin` also matches
objects with the key absent, so it selects every route except
`prometheus-ts-web` — that is the marked set plus `httpsredirect`, which
publishes nothing.

The set-equality is also checked statically: I rendered all 17 HelmReleases with
`helm template` against the pinned charts and parsed all raw manifests, then
compared the marked-object hostname set against the 26 live published records.
They match exactly.

## AC: an unmarked route publishes nothing

```
--label-filter=dns.home-ops/public=true   (no live object carries it yet)

  A/AAAA/CNAME records created : 0
  k8s. TXT ownership records   : 0
  endpoints generated at all   : 0
  plan verdict                 : All records are already up to date
```

This is stronger than a single synthetic route: because no live object carries
the marker, **all 27 HTTPRoutes and the DNSEndpoint simultaneously act as
"newly added, unmarked"**, and every one of them produced nothing — no address
record and no TXT. `kubectl auth can-i create httproutes` returns `no` for this
read-only service account, so a genuinely new object could not be created; this
form of the test covers the same ground and more.

## AC: filter flag confirmed honoured, for every active source

`--label-filter` was chosen over `--annotation-filter`:

1. **The deployed version documents it.** The Deployment runs
   `registry.k8s.io/external-dns/external-dns:v0.21.0`. I pulled that exact
   image blob from the registry and extracted the binary (`--version` reports
   `v20260406-v0.21.0`). Its own help text:

   ```
   --label-filter=""    Filter resources queried for endpoints by label
                        selector; currently supported by source types
                        crd, gateway-httproute, gateway-grpcroute,
                        gateway-tlsroute, gateway-tcproute,
                        gateway-udproute, ingress, node,
                        openshift-route, service and ambassador-host
   ```

   All three active sources — `crd`, `gateway-httproute`, `ingress` — are named.
   `--annotation-filter` names no source types at all.

2. **Enforced by the informer, not a client-side skip.** `source/gateway.go` at
   tag `v0.21.0` passes the selector to the route informer factory (line 195)
   and to the List call (line 266), so an unlabelled route never enters the
   cache. `--annotation-filter` is a `continue` on an already-listed object
   (line 291). For the `crd` source, `NewCRDSource` passes it through
   `buildCacheOptions(cfg.Namespace, cfg.LabelFilter, annotationSelector)`.

3. **Auditing is one command.** `kubectl get httproute -A -l
   dns.home-ops/public=true`. This also gives the CI lint in #3519 a trivial
   predicate.

### The catastrophic path, ruled out

If `--label-filter` had also applied to the **Gateway** informer, the unlabelled
`traefik-gateway` would have gone invisible, all 25 routes would have failed to
resolve their parent, and `policy: sync` would have deleted every record at
once. Ruled out two ways.

**Source**, `source/gateway.go` at tag `v0.21.0` — Gateways and routes key off
different flags:

```go
gwLabels, err := getLabelSelector(config.GatewayLabelFilter)  // L160, separate flag, unset here
rtLabels := config.LabelFilter                                // L164, --label-filter, routes only
```

**Runtime**, against the live cluster. Note that the before/after comparison
above does *not* rule this out on its own: the traefik Gateway also satisfies
`notin (prometheus)`, so that test passes either way. This one is built to
distinguish the two cases — the Gateway carries `app.kubernetes.io/name=traefik`,
so the selector below excludes the Gateway itself:

```
--source=gateway-httproute --label-filter='app.kubernetes.io/name notin (traefik)'

  endpoints generated : 25   (all 25 routes still resolve their parent)
```

No route carries `app.kubernetes.io/name=traefik`, and `traefik-dashboard` has
no `app.kubernetes.io/name` label at all — set-based `notin` matches a missing
key, so every route stayed selected while the Gateway was excluded. All 25 still
produced endpoints, so the Gateway informer is demonstrably unaffected by
`--label-filter`.

Runtime confirmation per source, all measured with the real binary against the
live cluster (see the two AC sections above): `gateway-httproute` honours it —
25 endpoints unfiltered, 0 with the marker filter. `crd` honours it —
`tun.<domain>` present unfiltered, absent with the marker filter. `ingress` has
no objects to test, and the flag help names it.

## AC: complete effective source set

The `tun.` near-miss came from enumerating one source instead of all of them, so
here is the whole set. Source flags come from two places in the HelmRelease —
the chart-level `sources:` list and `extraArgs` — so the live Deployment is the
source of truth:

```
--source=ingress            (chart-level sources:)
--source=crd                (chart-level sources:)
--source=gateway-httproute  (extraArgs)
```

The binary confirms it parsed exactly those three: `Sources:[ingress crd
gateway-httproute]`.

There is **no fourth source and no bare `gateway` source to miss**. The v0.21.0
`--source` enum is `service, ingress, node, pod, gateway-httproute,
gateway-grpcroute, gateway-tlsroute, gateway-tcproute, gateway-udproute,
istio-gateway, istio-virtualservice, contour-httpproxy, gloo-proxy, fake,
connector, crd, empty, skipper-routegroup, openshift-route, ambassador-host,
kong-tcpingress, f5-virtualserver, f5-transportserver, traefik-proxy,
unstructured`. Route sources are per-route-kind, so the traefik Gateway object
is never a record source; it only supplies targets and listener acceptance.

| Source | Publishes today | Marked |
|---|---|---|
| `gateway-httproute` | 25 hostnames | 25 routes marked |
| `crd` | 1 (`tun.<domain>`) | DNSEndpoint marked |
| `ingress` | 0 (zero Ingress objects cluster-wide) | n/a; a future Ingress needs the label |

Total published set: **26** records. Nothing else exists for the filter to catch.

## AC: `ipv4.<domain>` is not managed by external-dns

Every public hostname is a CNAME to `ipv4.<domain>` via the `target` annotation
on the traefik Gateway
(`kubernetes/cluster0/apps/networking/traefik/app/helm-release.yaml:68`), so if
external-dns managed that record and it lost the marker, every public name would
break at once. It does not manage it. Three independent lines of evidence:

**1. Never in `desired`.** Across all three sources with no filter,
`ipv4.<domain>` appears **zero** times as a generated `dnsName` and **50** times
as a *target*. The label filter only decides which source objects are visible, so
a name that is never a source dnsName cannot be affected by it.

**2. external-dns disclaims it on every reconcile.** From the live Deployment's
own debug log, 465 occurrences in the log window:

```
Skipping endpoint ipv4.<domain> 1 IN A <home-ip>
  [{external-dns.alpha.kubernetes.io/cloudflare-proxied true}]
  because of missing owner label (required: "default")
```

**3. `policy: sync` cannot delete an unowned record.** `plan.calculateChanges`
in `plan/plan.go` at tag `v0.21.0`:

```go
// filter out updates this external dns does not have ownership claim over
if p.OwnerID != "" {
    changes.Delete = endpoint.FilterEndpointsByOwnerID(p.OwnerID, changes.Delete)
    ...
}
```

`OwnerID` is `default`, so the filter always runs. Ownership is a hard
precondition for deletion, independent of the source set and of the label filter.

**Conclusion: not managed by external-dns, and not at risk.** It is an A record
for the home IP, Cloudflare-proxied, maintained in Cloudflare outside the
cluster. In-repo it appears only as the target annotation. It therefore does not
need the marker.

## The redundant opt-out annotation: KEPT

`monitoring/kube-prometheus-stack/app/httproute.yaml` keeps
`external-dns.alpha.kubernetes.io/controller: none`:

- It costs nothing — external-dns evaluates it after the label filter, so it is
  pure defence in depth.
- It still holds if someone copies that file as a template for a new
  tailnet-only route and pastes the opt-in label in by mistake. Two independent
  mechanisms must both fail before a tailnet-only hostname leaks.
- Removing it is a change with no upside on a security control.

Its comment is rewritten to say which mechanism is primary now, and to record
that it is the only HTTPRoute on the cluster with no opt-in label. New
tailnet-only routes should not copy the annotation — absence of the label is
enough.

## `policy: sync` unchanged

`policy: sync` stays. Removing a label withdraws the record on the next
reconcile. AGENTS.md states plainly that this is *not* a way to make a service
internal-only, and must be paired with internal resolution for that hostname.

## Rollout

Because the published set does not change, there is no DNS-visible change and no
race that matters: if external-dns picks up the flag before an app HelmRelease
applies its label, the worst case is a brief withdrawal-and-recreate of that one
record. To remove even that, pre-seed the labels before merging — Flux converges
to the same state, so this is idempotent:

```bash
kubectl -n media       label httproute plex jellyfin overseerr lidarr miniflux \
                             prowlarr qbittorrent radarr sabnzbd sonarr dns.home-ops/public=true
kubectl -n home        label httproute home-assistant searxng zigbee2mqtt dns.home-ops/public=true
kubectl -n auth        label httproute authelia dns.home-ops/public=true
kubectl -n monitoring  label httproute changedetection-io grafana uptime-kuma dns.home-ops/public=true
kubectl -n kube-system label httproute hubble-ui dns.home-ops/public=true
kubectl -n longhorn-system label httproute longhorn dns.home-ops/public=true
kubectl -n seaweedfs   label httproute seaweedfs-console dns.home-ops/public=true
kubectl -n networking  label httproute headscale traefik-dashboard nas0 octoprint unifi dns.home-ops/public=true
kubectl -n networking  label dnsendpoint cloudflared-tunnel dns.home-ops/public=true

# Expect 25 routes and 1 dnsendpoint. prometheus-ts-web and httpsredirect stay absent.
kubectl get httproute -A -l dns.home-ops/public=true | wc -l
kubectl get dnsendpoint -A -l dns.home-ops/public=true
```

### After merge

```bash
flux reconcile source git home-ops-cluster0
kubectl -n networking rollout status deploy/external-dns

# Expect the same 26 names as before the change.
kubectl -n networking logs deploy/external-dns --tail=500 | grep "Endpoints generated from"
# Expect no deletions.
kubectl -n networking logs deploy/external-dns --tail=500 | grep -E "DELETE|CREATE|UPDATE"
```

### Rollback

Drop the `--label-filter` line from the external-dns HelmRelease. Behaviour
returns to publish-everything on the next reconcile. The labels are inert
without the flag, so they can stay.

## Verification done

- `helm template` on all 17 HelmReleases against the pinned charts
  (`app-template` 5.1.0, `grafana` 10.5.15): the label lands in
  `metadata.labels` of every rendered HTTPRoute, with the expected hostname.
  Confirms `route.<name>.labels` is supported by both charts.
- `kustomize build` on all 10 affected raw-manifest trees: the label lands on
  the 8 HTTPRoutes and the DNSEndpoint; `prometheus-ts-web` and `httpsredirect`
  correctly show it absent.
- Static set-equality between marked objects and the 26 live published records.
- The four dry-runs described above against the live cluster.
- No file listed as owned by a concurrent session is touched.

## AGENTS.md

Section "Public DNS is opt-in (external-dns)" documents the exact label, the
flag, both worked examples (`app-template`/`grafana` route form and raw
HTTPRoute form), and — the part that matters most — that the label means
"published today", that only five hostnames are intended to stay public, and
that **removing the label withdraws public DNS and must be paired with internal
resolution for that hostname as part of a tailnet migration**, with the client
resolver path spelled out so the next reader does not have to rediscover it.

## Out of scope

- The CI lint is #3519.
- Narrowing the published set: per-service tailnet migrations, not a bulk
  operation.
- `lemmy.<domain>` and `vaultwarden.<domain>` resolve publicly with no HTTPRoute
  behind them, and external-dns holds no ownership TXT for either, so it cannot
  remove them. Worth its own issue.
